### PR TITLE
Fixed Circle.GetBounds() to tield the correct bounds for non-equatorial circles

### DIFF
--- a/Geo.Tests/Geo.Tests.csproj
+++ b/Geo.Tests/Geo.Tests.csproj
@@ -66,6 +66,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Geo\Geometries\Circles\CircleTests.cs" />
     <Compile Include="Geo\CoordinateTests.cs" />
     <Compile Include="Geo\Gps\Serialization\GarminFlightplanDeSerializerTests.cs" />
     <Compile Include="Geo\Gps\Serialization\GpsDeSerializerTests.cs" />

--- a/Geo.Tests/Geo/Geometries/Circles/CircleTests.cs
+++ b/Geo.Tests/Geo/Geometries/Circles/CircleTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Geo.Geometries;
+using NUnit.Framework;
+
+namespace Geo.Tests.Geo.Geometries
+{
+    [TestFixture]
+    public class CircleTests
+    {
+        [Test]
+        public void AnEquatorialCircleWith_111000M_RadiusShouldBeAboutTwoDegreesTall()
+        {
+            var circle = new Circle(0, 20, 111000);
+            var bounds = circle.GetBounds();
+
+            var minLatError = Distance(-1, bounds.MinLat);
+            Assert.LessOrEqual(minLatError, 0.002);
+
+            var maxLatError = Distance(+1, bounds.MaxLat);
+            Assert.LessOrEqual(maxLatError, 0.002);
+        }
+
+        [Test]
+        public void Bounds_A_111000_RadiusMeterEquatorialCircleShouldBeAboutTwoDegreesWide()
+        {
+            var circle = new Circle(0, 20, 111000);
+            var bounds = circle.GetBounds();
+
+            var minLonError = Distance(19, bounds.MinLon);
+            Assert.LessOrEqual(minLonError, 0.002);
+
+            var maxLonError = Distance(21, bounds.MaxLon);
+            Assert.LessOrEqual(maxLonError, 0.002);
+        }
+
+        
+        ///////////
+
+        [Test]
+        public void An_60Degree_CircleWith_111000M_RadiusShouldBeAboutTwoDegreesTall()
+        {
+            var circle = new Circle(60, 20, 111000);
+            var bounds = circle.GetBounds();
+
+            var minLatError = Distance(59, bounds.MinLat);
+            Assert.LessOrEqual(minLatError, 0.002);
+
+            var maxLatError = Distance(61, bounds.MaxLat);
+            Assert.LessOrEqual(maxLatError, 0.002);
+        }
+
+        [Test]
+        public void An_60Degree_CircleWith_111000M_RadiusShouldBeAboutOneDegreeWide()
+        {
+            var circle = new Circle(60, 20, 111000);
+            var bounds = circle.GetBounds();
+
+            var minLonError = Distance(19.5, bounds.MinLon);
+            Assert.LessOrEqual(minLonError, 0.002);
+
+            var maxLonError = Distance(20.5, bounds.MaxLon);
+            Assert.LessOrEqual(maxLonError, 0.002);
+        }
+
+
+        public double Distance(double nr1, double nr2)
+        {
+            return Math.Abs(nr1 - nr2);
+        }
+    }
+}

--- a/Geo.Tests/Geo/IO/Wkt/WktReaderTests.cs
+++ b/Geo.Tests/Geo/IO/Wkt/WktReaderTests.cs
@@ -65,7 +65,7 @@ namespace Geo.Tests.Geo.IO.Wkt
             Assert.AreEqual(new Point(65.9, 0, 4, 5), xyzm2);
 
             var empty = reader.Read("POINT ZM EMPTY");
-            Assert.AreEqual(Geometries.Point.Empty, empty);
+            Assert.AreEqual(global::Geo.Geometries.Point.Empty, empty);
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace Geo.Tests.Geo.IO.Wkt
             Assert.AreEqual(new Polygon(new LinearRing(new Coordinate(65.9, 0), new Coordinate(9, -34.5), new Coordinate(40, -20), new Coordinate(65.9, 0))), xy);
 
             var empty = reader.Read("POLYGON ZM EMPTY");
-            Assert.AreEqual(Geometries.Polygon.Empty, empty);
+            Assert.AreEqual(global::Geo.Geometries.Polygon.Empty, empty);
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace Geo.Tests.Geo.IO.Wkt
             Assert.AreEqual(new Triangle(new LinearRing(new Coordinate(65.9, 0), new Coordinate(9, -34.5), new Coordinate(40, -20), new Coordinate(65.9, 0))), xy);
 
             var empty = reader.Read("Triangle ZM EMPTY");
-            Assert.AreEqual(Geometries.Triangle.Empty, empty);
+            Assert.AreEqual(global::Geo.Geometries.Triangle.Empty, empty);
         }
 
         [Test]

--- a/Geo.Tests/Geo/IO/Wkt/WktWriterTests.cs
+++ b/Geo.Tests/Geo/IO/Wkt/WktWriterTests.cs
@@ -24,7 +24,7 @@ namespace Geo.Tests.Geo.IO.Wkt
             var xyzm = writer.Write(new Point(65.9, 0, 4, 5));
             Assert.AreEqual("POINT ZM (0 65.9 4 5)", xyzm);
 
-            var empty = writer.Write(Geometries.Point.Empty);
+            var empty = writer.Write(global::Geo.Geometries.Point.Empty);
             Assert.AreEqual("POINT EMPTY", empty);
         }
 
@@ -36,7 +36,7 @@ namespace Geo.Tests.Geo.IO.Wkt
             var xy = writer.Write(new LineString(new Coordinate(65.9, 0), new Coordinate(9, -34.5)));
             Assert.AreEqual("LINESTRING (0 65.9, -34.5 9)", xy);
 
-            var empty = writer.Write(Geometries.LineString.Empty);
+            var empty = writer.Write(global::Geo.Geometries.LineString.Empty);
             Assert.AreEqual("LINESTRING EMPTY", empty);
         }
 
@@ -53,7 +53,7 @@ namespace Geo.Tests.Geo.IO.Wkt
             var linearRing = writer2.Write(new LinearRing(new Coordinate(65.9, 0), new Coordinate(9, -34.5), new Coordinate(50, 0), new Coordinate(65.9, 0)));
             Assert.AreEqual("LINEARRING (0 65.9, -34.5 9, 0 50, 0 65.9)", linearRing);
 
-            var empty = writer2.Write(Geometries.LinearRing.Empty);
+            var empty = writer2.Write(global::Geo.Geometries.LinearRing.Empty);
             Assert.AreEqual("LINEARRING EMPTY", empty);
         }
 
@@ -65,7 +65,7 @@ namespace Geo.Tests.Geo.IO.Wkt
             var xy = writer.Write(new Polygon(new LinearRing(new Coordinate(65.9, 0), new Coordinate(9, -34.5), new Coordinate(40, -20), new Coordinate(65.9, 0))));
             Assert.AreEqual("POLYGON ((0 65.9, -34.5 9, -20 40, 0 65.9))", xy);
 
-            var empty = writer.Write(Geometries.Polygon.Empty);
+            var empty = writer.Write(global::Geo.Geometries.Polygon.Empty);
             Assert.AreEqual("POLYGON EMPTY", empty);
         }
 
@@ -82,7 +82,7 @@ namespace Geo.Tests.Geo.IO.Wkt
             var triangle = writer2.Write(new Triangle(new LinearRing(new Coordinate(65.9, 0), new Coordinate(9, -34.5), new Coordinate(40, -20), new Coordinate(65.9, 0))));
             Assert.AreEqual("TRIANGLE ((0 65.9, -34.5 9, -20 40, 0 65.9))", triangle);
 
-            var empty = writer2.Write(Geometries.Triangle.Empty);
+            var empty = writer2.Write(global::Geo.Geometries.Triangle.Empty);
             Assert.AreEqual("TRIANGLE EMPTY", empty);
         }
 

--- a/Geo/Geometries/Circle.cs
+++ b/Geo/Geometries/Circle.cs
@@ -46,13 +46,14 @@ namespace Geo.Geometries
 
         public Envelope GetBounds()
         {
-            var radiusDeg = Radius / (Constants.NauticalMile * 60);
+            var latitudinalRadiusDeg = (Radius / (Constants.NauticalMile * 60));
+            var longditudinalRadiusDeg = (Radius / (Constants.NauticalMile * 60)) * Math.Cos(Center.Latitude.ToRadians());
 
             return new Envelope(
-                Center.Latitude - radiusDeg,
-                Center.Longitude - radiusDeg,
-                Center.Latitude + radiusDeg,
-                Center.Longitude + radiusDeg
+                Center.Latitude - latitudinalRadiusDeg,
+                Center.Longitude - longditudinalRadiusDeg,
+                Center.Latitude + latitudinalRadiusDeg,
+                Center.Longitude + longditudinalRadiusDeg
             );
         }
 


### PR DESCRIPTION
To keep the namespace convention, I had to add a couple of global:: to the tests.

Happy to use a different NS convention if you don't like this
