### PR TITLE
Fix bugs in converting Coordinate to Is3D during serialization.

### DIFF
--- a/Geo/Gps/Serialization/Gpx10Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx10Serializer.cs
@@ -65,7 +65,7 @@ namespace Geo.Gps.Serialization
                 {
                     lat = (decimal)waypoint.Coordinate.Latitude,
                     lon = (decimal)waypoint.Coordinate.Longitude,
-                    ele = waypoint.Coordinate.Is3D ? 0m : (decimal) ((Is3D)waypoint.Coordinate).Elevation
+                    ele = waypoint.Coordinate.Is3D ? (decimal)((Is3D)waypoint.Coordinate).Elevation : 0m
                 });
         }
 
@@ -90,7 +90,7 @@ namespace Geo.Gps.Serialization
                         {
                             lat = (decimal)segment.Fixes[j].Coordinate.Latitude,
                             lon = (decimal)segment.Fixes[j].Coordinate.Longitude,
-                            ele = segment.Fixes[j].Coordinate.Is3D ? 0m : (decimal) ((Is3D)segment.Fixes[j].Coordinate).Elevation
+                            ele = segment.Fixes[j].Coordinate.Is3D ? (decimal)((Is3D)segment.Fixes[j].Coordinate).Elevation : 0m
                         };
                     }
                     trk.trkseg[i] = new GpxTrackSegment { trkpt = pts };
@@ -117,7 +117,7 @@ namespace Geo.Gps.Serialization
                     {
                         lat = (decimal)route.Coordinates[j].Latitude,
                         lon = (decimal)route.Coordinates[j].Longitude,
-                        ele = route.Coordinates[j].Is3D ? 0m : (decimal) ((Is3D)route.Coordinates[j]).Elevation
+                        ele = route.Coordinates[j].Is3D ? (decimal)((Is3D)route.Coordinates[j]).Elevation : 0m
                     };
                 }
                 yield return rte;

--- a/Geo/Gps/Serialization/Gpx11Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx11Serializer.cs
@@ -144,7 +144,7 @@ namespace Geo.Gps.Serialization
             {
                 lat = (decimal)waypoint.Coordinate.Latitude,
                 lon = (decimal)waypoint.Coordinate.Longitude,
-                ele = waypoint.Coordinate.Is3D ? 0m : (decimal) ((Is3D)waypoint.Coordinate).Elevation
+                ele = waypoint.Coordinate.Is3D ? (decimal)((Is3D)waypoint.Coordinate).Elevation : 0m
             });
         }
 


### PR DESCRIPTION
When serializing waypoints, tracks or routes using Gpx10Serializer, or waypoints using Gpx11Serializer, an exception is thrown if the Coordinate objects representing the GPS points return false for "Is3D". This is due to the wrong order of statements in some ternary expressions in the code.