### PR TITLE
Fix V3013

### DIFF
--- a/Geo/Linq/EnumerableExtensions.cs
+++ b/Geo/Linq/EnumerableExtensions.cs
@@ -40,12 +40,12 @@ namespace Geo.Linq
 
         public static Area Min<TSource>(this IEnumerable<TSource> source, Func<TSource, Area> selector)
         {
-            return new Area(source.Select(selector).Max(x => x.SiValue));
+            return new Area(source.Select(selector).Min(x => x.SiValue));
         }
 
         public static Distance Min<TSource>(this IEnumerable<TSource> source, Func<TSource, Distance> selector)
         {
-            return new Distance(source.Select(selector).Max(x => x.SiValue));
+            return new Distance(source.Select(selector).Min(x => x.SiValue));
         }
     }
 }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

-  It is odd that the body of 'Max' function is fully equivalent to the body of 'Min' function (31, line 41). Geo EnumerableExtensions.cs 31

- It is odd that the body of 'Max' function is fully equivalent to the body of 'Min' function (36, line 46). Geo EnumerableExtensions.cs 36