### PR TITLE
Routes: use waypoints instead of coordinates for routes

### DIFF
--- a/Geo.Tests/Gps/Serialization/GarminFlightplanDeSerializerTests.cs
+++ b/Geo.Tests/Gps/Serialization/GarminFlightplanDeSerializerTests.cs
@@ -19,7 +19,7 @@ namespace Geo.Tests.Gps.Serialization
                 var file = new GarminFlightplanDeSerializer().DeSerialize(new StreamWrapper(stream));
                 Assert.That(file, Is.Not.Null);
                 Assert.That(file.Routes.Count, Is.EqualTo(1));
-                Assert.That(file.Routes[0].Coordinates.Count, Is.EqualTo(5));
+                Assert.That(file.Routes[0].Waypoints.Count, Is.EqualTo(5));
             }
         }
     }

--- a/Geo.Tests/Gps/Serialization/GpxSerializerTests.cs
+++ b/Geo.Tests/Gps/Serialization/GpxSerializerTests.cs
@@ -127,12 +127,21 @@ namespace Geo.Tests.Gps.Serialization
                     Assert.AreEqual(entry.Value, r2.Metadata[entry.Key]);
                 }
 
-                Assert.AreEqual(r1.Coordinates.Count, r2.Coordinates.Count);
-                for (int c = 0; c < r1.Coordinates.Count; c ++)
+                Assert.AreEqual(r1.Waypoints.Count, r2.Waypoints.Count);
+                for (int c = 0; c < r1.Waypoints.Count; c ++)
                 {
-                    Compare(r1.Coordinates[c], r2.Coordinates[c]);
+                    Compare(r1.Waypoints[c], r2.Waypoints[c]);
                 }
             }
+        }
+
+        private static void Compare(Waypoint wp1, Waypoint wp2)
+        {
+            Compare(wp1.Coordinate, wp2.Coordinate);
+
+            Assert.AreEqual(wp1.Name, wp2.Name);
+            Assert.AreEqual(wp1.Description, wp2.Description);
+            Assert.AreEqual(wp1.Comment, wp2.Comment);
         }
 
         private static void Compare(Coordinate coord1, Coordinate coord2)

--- a/Geo.Tests/Gps/Serialization/SkyDemonFlightplanDeSerializerTests.cs
+++ b/Geo.Tests/Gps/Serialization/SkyDemonFlightplanDeSerializerTests.cs
@@ -19,7 +19,7 @@ namespace Geo.Tests.Gps.Serialization
                 var file = new SkyDemonFlightplanDeSerializer().DeSerialize(new StreamWrapper(stream));
                 Assert.That(file, Is.Not.Null);
                 Assert.That(file.Routes.Count, Is.EqualTo(1));
-                Assert.That(file.Routes[0].Coordinates.Count, Is.EqualTo(4));
+                Assert.That(file.Routes[0].Waypoints.Count, Is.EqualTo(4));
             }
         }
     }

--- a/Geo/Gps/Route.cs
+++ b/Geo/Gps/Route.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Geo.Abstractions.Interfaces;
 using Geo.Geometries;
 using Geo.Gps.Metadata;
@@ -11,15 +12,15 @@ namespace Geo.Gps
         public Route()
         {
             Metadata = new RouteMetadata();
-            Coordinates = new List<Coordinate>();
+            Waypoints = new List<Waypoint>();
         }
 
         public RouteMetadata Metadata { get; private set; }
-        public List<Coordinate> Coordinates { get; set; }
+        public List<Waypoint> Waypoints { get; set; }
 
         public LineString ToLineString()
         {
-            return new LineString(Coordinates);
+            return new LineString(Waypoints.Select(wp => wp.Coordinate));
         }
 
         public Distance GetLength()

--- a/Geo/Gps/Serialization/GarminFlightplanDeSerializer.cs
+++ b/Geo/Gps/Serialization/GarminFlightplanDeSerializer.cs
@@ -39,7 +39,7 @@ namespace Geo.Gps.Serialization
                 foreach (var point in route.routepoint)
                 {
                     var wp = xml.waypointtable.Single(x => x.identifier == point.waypointidentifier);
-                    rte.Coordinates.Add(new Coordinate(wp.lat, wp.lon));
+                    rte.Waypoints.Add(new Waypoint(null, null, null, new Point(wp.lat, wp.lon)));
                 }
                 data.Routes.Add(rte);
             }

--- a/Geo/Gps/Serialization/Gpx10Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx10Serializer.cs
@@ -117,15 +117,18 @@ namespace Geo.Gps.Serialization
                 SerializeRouteMetadata(route, rte, x => x.Description, (gpx, s) => gpx.desc = s);
                 SerializeRouteMetadata(route, rte, x => x.Comment, (gpx, s) => gpx.cmt = s);
 
-                rte.rtept = new GpxPoint[route.Coordinates.Count];
-                for (var j = 0; j < route.Coordinates.Count; j++)
+                rte.rtept = new GpxPoint[route.Waypoints.Count];
+                for (var j = 0; j < route.Waypoints.Count; j++)
                 {
                     rte.rtept[j] = new GpxPoint
                     {
-                        lat = (decimal)route.Coordinates[j].Latitude,
-                        lon = (decimal)route.Coordinates[j].Longitude,
-                        ele = route.Coordinates[j].Is3D ? (decimal)((Is3D)route.Coordinates[j]).Elevation : 0m,
-                        eleSpecified = route.Coordinates[j].Is3D
+                        lat = (decimal)route.Waypoints[j].Point.Coordinate.Latitude,
+                        lon = (decimal)route.Waypoints[j].Point.Coordinate.Longitude,
+                        ele = route.Waypoints[j].Point.Is3D ? (decimal)((Is3D)route.Waypoints[j].Point.Coordinate).Elevation : 0m,
+                        eleSpecified = route.Waypoints[j].Point.Is3D,
+                        name = route.Waypoints[j].Name,
+                        desc = route.Waypoints[j].Description,
+                        cmt = route.Waypoints[j].Comment,
                     };
                 }
                 yield return rte;
@@ -182,8 +185,10 @@ namespace Geo.Gps.Serialization
 
                     foreach (var wptType in rteType.rtept)
                     {
-                        var fix = new CoordinateZ((double)wptType.lat, (double)wptType.lon, (double)wptType.ele);
-                        route.Coordinates.Add(fix);
+                        Point point = wptType.eleSpecified ? new Point((double)wptType.lat, (double)wptType.lon, (double)wptType.ele) :
+                                                             new Point((double)wptType.lat, (double)wptType.lon);
+
+                        route.Waypoints.Add(new Waypoint(wptType.name, wptType.desc, wptType.desc, point));
                     }
                     data.Routes.Add(route);
                 }

--- a/Geo/Gps/Serialization/Gpx11Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx11Serializer.cs
@@ -196,15 +196,18 @@ namespace Geo.Gps.Serialization
                 SerializeRouteMetadata(route, rte, x => x.Description, (gpx, s) => gpx.desc = s);
                 SerializeRouteMetadata(route, rte, x => x.Comment, (gpx, s) => gpx.cmt = s);
 
-                rte.rtept = new GpxWaypoint[route.Coordinates.Count];
-                for (var j = 0; j < route.Coordinates.Count; j++)
+                rte.rtept = new GpxWaypoint[route.Waypoints.Count];
+                for (var j = 0; j < route.Waypoints.Count; j++)
                 {
                     rte.rtept[j] = new GpxWaypoint
                     {
-                        lat = (decimal)route.Coordinates[j].Latitude,
-                        lon = (decimal)route.Coordinates[j].Longitude,
-                        ele = route.Coordinates[j].Is3D ? (decimal) ((Is3D)route.Coordinates[j]).Elevation : 0m,
-                        eleSpecified = route.Coordinates[j].Is3D,
+                        lat = (decimal)route.Waypoints[j].Point.Coordinate.Latitude,
+                        lon = (decimal)route.Waypoints[j].Point.Coordinate.Longitude,
+                        ele = route.Waypoints[j].Point.Is3D ? (decimal)((Is3D)route.Waypoints[j].Point.Coordinate).Elevation : 0m,
+                        eleSpecified = route.Waypoints[j].Point.Is3D,
+                        name = route.Waypoints[j].Name,
+                        desc = route.Waypoints[j].Description,
+                        cmt = route.Waypoints[j].Comment,
                     };
                 }
                 yield return rte;
@@ -279,8 +282,10 @@ namespace Geo.Gps.Serialization
 
                     foreach (var wptType in rteType.rtept)
                     {
-                        var fix = new CoordinateZ((double)wptType.lat, (double)wptType.lon, (double)wptType.ele);
-                        route.Coordinates.Add(fix);
+                        Point point = wptType.eleSpecified ? new Point((double)wptType.lat, (double)wptType.lon, (double)wptType.ele) :
+                                                             new Point((double)wptType.lat, (double)wptType.lon);
+
+                        route.Waypoints.Add(new Waypoint(wptType.name, wptType.desc, wptType.desc, point));
                     }
                     data.Routes.Add(route);
                 }

--- a/Geo/Gps/Serialization/PocketFmsFlightplanDeSerializer.cs
+++ b/Geo/Gps/Serialization/PocketFmsFlightplanDeSerializer.cs
@@ -31,10 +31,10 @@ namespace Geo.Gps.Serialization
         protected override GpsData DeSerialize(PocketFmsFlightplan xml)
         {
             var route = new Route();
-            route.Coordinates.Add(new Coordinate((double)xml.LIB[0].FromPoint.Latitude, (double)xml.LIB[0].FromPoint.Longitude));
+            route.Waypoints.Add(new Waypoint(null, null, null, new Point((double)xml.LIB[0].FromPoint.Latitude, (double)xml.LIB[0].FromPoint.Longitude)));
             foreach (var lib in xml.LIB)
             {
-                route.Coordinates.Add(new Coordinate((double)lib.ToPoint.Latitude, (double)lib.ToPoint.Longitude));
+                route.Waypoints.Add(new Waypoint(null, null, null, new Point((double)lib.ToPoint.Latitude, (double)lib.ToPoint.Longitude)));
             }
 
             var data = new GpsData();

--- a/Geo/Gps/Serialization/SkyDemonFlightplanDeSerializer.cs
+++ b/Geo/Gps/Serialization/SkyDemonFlightplanDeSerializer.cs
@@ -28,10 +28,10 @@ namespace Geo.Gps.Serialization
         private Route ConvertRoute(SkyDemonRoute route)
         {
             var result = new Route();
-            result.Coordinates.Add(ParseCoordinate(route.Start));
+            result.Waypoints.Add(ParseWaypoint(route.Start));
             foreach (var rhumbLine in route.RhumbLineRoute)
             {
-                result.Coordinates.Add(ParseCoordinate(rhumbLine.To));
+                result.Waypoints.Add(ParseWaypoint(rhumbLine.To));
             }
             return result;
         }
@@ -39,7 +39,7 @@ namespace Geo.Gps.Serialization
         private const string COORD_REGEX1 = @"^(?<dir>[NnSs])(?<d>\d\d)(?<m>\d\d)(?<s>\d\d.\d\d)$";
         private const string COORD_REGEX2 = @"^(?<dir>[EeWw])(?<d>\d\d\d)(?<m>\d\d)(?<s>\d\d.\d\d)$";
 
-        private Coordinate ParseCoordinate(string c)
+        private Waypoint ParseWaypoint(string c)
         {
             var ord = c.Trim().Split(' ');
 
@@ -57,7 +57,7 @@ namespace Geo.Gps.Serialization
             var latd = Regex.IsMatch(match1.Groups["dir"].Value, "[NnEe]") ? 1 : -1;
             var lond = Regex.IsMatch(match2.Groups["dir"].Value, "[NnEe]") ? 1 : -1;
 
-            return new Coordinate(lat * latd, lon * lond);
+            return new Waypoint(null, null, null, new Point(lat * latd, lon * lond));
         }
 
         protected override bool CanDeSerialize(XmlReader xml) {


### PR DESCRIPTION
Probably the simplest approach towards resolving https://github.com/sibartlett/Geo/issues/43

Note that this isn't a complete fix: it just enables the most obvious scenario (i.e. the one that I'm looking to enable 😄), namely preserving names, descriptions, and comments on GPX XML route points.

I'm not attached to anything in particular about his change, so feedback is more than welcome.