### PR TITLE
IPosition: Switch GetCoordinate() to Coordinate property

### DIFF
--- a/Geo/Abstractions/Interfaces/IPosition.cs
+++ b/Geo/Abstractions/Interfaces/IPosition.cs
@@ -2,5 +2,5 @@ namespace Geo.Abstractions.Interfaces;
 
 public interface IPosition
 {
-    Coordinate GetCoordinate();
+    Coordinate Coordinate { get; }
 }

--- a/Geo/Coordinate.cs
+++ b/Geo/Coordinate.cs
@@ -45,9 +45,9 @@ public class Coordinate : SpatialObject, IPosition
 
     public virtual bool IsMeasured => false;
 
-    Coordinate IPosition.GetCoordinate()
+    Coordinate IPosition.Coordinate
     {
-        return this;
+        get => this;
     }
 
     public override string ToString()

--- a/Geo/Geodesy/GeodeticCalculations.cs
+++ b/Geo/Geodesy/GeodeticCalculations.cs
@@ -8,7 +8,7 @@ public static class GeodeticCalculations
     public static double CalculateMeridionalParts(this IPosition point)
     {
         return GeoContext.Current.GeodeticCalculator.CalculateMeridionalParts(
-            point.GetCoordinate().Latitude
+            point.Coordinate.Latitude
         );
     }
 
@@ -16,7 +16,7 @@ public static class GeodeticCalculations
     {
         return new Distance(
             GeoContext.Current.GeodeticCalculator.CalculateMeridionalDistance(
-                point.GetCoordinate().Latitude
+                point.Coordinate.Latitude
             )
         );
     }

--- a/Geo/Geodesy/SpheroidCalculator.cs
+++ b/Geo/Geodesy/SpheroidCalculator.cs
@@ -25,8 +25,8 @@ public class SpheroidCalculator : IGeodeticCalculator
 
     public GeodeticLine CalculateOrthodromicLine(IPosition point, double heading, double distance)
     {
-        var lat1 = point.GetCoordinate().Latitude.ToRadians();
-        var lon1 = point.GetCoordinate().Longitude.ToRadians();
+        var lat1 = point.Coordinate.Latitude.ToRadians();
+        var lon1 = point.Coordinate.Longitude.ToRadians();
         var faz = heading.ToRadians();
 
         // glat1 initial geodetic latitude in radians N positive
@@ -94,7 +94,7 @@ public class SpheroidCalculator : IGeodeticCalculator
         var baz = modcrs(Math.Atan2(sa, b) + Math.PI);
 
         return new GeodeticLine(
-            new Coordinate(point.GetCoordinate().Latitude, point.GetCoordinate().Longitude),
+            new Coordinate(point.Coordinate.Latitude, point.Coordinate.Longitude),
             new Coordinate(glat2.ToDegrees(), glon2.ToDegrees()),
             distance,
             heading,
@@ -108,8 +108,8 @@ public class SpheroidCalculator : IGeodeticCalculator
         if (result == null)
             return null;
         return new GeodeticLine(
-            position1.GetCoordinate(),
-            position2.GetCoordinate(),
+            position1.Coordinate,
+            position2.Coordinate,
             result[0],
             result[1],
             result[2]
@@ -118,8 +118,8 @@ public class SpheroidCalculator : IGeodeticCalculator
 
     public GeodeticLine CalculateLoxodromicLine(IPosition position1, IPosition position2)
     {
-        var point1 = position1.GetCoordinate();
-        var point2 = position2.GetCoordinate();
+        var point1 = position1.Coordinate;
+        var point2 = position2.Coordinate;
         var lat1 = point1.Latitude;
         var lon1 = point1.Longitude;
         var lat2 = point2.Latitude;
@@ -281,8 +281,8 @@ public class SpheroidCalculator : IGeodeticCalculator
 
     private double[] CalculateOrthodromicLineInternal(IPosition position1, IPosition position2)
     {
-        var point1 = position1.GetCoordinate();
-        var point2 = position2.GetCoordinate();
+        var point1 = position1.Coordinate;
+        var point2 = position2.Coordinate;
 
         if (
             Math.Abs(point1.Latitude - point2.Latitude) < double.Epsilon

--- a/Geo/Geomagnetism/GeomagnetismCalculator.cs
+++ b/Geo/Geomagnetism/GeomagnetismCalculator.cs
@@ -50,7 +50,7 @@ public class GeomagnetismCalculator
 
     public bool TryCalculate(IPosition position, DateTime utcDate, out GeomagnetismResult result)
     {
-        var coordinate = position.GetCoordinate();
+        var coordinate = position.Coordinate;
         var coordinateZ =
             coordinate as CoordinateZ
             ?? new CoordinateZ(coordinate.Latitude, coordinate.Longitude, 0);

--- a/Geo/Geometries/Point.cs
+++ b/Geo/Geometries/Point.cs
@@ -38,11 +38,6 @@ public class Point : Geometry, IPosition
 
     public override bool IsMeasured => Coordinate != null && Coordinate.IsMeasured;
 
-    Coordinate IPosition.GetCoordinate()
-    {
-        return Coordinate;
-    }
-
     public override Envelope GetBounds()
     {
         return Coordinate.GetBounds();

--- a/Geo/IO/GeoJson/GeoJsonWriter.cs
+++ b/Geo/IO/GeoJson/GeoJsonWriter.cs
@@ -201,7 +201,7 @@ public class GeoJsonWriter
 
     private double[] WriteCoordinate(IPosition position)
     {
-        var coordinate = position.GetCoordinate();
+        var coordinate = position.Coordinate;
         var pointZM = coordinate as CoordinateZM;
         if (pointZM != null)
             return new[]


### PR DESCRIPTION
This is a semantic change, so I completely understand if you don't want to accept this PR, but I adjusted the `GetCoordinate()` function to be a `Coordinate` property in `IPosition` as a quality-of-life adjustment.  For example, the `Point` class already had this property and also had to implement the `GetCoordinate()` function to satisfy the interface.  I prefer to use a `Coordinate` property rather than a function, but it's really up to the eye of the beholder if you think it's worth merging.  Thanks for considering this submission!