### PR TITLE
Fix SphereCalculator envelope area/length calculations

### DIFF
--- a/Geo.Tests/Geodesy/SphereCalculatorTests.cs
+++ b/Geo.Tests/Geodesy/SphereCalculatorTests.cs
@@ -1,0 +1,66 @@
+using System;
+using Geo.Geodesy;
+using Xunit;
+
+namespace Geo.Tests.Geodesy;
+
+public class SphereCalculatorTests
+{
+    // Earth mean radius (matches Geo.Constants.EarthMeanRadius, which is internal).
+    private const double Radius = 6371008.7714d;
+
+    [Fact]
+    public void Area_of_the_whole_sphere_equals_four_pi_r_squared()
+    {
+        var calculator = new SphereCalculator(Radius);
+        var envelope = new Envelope(-90, -180, 90, 180);
+
+        var expected = 4 * Math.PI * Radius * Radius;
+        Assert.Equal(expected, calculator.CalculateArea(envelope).SiValue, expected * 1e-9);
+    }
+
+    [Fact]
+    public void Area_of_the_northern_hemisphere_equals_two_pi_r_squared()
+    {
+        var calculator = new SphereCalculator(Radius);
+        var envelope = new Envelope(0, -180, 90, 180);
+
+        var expected = 2 * Math.PI * Radius * Radius;
+        Assert.Equal(expected, calculator.CalculateArea(envelope).SiValue, expected * 1e-9);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 1, 1, 12363718034.176485)]
+    [InlineData(0, 0, 10, 10, 1230166804525.028)]
+    public void Area_of_an_envelope_is_positive_and_matches_the_spherical_zone(
+        double minLat,
+        double minLon,
+        double maxLat,
+        double maxLon,
+        double expected
+    )
+    {
+        var calculator = new SphereCalculator(Radius);
+        var result = calculator.CalculateArea(new Envelope(minLat, minLon, maxLat, maxLon));
+
+        Assert.True(result.SiValue > 0);
+        Assert.Equal(expected, result.SiValue, expected * 1e-9);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 1, 1, 444763.38338824594)]
+    [InlineData(0, 0, 10, 10, 4430910.158223232)]
+    public void Length_of_an_envelope_is_its_perimeter(
+        double minLat,
+        double minLon,
+        double maxLat,
+        double maxLon,
+        double expected
+    )
+    {
+        var calculator = new SphereCalculator(Radius);
+        var result = calculator.CalculateLength(new Envelope(minLat, minLon, maxLat, maxLon));
+
+        Assert.Equal(expected, result.SiValue, expected * 1e-9);
+    }
+}

--- a/Geo/Geodesy/SphereCalculator.cs
+++ b/Geo/Geodesy/SphereCalculator.cs
@@ -46,22 +46,21 @@ public class SphereCalculator : IGeodeticCalculator
 
     public Distance CalculateLength(Envelope envelope)
     {
-        var lat = 180 / envelope.MaxLat - envelope.MinLat;
-        var lon = 360 / envelope.MaxLon - envelope.MinLon;
-        if (envelope.MinLon > envelope.MaxLon)
-            lon = 1 - lon;
+        // Perimeter of the envelope: the two east-west arcs along the parallels
+        // at the min/max latitude, plus the two north-south meridian arcs at the
+        // sides. Fractions are of a full 360 degree great circle.
+        var latFraction = (envelope.MaxLat - envelope.MinLat) / 360;
+        var lonFraction = (envelope.MaxLon - envelope.MinLon) / 360;
 
-        var h1 = Radius * (1 - Math.Cos(envelope.MaxLat.ToRadians()));
-        var h2 = Radius * (1 - Math.Cos(envelope.MinLat.ToRadians()));
+        // Radius of the circle of latitude (parallel) at each latitude.
+        var r1 = Radius * Math.Cos(envelope.MaxLat.ToRadians());
+        var r2 = Radius * Math.Cos(envelope.MinLat.ToRadians());
 
-        var r1 = Math.Sqrt(h1 * (2 * Radius - h1));
-        var r2 = Math.Sqrt(h2 * (2 * Radius - h2));
+        var top = 2 * Math.PI * r1 * lonFraction;
+        var bottom = 2 * Math.PI * r2 * lonFraction;
+        var sides = 2 * Math.PI * Radius * latFraction * 2;
 
-        var c1 = 2 * Math.PI * r1 * lon;
-        var c2 = 2 * Math.PI * r2 * lon;
-        var c3 = 2 * Math.PI * Radius * lat * 2;
-
-        return new Distance(c1 + c2 + c3);
+        return new Distance(top + bottom + sides);
     }
 
     public Area CalculateArea(CoordinateSequence coordinates)
@@ -99,8 +98,11 @@ public class SphereCalculator : IGeodeticCalculator
 
     public Area CalculateArea(Envelope envelope)
     {
-        var h1 = Radius * (1 - Math.Cos(envelope.MaxLat.ToRadians()));
-        var h2 = Radius * (1 - Math.Cos(envelope.MinLat.ToRadians()));
+        // Area of the spherical zone between the two latitudes, scaled by the
+        // fraction of longitude the envelope spans:
+        //   2 * pi * R^2 * (sin(maxLat) - sin(minLat)) * (lonSpan / 360).
+        var h1 = Radius * (1 - Math.Sin(envelope.MaxLat.ToRadians()));
+        var h2 = Radius * (1 - Math.Sin(envelope.MinLat.ToRadians()));
         var zoneArea = 2 * Math.PI * Radius * (h2 - h1);
         var lonPercentage = (envelope.MaxLon - envelope.MinLon) / 360;
         return new Area(zoneArea * lonPercentage);


### PR DESCRIPTION
## Summary

Both `Envelope`-based methods on `SphereCalculator` produced incorrect results and had no test coverage. This fixes them and adds regression tests.

### `CalculateArea(Envelope)`
Used `Math.Cos(latitude)` where the spherical-zone area formula requires `Math.Sin` (the cap height must be measured from the colatitude). Consequences:
- Whole sphere returned **0** instead of `4πR²`.
- Ordinary envelopes (e.g. `0,0 → 10,10`) returned a **negative** area.

Now computes `2πR²·(sin(maxLat) − sin(minLat))` scaled by the longitude fraction.

### `CalculateLength(Envelope)`
Two bugs:
- Broken operator precedence — `180 / MaxLat - MinLat` parsed as `(180 / MaxLat) - MinLat` instead of a latitude-span fraction.
- Each parallel's radius was derived as `R·sin(lat)` instead of `R·cos(lat)`.

Now sums the two parallel arcs (radius `R·cos(lat)`) and the two meridian arcs to give the envelope perimeter.

## Tests

Adds `Geo.Tests/Geodesy/SphereCalculatorTests.cs` covering both methods, including the whole-sphere (`4πR²`) and hemisphere (`2πR²`) area identities plus concrete perimeter/zone-area values.

## Verification note

The .NET SDK could not be installed in the authoring environment (network policy blocks the SDK download), so `./build.sh Test` and CSharpier were not run locally. The corrected formulas were validated independently (full sphere → exactly `4πR²`, hemisphere → `2πR²`), and the test expected values derive from those same formulas. CI (`CheckForUncommittedChanges Test`) is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjuyjtW8YaWa74P3MoEdkY)_