### PR TITLE
Fix pole-equality operator precedence in Coordinate.Equals

### DIFF
--- a/Geo.Tests/CoordinateTests.cs
+++ b/Geo.Tests/CoordinateTests.cs
@@ -89,6 +89,23 @@ public class CoordinateTests
     }
 
     [Fact]
+    public void Equality_SouthPoleCoordinates()
+    {
+        Assert.True(
+            new Coordinate(-90, 0).Equals(
+                new Coordinate(-90, 180),
+                new SpatialEqualityOptions { PoleCoordiantesAreEqual = true }
+            )
+        );
+        Assert.False(
+            new Coordinate(-90, 0).Equals(
+                new Coordinate(-90, 180),
+                new SpatialEqualityOptions { PoleCoordiantesAreEqual = false }
+            )
+        );
+    }
+
+    [Fact]
     public void Equality_AntiMeridianCoordinates()
     {
         Assert.True(

--- a/Geo/Coordinate.cs
+++ b/Geo/Coordinate.cs
@@ -144,7 +144,7 @@ public class Coordinate : SpatialObject, IPosition
 
         if (Latitude.Equals(other.Latitude))
         {
-            if ((options.PoleCoordiantesAreEqual && Latitude.Equals(90d)) || Latitude.Equals(-90d))
+            if (options.PoleCoordiantesAreEqual && (Latitude.Equals(90d) || Latitude.Equals(-90d)))
                 return true;
 
             if (Longitude.Equals(other.Longitude))

--- a/Geo/CoordinateM.cs
+++ b/Geo/CoordinateM.cs
@@ -36,7 +36,7 @@ public class CoordinateM : Coordinate, IsMeasured
 
         if (Latitude.Equals(other.Latitude))
         {
-            if ((options.PoleCoordiantesAreEqual && Latitude.Equals(90d)) || Latitude.Equals(-90d))
+            if (options.PoleCoordiantesAreEqual && (Latitude.Equals(90d) || Latitude.Equals(-90d)))
                 return true;
 
             if (Longitude.Equals(other.Longitude))

--- a/Geo/CoordinateZ.cs
+++ b/Geo/CoordinateZ.cs
@@ -36,7 +36,7 @@ public class CoordinateZ : Coordinate, Is3D
 
         if (Latitude.Equals(other.Latitude))
         {
-            if ((options.PoleCoordiantesAreEqual && Latitude.Equals(90d)) || Latitude.Equals(-90d))
+            if (options.PoleCoordiantesAreEqual && (Latitude.Equals(90d) || Latitude.Equals(-90d)))
                 return true;
 
             if (Longitude.Equals(other.Longitude))

--- a/Geo/CoordinateZM.cs
+++ b/Geo/CoordinateZM.cs
@@ -46,7 +46,7 @@ public class CoordinateZM : Coordinate, Is3D, IsMeasured
 
         if (Latitude.Equals(other.Latitude))
         {
-            if ((options.PoleCoordiantesAreEqual && Latitude.Equals(90d)) || Latitude.Equals(-90d))
+            if (options.PoleCoordiantesAreEqual && (Latitude.Equals(90d) || Latitude.Equals(-90d)))
                 return true;
 
             if (Longitude.Equals(other.Longitude))


### PR DESCRIPTION
The spatial Equals overload on Coordinate, CoordinateZ, CoordinateM and
CoordinateZM used the mis-parenthesized condition

    (options.PoleCoordiantesAreEqual && Latitude.Equals(90d)) || Latitude.Equals(-90d)

so any two coordinates at the south pole (latitude -90) were reported equal
regardless of longitude, even when PoleCoordiantesAreEqual was false. This
also broke the equals/hashcode contract, since the matching GetHashCode
overloads already used the correct precedence, and left the north and south
poles behaving inconsistently.

Group the pole checks under the option, matching GetHashCode:

    options.PoleCoordiantesAreEqual && (Latitude.Equals(90d) || Latitude.Equals(-90d))

Add a south-pole regression test covering the option on and off.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017LowKV2aqwrVxaS8wPFMaV