### PR TITLE
Add test coverage for Measure, geometries, Envelope and Linq

### DIFF
--- a/Geo.Tests/CoordinateSequenceTests.cs
+++ b/Geo.Tests/CoordinateSequenceTests.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using Xunit;
+
+namespace Geo.Tests;
+
+public class CoordinateSequenceTests
+{
+    [Fact]
+    public void Empty_sequence_reports_no_bounds()
+    {
+        var sequence = new CoordinateSequence();
+
+        Assert.True(sequence.IsEmpty);
+        Assert.Null(sequence.GetBounds());
+    }
+
+    [Fact]
+    public void GetBounds_spans_the_minimum_and_maximum_ordinates()
+    {
+        var sequence = new CoordinateSequence(
+            new Coordinate(10, 20),
+            new Coordinate(-5, 40),
+            new Coordinate(30, -15)
+        );
+
+        var bounds = sequence.GetBounds();
+
+        Assert.Equal(new Envelope(-5, -15, 30, 40), bounds);
+    }
+
+    [Fact]
+    public void HasElevation_is_true_when_any_coordinate_is_3d()
+    {
+        Assert.False(
+            new CoordinateSequence(new Coordinate(0, 0), new Coordinate(1, 1)).HasElevation
+        );
+        Assert.True(
+            new CoordinateSequence(new Coordinate(0, 0), new CoordinateZ(1, 1, 5)).HasElevation
+        );
+    }
+
+    [Fact]
+    public void HasM_is_true_when_any_coordinate_is_measured()
+    {
+        Assert.False(new CoordinateSequence(new Coordinate(0, 0)).HasM);
+        Assert.True(new CoordinateSequence(new CoordinateM(0, 0, 3)).HasM);
+    }
+
+    [Fact]
+    public void IsClosed_requires_more_than_two_matching_endpoints()
+    {
+        var closed = new CoordinateSequence(
+            new Coordinate(0, 0),
+            new Coordinate(1, 1),
+            new Coordinate(2, 0),
+            new Coordinate(0, 0)
+        );
+        var open = new CoordinateSequence(
+            new Coordinate(0, 0),
+            new Coordinate(1, 1),
+            new Coordinate(2, 0)
+        );
+
+        Assert.True(closed.IsClosed);
+        Assert.False(open.IsClosed);
+    }
+
+    [Fact]
+    public void ToLineSegments_yields_one_segment_per_adjacent_pair()
+    {
+        var sequence = new CoordinateSequence(
+            new Coordinate(0, 0),
+            new Coordinate(1, 1),
+            new Coordinate(2, 2)
+        );
+
+        var segments = sequence.ToLineSegments().ToList();
+
+        Assert.Equal(2, segments.Count);
+        Assert.Equal(new Coordinate(0, 0), segments[0].Coordinate1);
+        Assert.Equal(new Coordinate(1, 1), segments[0].Coordinate2);
+        Assert.Equal(new Coordinate(1, 1), segments[1].Coordinate1);
+        Assert.Equal(new Coordinate(2, 2), segments[1].Coordinate2);
+    }
+
+    [Fact]
+    public void Equality_compares_the_coordinates_in_order()
+    {
+        var a = new CoordinateSequence(new Coordinate(0, 0), new Coordinate(1, 1));
+        var b = new CoordinateSequence(new Coordinate(0, 0), new Coordinate(1, 1));
+        var c = new CoordinateSequence(new Coordinate(1, 1), new Coordinate(0, 0));
+
+        Assert.True(a == b);
+        Assert.True(a != c);
+        Assert.True(a.Equals(b));
+        Assert.False(a.Equals(c));
+    }
+}

--- a/Geo.Tests/CoordinateTests.cs
+++ b/Geo.Tests/CoordinateTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 
 namespace Geo.Tests;
 
@@ -120,5 +121,115 @@ public class CoordinateTests
                 new SpatialEqualityOptions { AntiMeridianCoordinatesAreEqual = false }
             )
         );
+    }
+
+    [Fact]
+    public void Parse_null_throws_argument_null_exception()
+    {
+        Assert.Throws<ArgumentNullException>(() => Coordinate.Parse(null));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Parse_empty_or_whitespace_throws_argument_exception(string value)
+    {
+        Assert.Throws<ArgumentException>(() => Coordinate.Parse(value));
+    }
+
+    [Fact]
+    public void Parse_unrecognised_format_throws_format_exception()
+    {
+        Assert.Throws<FormatException>(() => Coordinate.Parse("not a coordinate"));
+    }
+
+    [Fact]
+    public void TryParse_returns_false_for_unrecognised_input()
+    {
+        var success = Coordinate.TryParse("not a coordinate", out var result);
+
+        Assert.False(success);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryParse_returns_true_for_valid_input()
+    {
+        var success = Coordinate.TryParse("42.294498, -89.637901", out var result);
+
+        Assert.True(success);
+        Assert.NotNull(result);
+        Assert.Equal(42.294498, result.Latitude);
+        Assert.Equal(-89.637901, result.Longitude);
+    }
+
+    [Fact]
+    public void TryParse_string_overload_returns_null_for_unrecognised_input()
+    {
+        Assert.Null(Coordinate.TryParse("not a coordinate"));
+        Assert.NotNull(Coordinate.TryParse("1, 2"));
+    }
+
+    [Theory]
+    [InlineData(91, 0)]
+    [InlineData(-91, 0)]
+    [InlineData(0, 181)]
+    [InlineData(0, -181)]
+    public void Out_of_range_ordinates_throw(double latitude, double longitude)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Coordinate(latitude, longitude));
+    }
+
+    [Fact]
+    public void CoordinateZ_exposes_elevation_and_is_3d()
+    {
+        var coordinate = new CoordinateZ(1, 2, 3);
+
+        Assert.Equal(3, coordinate.Elevation);
+        Assert.True(coordinate.Is3D);
+        Assert.False(coordinate.IsMeasured);
+    }
+
+    [Fact]
+    public void CoordinateM_exposes_measure_and_is_measured()
+    {
+        var coordinate = new CoordinateM(1, 2, 3);
+
+        Assert.Equal(3, coordinate.Measure);
+        Assert.True(coordinate.IsMeasured);
+        Assert.False(coordinate.Is3D);
+    }
+
+    [Fact]
+    public void CoordinateZM_exposes_elevation_and_measure()
+    {
+        var coordinate = new CoordinateZM(1, 2, 3, 4);
+
+        Assert.Equal(3, coordinate.Elevation);
+        Assert.Equal(4, coordinate.Measure);
+        Assert.True(coordinate.Is3D);
+        Assert.True(coordinate.IsMeasured);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void CoordinateZ_rejects_non_finite_elevation(double elevation)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CoordinateZ(1, 2, elevation));
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void CoordinateM_rejects_non_finite_measure(double measure)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CoordinateM(1, 2, measure));
+    }
+
+    [Fact]
+    public void GetBounds_is_a_degenerate_envelope_at_the_coordinate()
+    {
+        Assert.Equal(new Envelope(12, 34, 12, 34), new Coordinate(12, 34).GetBounds());
     }
 }

--- a/Geo.Tests/EnvelopeTests.cs
+++ b/Geo.Tests/EnvelopeTests.cs
@@ -1,0 +1,108 @@
+using Geo.Abstractions.Interfaces;
+using Geo.Geometries;
+using Xunit;
+
+namespace Geo.Tests;
+
+public class EnvelopeTests
+{
+    [Fact]
+    public void Constructor_exposes_the_bounds()
+    {
+        var envelope = new Envelope(-10, -20, 30, 40);
+
+        Assert.Equal(-10, envelope.MinLat);
+        Assert.Equal(-20, envelope.MinLon);
+        Assert.Equal(30, envelope.MaxLat);
+        Assert.Equal(40, envelope.MaxLon);
+    }
+
+    [Fact]
+    public void Contains_coordinate_uses_strict_interior()
+    {
+        var envelope = new Envelope(0, 0, 10, 10);
+
+        Assert.True(envelope.Contains(new Coordinate(5, 5)));
+        Assert.False(envelope.Contains(new Coordinate(0, 0)));
+        Assert.False(envelope.Contains(new Coordinate(5, 10)));
+        Assert.False(envelope.Contains(new Coordinate(20, 20)));
+    }
+
+    [Fact]
+    public void Contains_envelope_requires_a_strictly_smaller_envelope()
+    {
+        var envelope = new Envelope(0, 0, 10, 10);
+
+        Assert.True(envelope.Contains(new Envelope(1, 1, 9, 9)));
+        Assert.False(envelope.Contains(new Envelope(0, 0, 10, 10)));
+        Assert.False(envelope.Contains(new Envelope(-1, -1, 11, 11)));
+        Assert.False(envelope.Contains((Envelope)null));
+    }
+
+    [Fact]
+    public void Contains_geometry_uses_the_geometry_bounds()
+    {
+        var envelope = new Envelope(0, 0, 10, 10);
+
+        Assert.True(envelope.Contains(new Point(5, 5)));
+        Assert.False(envelope.Contains(new Point(50, 50)));
+        Assert.False(envelope.Contains((IGeometry)null));
+    }
+
+    [Fact]
+    public void Combine_produces_the_bounding_envelope_of_both()
+    {
+        var combined = new Envelope(0, 0, 5, 5).Combine(new Envelope(3, 3, 10, 12));
+
+        Assert.Equal(new Envelope(0, 0, 10, 12), combined);
+    }
+
+    [Fact]
+    public void Combine_with_null_returns_the_same_envelope()
+    {
+        var envelope = new Envelope(0, 0, 5, 5);
+
+        Assert.Same(envelope, envelope.Combine(null));
+    }
+
+    [Fact]
+    public void Intersects_is_true_for_overlapping_envelopes()
+    {
+        var envelope = new Envelope(0, 0, 10, 10);
+
+        Assert.True(envelope.Intersects(new Envelope(5, 5, 15, 15)));
+        Assert.False(envelope.Intersects(new Envelope(20, 20, 30, 30)));
+    }
+
+    [Fact]
+    public void Equality_compares_all_four_bounds()
+    {
+        var a = new Envelope(0, 0, 10, 10);
+        var b = new Envelope(0, 0, 10, 10);
+        var c = new Envelope(0, 0, 10, 11);
+
+        Assert.True(a == b);
+        Assert.True(a != c);
+        Assert.True(a.Equals(b));
+        Assert.False(a.Equals(c));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void Area_and_length_are_positive_for_a_real_envelope()
+    {
+        var envelope = new Envelope(0, 0, 10, 10);
+
+        Assert.True(envelope.GetArea().SiValue > 0);
+        Assert.True(envelope.GetLength().SiValue > 0);
+    }
+
+    [Fact]
+    public void A_larger_envelope_has_a_larger_area()
+    {
+        var small = new Envelope(0, 0, 1, 1);
+        var large = new Envelope(0, 0, 10, 10);
+
+        Assert.True(large.GetArea().SiValue > small.GetArea().SiValue);
+    }
+}

--- a/Geo.Tests/Geometries/CircleTests.cs
+++ b/Geo.Tests/Geometries/CircleTests.cs
@@ -58,6 +58,61 @@ public class CircleTests
         Assert.True(maxLonError <= 0.002);
     }
 
+    [Fact]
+    public void GetArea_approximates_pi_r_squared()
+    {
+        const double radius = 111000;
+        var circle = new Circle(0, 20, radius);
+
+        var expected = Math.PI * radius * radius;
+
+        Assert.Equal(expected, circle.GetArea().SiValue, expected * 0.01);
+    }
+
+    [Fact]
+    public void GetLength_approximates_the_circumference()
+    {
+        const double radius = 111000;
+        var circle = new Circle(0, 20, radius);
+
+        var expected = 2 * Math.PI * radius;
+
+        Assert.Equal(expected, circle.GetLength().SiValue, expected * 0.01);
+    }
+
+    [Fact]
+    public void ToPolygon_produces_a_closed_ring_with_one_coordinate_per_side()
+    {
+        var polygon = new Circle(0, 20, 111000).ToPolygon(8);
+
+        Assert.False(polygon.IsEmpty);
+        Assert.True(polygon.Shell.IsClosed);
+        // eight vertices plus the repeated closing coordinate
+        Assert.Equal(9, polygon.Shell.Coordinates.Count);
+    }
+
+    [Fact]
+    public void ToPolygon_requires_at_least_three_sides()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Circle(0, 20, 111000).ToPolygon(2));
+    }
+
+    [Fact]
+    public void Empty_circles_report_empty()
+    {
+        Assert.True(new Circle().IsEmpty);
+        Assert.True(Circle.Empty.IsEmpty);
+        Assert.False(new Circle(0, 20, 111000).IsEmpty);
+    }
+
+    [Fact]
+    public void Equality_compares_center_and_radius()
+    {
+        Assert.True(new Circle(0, 20, 111000) == new Circle(0, 20, 111000));
+        Assert.True(new Circle(0, 20, 111000) != new Circle(0, 20, 222000));
+        Assert.True(new Circle(0, 20, 111000) != new Circle(1, 20, 111000));
+    }
+
     public double Distance(double nr1, double nr2)
     {
         return Math.Abs(nr1 - nr2);

--- a/Geo.Tests/Geometries/LineStringTests.cs
+++ b/Geo.Tests/Geometries/LineStringTests.cs
@@ -1,0 +1,106 @@
+using System;
+using Geo.Geometries;
+using Xunit;
+
+namespace Geo.Tests.Geometries;
+
+public class LineStringTests
+{
+    [Fact]
+    public void Default_line_string_is_empty_and_has_no_bounds()
+    {
+        var line = new LineString();
+
+        Assert.True(line.IsEmpty);
+        Assert.Null(line.GetBounds());
+    }
+
+    [Fact]
+    public void GetBounds_spans_all_coordinates()
+    {
+        var line = new LineString(
+            new Coordinate(0, 0),
+            new Coordinate(10, -5),
+            new Coordinate(-3, 8)
+        );
+
+        Assert.Equal(new Envelope(-3, -5, 10, 8), line.GetBounds());
+    }
+
+    [Fact]
+    public void IsClosed_is_true_when_the_endpoints_coincide()
+    {
+        var open = new LineString(new Coordinate(0, 0), new Coordinate(1, 1));
+        var closed = new LineString(
+            new Coordinate(0, 0),
+            new Coordinate(1, 1),
+            new Coordinate(0, 0)
+        );
+
+        Assert.False(open.IsClosed);
+        Assert.True(closed.IsClosed);
+    }
+
+    [Fact]
+    public void Is3D_and_IsMeasured_reflect_the_coordinates()
+    {
+        Assert.True(new LineString(new CoordinateZ(0, 0, 1), new CoordinateZ(1, 1, 2)).Is3D);
+        Assert.True(new LineString(new CoordinateM(0, 0, 1), new CoordinateM(1, 1, 2)).IsMeasured);
+    }
+
+    [Fact]
+    public void GetLength_is_positive_for_a_real_line()
+    {
+        var line = new LineString(new Coordinate(0, 0), new Coordinate(0, 1));
+
+        Assert.True(line.GetLength().SiValue > 0);
+    }
+
+    [Fact]
+    public void Indexer_returns_the_coordinate_at_the_position()
+    {
+        var line = new LineString(new Coordinate(0, 0), new Coordinate(1, 1));
+
+        Assert.Equal(new Coordinate(1, 1), line[1]);
+    }
+
+    [Fact]
+    public void Equality_compares_the_coordinate_sequence()
+    {
+        var a = new LineString(new Coordinate(0, 0), new Coordinate(1, 1));
+        var b = new LineString(new Coordinate(0, 0), new Coordinate(1, 1));
+        var c = new LineString(new Coordinate(0, 0), new Coordinate(2, 2));
+
+        Assert.True(a == b);
+        Assert.True(a != c);
+    }
+
+    [Fact]
+    public void LinearRing_requires_a_closed_sequence()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new LinearRing(new Coordinate(0, 0), new Coordinate(1, 1), new Coordinate(2, 0))
+        );
+    }
+
+    [Fact]
+    public void LinearRing_accepts_a_closed_sequence()
+    {
+        var ring = new LinearRing(
+            new Coordinate(0, 0),
+            new Coordinate(1, 1),
+            new Coordinate(2, 0),
+            new Coordinate(0, 0)
+        );
+
+        Assert.True(ring.IsClosed);
+    }
+
+    [Fact]
+    public void An_empty_linear_ring_is_allowed()
+    {
+        var ring = new LinearRing();
+
+        Assert.True(ring.IsEmpty);
+    }
+}

--- a/Geo.Tests/Geometries/MultiGeometryTests.cs
+++ b/Geo.Tests/Geometries/MultiGeometryTests.cs
@@ -1,0 +1,87 @@
+using Geo.Geometries;
+using Xunit;
+
+namespace Geo.Tests.Geometries;
+
+public class MultiGeometryTests
+{
+    private static LinearRing Square(double size)
+    {
+        return new LinearRing(
+            new Coordinate(0, 0),
+            new Coordinate(size, 0),
+            new Coordinate(size, size),
+            new Coordinate(0, size),
+            new Coordinate(0, 0)
+        );
+    }
+
+    [Fact]
+    public void MultiPoint_collects_its_points()
+    {
+        var multi = new MultiPoint(new Point(0, 0), new Point(1, 1));
+
+        Assert.Equal(2, multi.Geometries.Count);
+        Assert.False(multi.IsEmpty);
+        Assert.True(new MultiPoint().IsEmpty);
+    }
+
+    [Fact]
+    public void MultiLineString_length_is_the_sum_of_its_lines()
+    {
+        var a = new LineString(new Coordinate(0, 0), new Coordinate(0, 1));
+        var b = new LineString(new Coordinate(0, 0), new Coordinate(0, 2));
+        var multi = new MultiLineString(a, b);
+
+        var expected = a.GetLength().SiValue + b.GetLength().SiValue;
+
+        Assert.Equal(expected, multi.GetLength().SiValue, 1e-6);
+    }
+
+    [Fact]
+    public void MultiPolygon_area_is_the_sum_of_its_polygons()
+    {
+        var a = new Polygon(Square(1));
+        var b = new Polygon(Square(2));
+        var multi = new MultiPolygon(a, b);
+
+        var expected = a.GetArea().SiValue + b.GetArea().SiValue;
+
+        Assert.Equal(expected, multi.GetArea().SiValue, 1e-6);
+    }
+
+    [Fact]
+    public void GeometryCollection_bounds_combine_all_members()
+    {
+        var collection = new GeometryCollection(new Point(0, 0), new Point(10, 10));
+
+        Assert.Equal(new Envelope(0, 0, 10, 10), collection.GetBounds());
+    }
+
+    [Fact]
+    public void GeometryCollection_is_3d_when_any_member_is_3d()
+    {
+        var collection = new GeometryCollection(new Point(0, 0), new Point(1, 1, 5));
+
+        Assert.True(collection.Is3D);
+        Assert.False(new GeometryCollection(new Point(0, 0)).Is3D);
+    }
+
+    [Fact]
+    public void Empty_geometry_collection_reports_empty()
+    {
+        Assert.True(new GeometryCollection().IsEmpty);
+        Assert.Null(new GeometryCollection().GetBounds());
+    }
+
+    [Fact]
+    public void GeometryCollection_equality_compares_members_in_order()
+    {
+        var a = new GeometryCollection(new Point(0, 0), new Point(1, 1));
+        var b = new GeometryCollection(new Point(0, 0), new Point(1, 1));
+        var c = new GeometryCollection(new Point(1, 1), new Point(0, 0));
+
+        Assert.True(a.Equals(b));
+        Assert.False(a.Equals(c));
+    }
+}

--- a/Geo.Tests/Geometries/PointTests.cs
+++ b/Geo.Tests/Geometries/PointTests.cs
@@ -1,0 +1,75 @@
+using Geo.Geometries;
+using Xunit;
+
+namespace Geo.Tests.Geometries;
+
+public class PointTests
+{
+    [Fact]
+    public void Default_and_empty_points_are_empty()
+    {
+        Assert.True(new Point().IsEmpty);
+        Assert.True(Point.Empty.IsEmpty);
+        Assert.False(new Point(1, 2).IsEmpty);
+    }
+
+    [Fact]
+    public void Two_argument_constructor_is_neither_3d_nor_measured()
+    {
+        var point = new Point(1, 2);
+
+        Assert.False(point.Is3D);
+        Assert.False(point.IsMeasured);
+        Assert.IsType<Coordinate>(point.Coordinate);
+    }
+
+    [Fact]
+    public void Elevation_constructor_is_3d()
+    {
+        var point = new Point(1, 2, 3);
+
+        Assert.True(point.Is3D);
+        Assert.False(point.IsMeasured);
+        Assert.IsType<CoordinateZ>(point.Coordinate);
+    }
+
+    [Fact]
+    public void Elevation_and_measure_constructor_is_3d_and_measured()
+    {
+        var point = new Point(1, 2, 3, 4);
+
+        Assert.True(point.Is3D);
+        Assert.True(point.IsMeasured);
+        Assert.IsType<CoordinateZM>(point.Coordinate);
+    }
+
+    [Fact]
+    public void GetBounds_is_a_degenerate_envelope_at_the_coordinate()
+    {
+        var bounds = new Point(12, 34).GetBounds();
+
+        Assert.Equal(new Envelope(12, 34, 12, 34), bounds);
+    }
+
+    [Fact]
+    public void Equality_compares_coordinates()
+    {
+        Assert.True(new Point(1, 2) == new Point(1, 2));
+        Assert.True(new Point(1, 2) != new Point(1, 3));
+        Assert.True(new Point(1, 2).Equals(new Point(1, 2)));
+        Assert.Equal(new Point(1, 2).GetHashCode(), new Point(1, 2).GetHashCode());
+    }
+
+    [Fact]
+    public void A_2d_point_does_not_equal_a_3d_point_at_the_same_location()
+    {
+        Assert.False(new Point(1, 2).Equals(new Point(1, 2, 3)));
+        Assert.False(new Point(1, 2, 3).Equals(new Point(1, 2)));
+    }
+
+    [Fact]
+    public void Two_empty_points_are_equal()
+    {
+        Assert.True(new Point().Equals(Point.Empty));
+    }
+}

--- a/Geo.Tests/Geometries/PolygonTests.cs
+++ b/Geo.Tests/Geometries/PolygonTests.cs
@@ -1,0 +1,91 @@
+using System;
+using Geo.Geometries;
+using Xunit;
+
+namespace Geo.Tests.Geometries;
+
+public class PolygonTests
+{
+    // A counter-clockwise ring so the geodetic area comes out positive.
+    private static LinearRing Square(double size)
+    {
+        return new LinearRing(
+            new Coordinate(0, 0),
+            new Coordinate(size, 0),
+            new Coordinate(size, size),
+            new Coordinate(0, size),
+            new Coordinate(0, 0)
+        );
+    }
+
+    [Fact]
+    public void Default_polygon_is_empty()
+    {
+        Assert.True(new Polygon().IsEmpty);
+        Assert.True(Polygon.Empty.IsEmpty);
+        Assert.False(new Polygon(Square(1)).IsEmpty);
+    }
+
+    [Fact]
+    public void GetBounds_matches_the_shell_bounds()
+    {
+        var polygon = new Polygon(Square(10));
+
+        Assert.Equal(polygon.Shell.GetBounds(), polygon.GetBounds());
+    }
+
+    [Fact]
+    public void GetArea_is_positive_for_a_real_polygon()
+    {
+        var polygon = new Polygon(Square(1));
+
+        Assert.True(polygon.GetArea().SiValue > 0);
+    }
+
+    [Fact]
+    public void A_hole_reduces_the_polygon_area()
+    {
+        var withoutHole = new Polygon(Square(10));
+        var withHole = new Polygon(Square(10), Square(5));
+
+        Assert.True(withHole.GetArea().SiValue < withoutHole.GetArea().SiValue);
+    }
+
+    [Fact]
+    public void Empty_polygons_are_equal()
+    {
+        Assert.True(new Polygon().Equals(Polygon.Empty));
+    }
+
+    [Fact]
+    public void Equality_compares_shell_and_holes()
+    {
+        var a = new Polygon(Square(10));
+        var b = new Polygon(Square(10));
+        var c = new Polygon(Square(10), Square(5));
+
+        Assert.True(a == b);
+        Assert.True(a != c);
+    }
+
+    [Fact]
+    public void Triangle_is_built_from_three_corners()
+    {
+        var triangle = new Triangle(
+            new Coordinate(0, 0),
+            new Coordinate(1, 0),
+            new Coordinate(0, 1)
+        );
+
+        Assert.False(triangle.IsEmpty);
+        Assert.True(triangle.GetArea().SiValue > 0);
+        Assert.Equal(4, triangle.Shell.Coordinates.Count);
+    }
+
+    [Fact]
+    public void Empty_triangle_is_empty()
+    {
+        Assert.True(new Triangle().IsEmpty);
+        Assert.True(Triangle.Empty.IsEmpty);
+    }
+}

--- a/Geo.Tests/LineSegmentTests.cs
+++ b/Geo.Tests/LineSegmentTests.cs
@@ -1,0 +1,47 @@
+using System;
+using Xunit;
+
+namespace Geo.Tests;
+
+public class LineSegmentTests
+{
+    [Fact]
+    public void Constructor_exposes_both_coordinates()
+    {
+        var c1 = new Coordinate(0, 0);
+        var c2 = new Coordinate(1, 1);
+
+        var segment = new LineSegment(c1, c2);
+
+        Assert.Same(c1, segment.Coordinate1);
+        Assert.Same(c2, segment.Coordinate2);
+    }
+
+    [Fact]
+    public void Null_coordinates_throw()
+    {
+        Assert.Throws<ArgumentNullException>(() => new LineSegment(null, new Coordinate(0, 0)));
+        Assert.Throws<ArgumentNullException>(() => new LineSegment(new Coordinate(0, 0), null));
+    }
+
+    [Fact]
+    public void GetBounds_spans_both_endpoints()
+    {
+        var segment = new LineSegment(new Coordinate(2, -3), new Coordinate(-4, 5));
+
+        Assert.Equal(new Envelope(-4, -3, 2, 5), segment.GetBounds());
+    }
+
+    [Fact]
+    public void Equality_compares_both_endpoints()
+    {
+        var a = new LineSegment(new Coordinate(0, 0), new Coordinate(1, 1));
+        var b = new LineSegment(new Coordinate(0, 0), new Coordinate(1, 1));
+        var reversed = new LineSegment(new Coordinate(1, 1), new Coordinate(0, 0));
+
+        Assert.True(a == b);
+        Assert.True(a != reversed);
+        Assert.True(a.Equals(b));
+        Assert.False(a.Equals(reversed));
+    }
+}

--- a/Geo.Tests/Linq/EnumerableExtensionsTests.cs
+++ b/Geo.Tests/Linq/EnumerableExtensionsTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Linq;
+using Geo.Linq;
+using Geo.Measure;
+using Xunit;
+
+namespace Geo.Tests.Linq;
+
+public class EnumerableExtensionsTests
+{
+    [Fact]
+    public void Distinct2D_collapses_coordinates_that_match_horizontally()
+    {
+        // Two coordinates at the same location but different elevations collapse
+        // to one when compared in 2D.
+        var coordinates = new List<Coordinate>
+        {
+            new CoordinateZ(0, 0, 100),
+            new CoordinateZ(0, 0, 200),
+            new CoordinateZ(1, 1, 0),
+        };
+
+        var distinct = coordinates.Distinct2D().ToList();
+
+        Assert.Equal(2, distinct.Count);
+    }
+
+    [Fact]
+    public void Distinct3D_keeps_coordinates_that_differ_in_elevation()
+    {
+        var coordinates = new List<Coordinate>
+        {
+            new CoordinateZ(0, 0, 100),
+            new CoordinateZ(0, 0, 200),
+            new CoordinateZ(0, 0, 100),
+        };
+
+        var distinct = coordinates.Distinct3D().ToList();
+
+        Assert.Equal(2, distinct.Count);
+    }
+
+    [Fact]
+    public void Sum_adds_distances_by_si_value()
+    {
+        var distances = new[] { new Distance(100), new Distance(250) };
+
+        Assert.Equal(350, distances.Sum(x => x).SiValue);
+    }
+
+    [Fact]
+    public void Sum_adds_areas_by_si_value()
+    {
+        var areas = new[] { new Area(100), new Area(250) };
+
+        Assert.Equal(350, areas.Sum(x => x).SiValue);
+    }
+
+    [Fact]
+    public void Max_and_Min_select_by_si_value()
+    {
+        var distances = new[] { new Distance(100), new Distance(250), new Distance(50) };
+
+        Assert.Equal(250, distances.Max(x => x).SiValue);
+        Assert.Equal(50, distances.Min(x => x).SiValue);
+    }
+
+    [Fact]
+    public void Max_and_Min_work_for_areas()
+    {
+        var areas = new[] { new Area(100), new Area(250), new Area(50) };
+
+        Assert.Equal(250, areas.Max(x => x).SiValue);
+        Assert.Equal(50, areas.Min(x => x).SiValue);
+    }
+}

--- a/Geo.Tests/Measure/AreaTests.cs
+++ b/Geo.Tests/Measure/AreaTests.cs
@@ -1,0 +1,82 @@
+using Geo.Measure;
+using Xunit;
+
+namespace Geo.Tests.Measure;
+
+public class AreaTests
+{
+    [Fact]
+    public void Metres_constructor_stores_si_value()
+    {
+        var area = new Area(2500);
+
+        Assert.Equal(2500, area.SiValue);
+    }
+
+    [Fact]
+    public void Addition_and_subtraction_operate_on_si_values()
+    {
+        Assert.Equal(300, (new Area(100) + new Area(200)).SiValue);
+        Assert.Equal(150, (new Area(200) - new Area(50)).SiValue);
+    }
+
+    [Fact]
+    public void Comparison_operators_reflect_magnitude()
+    {
+        var small = new Area(100);
+        var large = new Area(400);
+
+        Assert.True(large > small);
+        Assert.True(small < large);
+        Assert.True(large >= new Area(400));
+        Assert.True(small <= new Area(100));
+        Assert.Equal(1, large.CompareTo(small));
+        Assert.Equal(0, large.CompareTo(new Area(400)));
+    }
+
+    [Fact]
+    public void Equality_is_based_on_si_value()
+    {
+        Assert.True(new Area(100) == new Area(100));
+        Assert.True(new Area(100) != new Area(200));
+        Assert.True(new Area(100).Equals(new Area(100)));
+        Assert.Equal(new Area(100).GetHashCode(), new Area(100).GetHashCode());
+    }
+
+    [Fact]
+    public void Boxed_equality_compares_two_areas()
+    {
+        // Regression: Area.Equals(object) previously tested for Distance, so equal
+        // areas compared as objects were reported unequal.
+        object boxed = new Area(100);
+
+        Assert.True(new Area(100).Equals(boxed));
+        Assert.False(new Area(100).Equals((object)new Area(200)));
+        Assert.False(new Area(100).Equals((object)new Distance(100)));
+    }
+
+    [Theory]
+    [InlineData(1_000_000, AreaUnit.Km, 1)]
+    [InlineData(1, AreaUnit.M, 1)]
+    public void Area_unit_extension_converts_from_square_metres(
+        double squareMetres,
+        AreaUnit unit,
+        double expected
+    )
+    {
+        Assert.Equal(expected, squareMetres.ConvertTo(unit), 1e-9);
+    }
+
+    [Fact]
+    public void Area_unit_extension_round_trips()
+    {
+        Assert.Equal(1_000_000, 1d.ConvertFrom(AreaUnit.Km).To(AreaUnit.M), 1e-6);
+    }
+
+    [Fact]
+    public void Area_unit_conversion_factor_is_the_square_of_the_linear_factor()
+    {
+        Assert.Equal(1000d * 1000d, AreaUnit.Km.GetConversionFactor());
+        Assert.Equal(1852d * 1852d, AreaUnit.Nm.GetConversionFactor());
+    }
+}

--- a/Geo.Tests/Measure/DistanceTests.cs
+++ b/Geo.Tests/Measure/DistanceTests.cs
@@ -1,0 +1,130 @@
+using Geo.Measure;
+using Xunit;
+
+namespace Geo.Tests.Measure;
+
+public class DistanceTests
+{
+    [Fact]
+    public void Metres_constructor_stores_si_value()
+    {
+        var distance = new Distance(1234.5);
+
+        Assert.Equal(1234.5, distance.SiValue);
+        Assert.Equal(DistanceUnit.M, distance.Unit);
+        Assert.Equal(1234.5, distance.Value);
+    }
+
+    [Theory]
+    [InlineData(1, DistanceUnit.M, 1)]
+    [InlineData(1, DistanceUnit.Km, 1000)]
+    [InlineData(1, DistanceUnit.Nm, 1852)]
+    [InlineData(1, DistanceUnit.Mile, 1609.34)]
+    [InlineData(1, DistanceUnit.Ft, 0.3048)]
+    public void Unit_constructor_converts_to_si_metres(
+        double value,
+        DistanceUnit unit,
+        double expectedSiValue
+    )
+    {
+        var distance = new Distance(value, unit);
+
+        Assert.Equal(expectedSiValue, distance.SiValue, 1e-9);
+        Assert.Equal(unit, distance.Unit);
+        Assert.Equal(value, distance.Value, 1e-9);
+    }
+
+    [Theory]
+    [InlineData(1000, DistanceUnit.Km, 1)]
+    [InlineData(1852, DistanceUnit.Nm, 1)]
+    [InlineData(1609.34, DistanceUnit.Mile, 1)]
+    [InlineData(0.3048, DistanceUnit.Ft, 1)]
+    public void ConvertTo_expresses_the_value_in_the_requested_unit(
+        double metres,
+        DistanceUnit unit,
+        double expectedValue
+    )
+    {
+        var converted = new Distance(metres).ConvertTo(unit);
+
+        Assert.Equal(expectedValue, converted.Value, 1e-9);
+        Assert.Equal(metres, converted.SiValue, 1e-9);
+        Assert.Equal(unit, converted.Unit);
+    }
+
+    [Fact]
+    public void ConvertTo_round_trips_back_to_metres()
+    {
+        var original = new Distance(5000);
+
+        var roundTripped = original.ConvertTo(DistanceUnit.Mile).ConvertTo(DistanceUnit.M);
+
+        Assert.Equal(original.SiValue, roundTripped.SiValue, 1e-6);
+    }
+
+    [Fact]
+    public void GetConversionFactor_returns_the_units_metre_factor()
+    {
+        Assert.Equal(1, DistanceUnit.M.GetConversionFactor());
+        Assert.Equal(1000, DistanceUnit.Km.GetConversionFactor());
+        Assert.Equal(1852, DistanceUnit.Nm.GetConversionFactor());
+    }
+
+    [Fact]
+    public void Double_extension_methods_convert_both_directions()
+    {
+        Assert.Equal(1, 1000d.ConvertTo(DistanceUnit.Km), 1e-9);
+        Assert.Equal(1000, 1d.ConvertFrom(DistanceUnit.Km).To(DistanceUnit.M), 1e-9);
+    }
+
+    [Fact]
+    public void Addition_and_subtraction_operate_on_si_values()
+    {
+        Assert.Equal(150, (new Distance(100) + new Distance(50)).SiValue);
+        Assert.Equal(70, (new Distance(100) - new Distance(30)).SiValue);
+    }
+
+    [Fact]
+    public void Multiplying_two_distances_produces_an_area()
+    {
+        Area area = new Distance(10) * new Distance(20);
+
+        Assert.Equal(200, area.SiValue);
+    }
+
+    [Fact]
+    public void Comparison_operators_reflect_magnitude()
+    {
+        var small = new Distance(50);
+        var large = new Distance(100);
+
+        Assert.True(large > small);
+        Assert.True(small < large);
+        Assert.True(large >= new Distance(100));
+        Assert.True(small <= new Distance(50));
+        Assert.Equal(1, large.CompareTo(small));
+        Assert.Equal(-1, small.CompareTo(large));
+        Assert.Equal(0, large.CompareTo(new Distance(100)));
+    }
+
+    [Fact]
+    public void Equality_is_based_on_si_value()
+    {
+        Assert.True(new Distance(100) == new Distance(100));
+        Assert.True(new Distance(100) != new Distance(200));
+        Assert.True(new Distance(100).Equals(new Distance(100)));
+        Assert.True(new Distance(100).Equals((object)new Distance(100)));
+        Assert.False(new Distance(100).Equals((object)"not a distance"));
+        Assert.Equal(new Distance(100).GetHashCode(), new Distance(100).GetHashCode());
+    }
+
+    [Fact]
+    public void Explicit_conversion_from_numeric_types_yields_metres()
+    {
+        Assert.Equal(5, ((Distance)5).SiValue);
+        Assert.Equal(5, ((Distance)5L).SiValue);
+        Assert.Equal(5.5, ((Distance)5.5d).SiValue);
+        Assert.Equal(5, ((Distance)5f).SiValue);
+        Assert.Equal(5, ((Distance)5m).SiValue);
+    }
+}

--- a/Geo.Tests/Measure/SpeedTests.cs
+++ b/Geo.Tests/Measure/SpeedTests.cs
@@ -1,0 +1,86 @@
+using System;
+using Geo.Measure;
+using Xunit;
+
+namespace Geo.Tests.Measure;
+
+public class SpeedTests
+{
+    [Fact]
+    public void Metres_per_second_constructor_stores_si_value()
+    {
+        var speed = new Speed(12.5);
+
+        Assert.Equal(12.5, speed.SiValue);
+        Assert.Equal(SpeedUnit.Ms, speed.Unit);
+    }
+
+    [Theory]
+    [InlineData(1, SpeedUnit.Ms, 1)]
+    [InlineData(1, SpeedUnit.Knots, 0.514444444)]
+    [InlineData(1, SpeedUnit.Kph, 0.277778)]
+    [InlineData(1, SpeedUnit.Mph, 0.44704)]
+    public void Unit_constructor_converts_to_si_metres_per_second(
+        double value,
+        SpeedUnit unit,
+        double expectedSiValue
+    )
+    {
+        var speed = new Speed(value, unit);
+
+        Assert.Equal(expectedSiValue, speed.SiValue, 1e-9);
+        Assert.Equal(value, speed.Value, 1e-6);
+    }
+
+    [Fact]
+    public void Distance_over_time_constructor_divides_metres_by_seconds()
+    {
+        var speed = new Speed(100, TimeSpan.FromSeconds(10));
+
+        Assert.Equal(10, speed.SiValue);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    public void Zero_distance_yields_zero_speed(double metres)
+    {
+        var speed = new Speed(metres, TimeSpan.FromSeconds(10));
+
+        Assert.Equal(0, speed.SiValue);
+    }
+
+    [Fact]
+    public void Zero_timespan_yields_zero_speed_instead_of_dividing_by_zero()
+    {
+        var speed = new Speed(100, TimeSpan.Zero);
+
+        Assert.Equal(0, speed.SiValue);
+    }
+
+    [Fact]
+    public void ConvertTo_expresses_value_in_requested_unit()
+    {
+        var converted = new Speed(1).ConvertTo(SpeedUnit.Kph);
+
+        // 1 m/s is roughly 3.6 km/h.
+        Assert.Equal(3.6, converted.Value, 1e-2);
+    }
+
+    [Fact]
+    public void Addition_and_subtraction_operate_on_si_values()
+    {
+        Assert.Equal(30, (new Speed(10) + new Speed(20)).SiValue);
+        Assert.Equal(5, (new Speed(20) - new Speed(15)).SiValue);
+    }
+
+    [Fact]
+    public void Comparison_and_equality()
+    {
+        Assert.True(new Speed(20) > new Speed(10));
+        Assert.True(new Speed(10) < new Speed(20));
+        Assert.True(new Speed(10) == new Speed(10));
+        Assert.True(new Speed(10) != new Speed(20));
+        Assert.True(new Speed(10).Equals((object)new Speed(10)));
+        Assert.Equal(0, new Speed(10).CompareTo(new Speed(10)));
+    }
+}

--- a/Geo/Measure/Area.cs
+++ b/Geo/Measure/Area.cs
@@ -56,7 +56,7 @@ public struct Area : IMeasure, IEquatable<Area>, IComparable<Area>
     {
         if (ReferenceEquals(null, obj))
             return false;
-        return obj is Distance && Equals((Distance)obj);
+        return obj is Area && Equals((Area)obj);
     }
 
     public override int GetHashCode()


### PR DESCRIPTION
Fill in several previously untested areas of the library:

- Measure: Distance/Area/Speed construction, unit conversions, operators,
  comparison and equality (including AreaUnit/DistanceUnit extensions).
- Geometries: Point, LineString/LinearRing, Polygon/Triangle, the multi
  geometries and GeometryCollection - emptiness, bounds, area/length,
  equality and dimensionality. Circle gains GetArea/GetLength/ToPolygon
  and equality coverage.
- Core types: Envelope (Combine/Intersects/Contains/equality),
  CoordinateSequence, LineSegment, and the coordinate variants plus
  Coordinate.Parse/TryParse error handling.
- Linq: Distinct2D/3D and the Distance/Area Sum/Min/Max aggregates.

Also fix Area.Equals(object), which compared against Distance instead of
Area, so two equal boxed areas were reported unequal.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J9CZ2EDn77rYWnjyrSN82c