### PR TITLE
Fix Coordinate.TryParse throwing on out-of-range ordinates

### DIFF
--- a/Geo.Tests/CoordinateTests.cs
+++ b/Geo.Tests/CoordinateTests.cs
@@ -171,6 +171,27 @@ public class CoordinateTests
     }
 
     [Theory]
+    [InlineData("91, 0")]
+    [InlineData("-91, 0")]
+    [InlineData("0, 181")]
+    [InlineData("0, -181")]
+    public void TryParse_returns_false_for_out_of_range_ordinates(string coordinate)
+    {
+        var success = Coordinate.TryParse(coordinate, out var result);
+
+        Assert.False(success);
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("91, 0")]
+    [InlineData("0, 181")]
+    public void TryParse_string_overload_returns_null_for_out_of_range_ordinates(string coordinate)
+    {
+        Assert.Null(Coordinate.TryParse(coordinate));
+    }
+
+    [Theory]
     [InlineData(91, 0)]
     [InlineData(-91, 0)]
     [InlineData(0, 181)]

--- a/Geo/Coordinate.cs
+++ b/Geo/Coordinate.cs
@@ -119,7 +119,7 @@ public class Coordinate : SpatialObject, IPosition
             var dir1 = Regex.IsMatch(match.Groups["Dir1"].Value, "[Ss]") ? -1d : 1d;
             var dir2 = Regex.IsMatch(match.Groups["Dir2"].Value, "[Ww]") ? -1d : 1d;
 
-            if (deg1 is <= 90 and >= -90 || deg2 is <= 180 and >= -180)
+            if (deg1 is <= 90 and >= -90 && deg2 is <= 180 and >= -180)
             {
                 result = new Coordinate(deg1 * dir1, deg2 * dir2);
                 return true;


### PR DESCRIPTION
The range guard in TryParse used `||` instead of `&&`, so only one of
the two ordinates needed to be within its valid range for the code to
proceed to the Coordinate constructor. When the other ordinate was out
of range (e.g. "91, 0"), the constructor threw ArgumentOutOfRangeException,
breaking the contract that TryParse returns false rather than throwing.

Require both the latitude and longitude to be in range before
constructing, and add tests covering out-of-range TryParse inputs for
both overloads.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KxD3MbJBK5ApGbiM1VA8FZ