### PR TITLE
Cover GeodeticLine, JulianDate and the spatial comparers (+ fix JulianDate milliseconds)

### DIFF
--- a/Geo.Tests/Geodesy/GeodeticLineTests.cs
+++ b/Geo.Tests/Geodesy/GeodeticLineTests.cs
@@ -1,0 +1,105 @@
+using Geo.Geodesy;
+using Geo.Measure;
+using Xunit;
+
+namespace Geo.Tests.Geodesy;
+
+public class GeodeticLineTests
+{
+    private static GeodeticLine Line(
+        double bearing12 = 45,
+        double bearing21 = 225,
+        double distance = 1000,
+        double elevation = 0
+    )
+    {
+        var c1 = new CoordinateZ(10, 20, elevation);
+        var c2 = new CoordinateZ(30, 40, elevation);
+        return new GeodeticLine(c1, c2, distance, bearing12, bearing21);
+    }
+
+    [Fact]
+    public void Bearings_are_normalized_into_0_to_360()
+    {
+        var line = new GeodeticLine(new Coordinate(0, 0), new Coordinate(1, 1), 1000, 450, -10);
+
+        Assert.Equal(90, line.Bearing12);
+        Assert.Equal(350, line.Bearing21);
+    }
+
+    [Fact]
+    public void Full_turn_bearing_normalizes_to_zero()
+    {
+        var line = new GeodeticLine(new Coordinate(0, 0), new Coordinate(1, 1), 1000, 360, 720);
+
+        Assert.Equal(0, line.Bearing12);
+        Assert.Equal(0, line.Bearing21);
+    }
+
+    [Fact]
+    public void Stores_coordinates_and_distance()
+    {
+        var c1 = new Coordinate(10, 20);
+        var c2 = new Coordinate(30, 40);
+        var line = new GeodeticLine(c1, c2, 1234.5, 45, 225);
+
+        Assert.Equal(c1, line.Coordinate1);
+        Assert.Equal(c2, line.Coordinate2);
+        Assert.Equal(1234.5, line.Distance.SiValue);
+    }
+
+    [Fact]
+    public void Equal_lines_are_equal_and_share_a_hashcode()
+    {
+        var a = Line();
+        var b = Line();
+
+        Assert.True(a.Equals(b));
+        Assert.True(a == b);
+        Assert.False(a != b);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Theory]
+    [InlineData(90, 225, 1000)] // different forward bearing
+    [InlineData(45, 200, 1000)] // different reverse bearing
+    [InlineData(45, 225, 2000)] // different distance
+    public void Differs_when_a_component_differs(
+        double bearing12,
+        double bearing21,
+        double distance
+    )
+    {
+        var reference = Line();
+        var other = Line(bearing12, bearing21, distance);
+
+        Assert.False(reference.Equals(other));
+        Assert.True(reference != other);
+    }
+
+    [Fact]
+    public void Equality_operators_handle_null()
+    {
+        GeodeticLine line = Line();
+
+        Assert.True((GeodeticLine)null == (GeodeticLine)null);
+        Assert.False(line == null);
+        Assert.False(null == line);
+        Assert.True(line != null);
+    }
+
+    [Fact]
+    public void Spatial_equality_can_ignore_elevation()
+    {
+        var seaLevel = Line(elevation: 0);
+        var elevated = Line(elevation: 500);
+
+        // Default comparison uses elevation, so the lines differ.
+        Assert.False(seaLevel.Equals(elevated));
+
+        // A 2D comparison ignores elevation, so they match.
+        Assert.True(seaLevel.Equals(elevated, new SpatialEqualityOptions().To2D()));
+        // A 3D comparison keeps elevation, so they still differ.
+        Assert.False(seaLevel.Equals(elevated, new SpatialEqualityOptions().To3D()));
+    }
+}

--- a/Geo.Tests/Geomagnetism/JulianDateTests.cs
+++ b/Geo.Tests/Geomagnetism/JulianDateTests.cs
@@ -63,11 +63,23 @@ public class JulianDateTests
     }
 
     [Fact]
+    public void JD_accounts_for_milliseconds()
+    {
+        var baseline = JulianDate.JD(2000, 1, 1, 12, 0, 0, 0);
+        var withMillis = JulianDate.JD(2000, 1, 1, 12, 0, 0, 500);
+
+        // 500 ms is half a second, i.e. 0.5 / 86400 of a day. (Subtracting two
+        // large Julian Dates limits the usable precision, but this still separates
+        // the correct ~5.8e-6 from the old millisecond*1000 bug's ~5.8.)
+        Assert.Equal(0.5 / 86400.0, withMillis - baseline, 8);
+    }
+
+    [Fact]
     public void JD_datetime_overload_matches_the_component_overload()
     {
-        var date = new DateTime(2012, 6, 15, 6, 30, 0, DateTimeKind.Utc);
+        var date = new DateTime(2012, 6, 15, 6, 30, 15, 250, DateTimeKind.Utc);
         var viaDateTime = JulianDate.JD(date);
-        var viaComponents = JulianDate.JD(2012, 6, 15, 6, 30, 0, 0);
+        var viaComponents = JulianDate.JD(2012, 6, 15, 6, 30, 15, 250);
 
         Assert.Equal(viaComponents, viaDateTime, 9);
     }

--- a/Geo.Tests/Geomagnetism/JulianDateTests.cs
+++ b/Geo.Tests/Geomagnetism/JulianDateTests.cs
@@ -1,0 +1,74 @@
+using System;
+using Geo.Geomagnetism;
+using Xunit;
+
+namespace Geo.Tests.Geomagnetism;
+
+public class JulianDateTests
+{
+    [Theory]
+    [InlineData(1500, 6, 1, true)] // well before the reform: Julian
+    [InlineData(1581, 12, 31, true)] // year before 1582: Julian
+    [InlineData(1582, 9, 30, true)] // 1582 before October: Julian
+    [InlineData(1582, 10, 4, true)] // last Julian day
+    [InlineData(1582, 10, 15, false)] // first Gregorian day
+    [InlineData(1582, 11, 1, false)] // 1582 after October: Gregorian
+    [InlineData(1583, 1, 1, false)] // year after 1582: Gregorian
+    [InlineData(2000, 1, 1, false)] // modern: Gregorian
+    public void IsJulianDate_classifies_dates_around_the_1582_reform(
+        int year,
+        int month,
+        int day,
+        bool expected
+    )
+    {
+        Assert.Equal(expected, JulianDate.IsJulianDate(year, month, day));
+    }
+
+    [Theory]
+    [InlineData(1582, 10, 5)]
+    [InlineData(1582, 10, 10)]
+    [InlineData(1582, 10, 14)]
+    public void IsJulianDate_throws_for_the_nonexistent_reform_gap(int year, int month, int day)
+    {
+        Assert.Throws<NotSupportedException>(() => JulianDate.IsJulianDate(year, month, day));
+    }
+
+    [Fact]
+    public void JD_matches_the_J2000_epoch()
+    {
+        // 2000-01-01 12:00:00 UT is the canonical Julian Date 2451545.0.
+        Assert.Equal(2451545.0, JulianDate.JD(2000, 1, 1, 12, 0, 0, 0), 6);
+    }
+
+    [Fact]
+    public void JD_advances_by_one_per_day()
+    {
+        var day1 = JulianDate.JD(2000, 1, 1, 12, 0, 0, 0);
+        var day2 = JulianDate.JD(2000, 1, 2, 12, 0, 0, 0);
+
+        Assert.Equal(1.0, day2 - day1, 6);
+    }
+
+    [Fact]
+    public void JD_is_continuous_across_the_1582_reform()
+    {
+        // The last Julian day and the first Gregorian day are consecutive.
+        var lastJulian = JulianDate.JD(1582, 10, 4, 0, 0, 0, 0);
+        var firstGregorian = JulianDate.JD(1582, 10, 15, 0, 0, 0, 0);
+
+        Assert.Equal(2299159.5, lastJulian, 6);
+        Assert.Equal(2299160.5, firstGregorian, 6);
+        Assert.Equal(1.0, firstGregorian - lastJulian, 6);
+    }
+
+    [Fact]
+    public void JD_datetime_overload_matches_the_component_overload()
+    {
+        var date = new DateTime(2012, 6, 15, 6, 30, 0, DateTimeKind.Utc);
+        var viaDateTime = JulianDate.JD(date);
+        var viaComponents = JulianDate.JD(2012, 6, 15, 6, 30, 0, 0);
+
+        Assert.Equal(viaComponents, viaDateTime, 9);
+    }
+}

--- a/Geo.Tests/Linq/Spatial2DComparerTests.cs
+++ b/Geo.Tests/Linq/Spatial2DComparerTests.cs
@@ -1,0 +1,29 @@
+using Geo.Geometries;
+using Geo.Linq;
+using Xunit;
+
+namespace Geo.Tests.Linq;
+
+public class Spatial2DComparerTests
+{
+    private static readonly Spatial2DComparer<Point> Comparer = new();
+
+    [Fact]
+    public void Equal_horizontal_position_ignores_elevation()
+    {
+        var a = new Point(1, 2, 100);
+        var b = new Point(1, 2, 200);
+
+        Assert.True(Comparer.Equals(a, b));
+        Assert.Equal(Comparer.GetHashCode(a), Comparer.GetHashCode(b));
+    }
+
+    [Fact]
+    public void Different_horizontal_position_is_not_equal()
+    {
+        var a = new Point(1, 2, 100);
+        var b = new Point(3, 4, 100);
+
+        Assert.False(Comparer.Equals(a, b));
+    }
+}

--- a/Geo.Tests/Linq/Spatial3DComparerTests.cs
+++ b/Geo.Tests/Linq/Spatial3DComparerTests.cs
@@ -1,0 +1,38 @@
+using Geo.Geometries;
+using Geo.Linq;
+using Xunit;
+
+namespace Geo.Tests.Linq;
+
+public class Spatial3DComparerTests
+{
+    private static readonly Spatial3DComparer<Point> Comparer = new();
+
+    [Fact]
+    public void Same_position_and_elevation_are_equal()
+    {
+        var a = new Point(1, 2, 100);
+        var b = new Point(1, 2, 100);
+
+        Assert.True(Comparer.Equals(a, b));
+        Assert.Equal(Comparer.GetHashCode(a), Comparer.GetHashCode(b));
+    }
+
+    [Fact]
+    public void Different_elevation_is_not_equal()
+    {
+        var a = new Point(1, 2, 100);
+        var b = new Point(1, 2, 200);
+
+        Assert.False(Comparer.Equals(a, b));
+    }
+
+    [Fact]
+    public void Different_horizontal_position_is_not_equal()
+    {
+        var a = new Point(1, 2, 100);
+        var b = new Point(3, 4, 100);
+
+        Assert.False(Comparer.Equals(a, b));
+    }
+}

--- a/Geo/Geo.csproj
+++ b/Geo/Geo.csproj
@@ -31,6 +31,9 @@
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Geo.Tests" />
+  </ItemGroup>
   <Target Name="Husky" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(HUSKY)' != 0">
     <Exec
       Command="dotnet tool restore"

--- a/Geo/Geomagnetism/JulianDate.cs
+++ b/Geo/Geomagnetism/JulianDate.cs
@@ -47,7 +47,7 @@ internal class JulianDate
 
         var m = month > 2 ? month : month + 12;
         var y = month > 2 ? year : year - 1;
-        var d = day + hour / 24.0 + minute / 1440.0 + (second + millisecond * 1000) / 86400.0;
+        var d = day + hour / 24.0 + minute / 1440.0 + (second + millisecond / 1000.0) / 86400.0;
         var b = isJulianDate ? 0 : 2 - y / 100 + y / 100 / 4;
 
         return (int)(365.25 * (y + 4716)) + (int)(30.6001 * (m + 1)) + d + b - 1524.5;


### PR DESCRIPTION
## Summary

Adds direct unit-test coverage for four library types that previously had none, and fixes a latent bug uncovered while writing the `JulianDate` tests.

### Tests
- **`GeodeticLine`** — bearing normalization into `[0,360)`, full-turn → 0, coordinate/distance storage, value equality (`Equals`/`==`/`!=`/`GetHashCode`), per-component inequality, null-operator handling, and the `SpatialEqualityOptions` overload (2D ignores elevation, 3D keeps it).
- **`Spatial2DComparer` / `Spatial3DComparer`** — the 2D comparer ignores elevation (and hashes equal), the 3D comparer distinguishes it; both distinguish horizontal position.
- **`JulianDate`** — Julian/Gregorian classification around the 1582 reform, the non-existent-gap `NotSupportedException`, the J2000 epoch value (2451545.0), one-day continuity, continuity across the reform boundary (Oct 4 Julian → Oct 15 Gregorian are consecutive JDNs), and millisecond handling.

### Fix
- **`JulianDate.DateToJD`** computed `(second + millisecond * 1000) / 86400`, scaling milliseconds *up* by 1000 instead of converting them to seconds. Corrected to `millisecond / 1000.0`. The error was latent because sub-second precision is immaterial to geomagnetic field synthesis (its only caller); the geomagnetism tests continue to pass.

### Enabler
- Added `<InternalsVisibleTo Include="Geo.Tests" />` to `Geo/Geo.csproj` so the `internal` `JulianDate` helper can be tested directly. Assembly metadata only — no runtime behavior change.

## Testing
- `dotnet csharpier check .` — clean
- `dotnet test` — 336 passed, 1 pre-existing skip, 0 failed
- CI green on the branch head (`e9a922a`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHRKnGtGKr3d6ZxrWWc8EB)_