### PR TITLE
Add argument-validation coverage and fix truncated-WKB handling

### DIFF
--- a/Geo.Tests/CoordinateTests.cs
+++ b/Geo.Tests/CoordinateTests.cs
@@ -248,6 +248,24 @@ public class CoordinateTests
         Assert.Throws<ArgumentOutOfRangeException>(() => new CoordinateM(1, 2, measure));
     }
 
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void CoordinateZM_rejects_non_finite_elevation(double elevation)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CoordinateZM(1, 2, elevation, 5));
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void CoordinateZM_rejects_non_finite_measure(double measure)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CoordinateZM(1, 2, 3, measure));
+    }
+
     [Fact]
     public void GetBounds_is_a_degenerate_envelope_at_the_coordinate()
     {

--- a/Geo.Tests/IO/GeoJson/GeoJsonTests.cs
+++ b/Geo.Tests/IO/GeoJson/GeoJsonTests.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 using Geo.Geometries;
 using Geo.IO.GeoJson;
 using Xunit;
@@ -15,6 +18,34 @@ public class GeoJsonTests
         var geo = new Point(0, 0);
         Assert.Equal(@"{""type"":""Point"",""coordinates"":[0,0]}", geo.ToGeoJson());
         Assert.Equal(geo, reader.Read(geo.ToGeoJson()));
+    }
+
+    [Fact]
+    public void Read_null_stream_throws_argument_null()
+    {
+        Assert.Throws<ArgumentNullException>(() => new GeoJsonReader().Read((Stream)null));
+    }
+
+    [Fact]
+    public void Read_invalid_json_throws_serialization()
+    {
+        Assert.Throws<SerializationException>(() => new GeoJsonReader().Read("not valid json"));
+    }
+
+    [Fact]
+    public void Read_json_without_a_recognised_type_throws_serialization()
+    {
+        Assert.Throws<SerializationException>(() =>
+            new GeoJsonReader().Read(@"{""type"":""Nonsense""}")
+        );
+    }
+
+    [Fact]
+    public void TryRead_returns_false_for_invalid_json()
+    {
+        object result;
+        Assert.False(new GeoJsonReader().TryRead("not valid json", out result));
+        Assert.Null(result);
     }
 
     [Fact]

--- a/Geo.Tests/IO/Wkb/WkbTests.cs
+++ b/Geo.Tests/IO/Wkb/WkbTests.cs
@@ -1,4 +1,6 @@
-﻿using Geo.IO.Wkb;
+﻿using System;
+using System.Runtime.Serialization;
+using Geo.IO.Wkb;
 using Geo.IO.Wkt;
 using Xunit;
 
@@ -60,6 +62,32 @@ public class WkbTests
         Test(
             "GEOMETRYCOLLECTION (LINESTRING ZM (45.89 23.9 0.45 34, 0 0 0.45 34), POLYGON ZM ((0 0 2 -1, 1 0 2 -1, 0 1 2 -1, 0 0 2 -1)))"
         );
+    }
+
+    [Fact]
+    public void Read_null_bytes_throws_argument_null()
+    {
+        Assert.Throws<ArgumentNullException>(() => new WkbReader().Read((byte[])null));
+    }
+
+    [Fact]
+    public void Read_null_stream_throws_argument_null()
+    {
+        Assert.Throws<ArgumentNullException>(() => new WkbReader().Read((System.IO.Stream)null));
+    }
+
+    [Fact]
+    public void Read_empty_bytes_returns_null()
+    {
+        Assert.Null(new WkbReader().Read(new byte[0]));
+    }
+
+    [Fact]
+    public void Read_unknown_geometry_type_throws_serialization()
+    {
+        // Little-endian byte order marker (0x01) followed by an unknown type code (99).
+        var bytes = new byte[] { 0x01, 99, 0, 0, 0 };
+        Assert.Throws<SerializationException>(() => new WkbReader().Read(bytes));
     }
 
     private void Test(string wkt)

--- a/Geo.Tests/IO/Wkb/WkbTests.cs
+++ b/Geo.Tests/IO/Wkb/WkbTests.cs
@@ -90,6 +90,14 @@ public class WkbTests
         Assert.Throws<SerializationException>(() => new WkbReader().Read(bytes));
     }
 
+    [Fact]
+    public void Read_truncated_geometry_throws_serialization()
+    {
+        // A little-endian Point (type 1) header with no coordinate data following.
+        var bytes = new byte[] { 0x01, 1, 0, 0, 0 };
+        Assert.Throws<SerializationException>(() => new WkbReader().Read(bytes));
+    }
+
     private void Test(string wkt)
     {
         var wktReader = new WktReader();

--- a/Geo/IO/Wkb/WkbBinaryReader.cs
+++ b/Geo/IO/Wkb/WkbBinaryReader.cs
@@ -35,6 +35,11 @@ internal class WkbBinaryReader : IDisposable
     public byte[] ReadBytes(int count)
     {
         var bytes = _reader.ReadBytes(count);
+        // BinaryReader.ReadBytes returns a short array at end of stream rather than
+        // throwing; surface that as EndOfStreamException so WkbReader can translate a
+        // truncated geometry into a SerializationException.
+        if (bytes.Length < count)
+            throw new EndOfStreamException();
         if (Encoding == WkbEncoding.BigEndian)
             Array.Reverse(bytes);
         return bytes;


### PR DESCRIPTION
## Summary

Adds argument-validation / error-path test coverage for coordinate types and the WKB/GeoJSON readers (these paths were previously exercised only on success), and fixes a latent robustness gap the tests exposed in the WKB reader.

### Tests
- **`CoordinateZM`** — rejects non-finite elevation and measure (`NaN` / ±`Infinity`), mirroring the existing `CoordinateZ`/`CoordinateM` checks.
- **`WkbReader`** — null bytes and null stream throw `ArgumentNullException`, empty input returns `null`, an unknown geometry type throws `SerializationException`, and truncated input throws `SerializationException`.
- **`GeoJsonReader`** — null stream throws `ArgumentNullException`, invalid JSON and JSON without a recognised `type` throw `SerializationException`, and `TryRead` returns `false` (with a null result) for invalid input.

### Fix
- **`WkbBinaryReader.ReadBytes`** now throws `EndOfStreamException` when the stream cannot supply the requested bytes. `WkbReader.Read` already catches `EndOfStreamException` and rethrows a `SerializationException`, but that handler was effectively dead: `BinaryReader.ReadBytes` returns a short array at end of stream instead of throwing, so truncated geometry previously surfaced as a low-level `ArgumentOutOfRangeException` from `BitConverter`. Truncated WKB is now reported as a `SerializationException` as intended. The length check only triggers at genuine end-of-stream, so valid reads (including all existing round-trip tests) are unaffected.

## Testing
- `dotnet csharpier check .` — clean
- `dotnet test` — 351 passed, 1 pre-existing skip, 0 failed
- CI green on the branch head (`6c34ed2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHRKnGtGKr3d6ZxrWWc8EB)_