### PR TITLE
Expand Coordinate equality/hash coverage and fix CoordinateM hash gating

### DIFF
--- a/Geo.Tests/CoordinateTests.cs
+++ b/Geo.Tests/CoordinateTests.cs
@@ -73,6 +73,106 @@ public class CoordinateTests
     }
 
     [Fact]
+    public void Equality_M_only_measure_toggle()
+    {
+        Assert.True(
+            new CoordinateM(0, 0, 0).Equals(
+                new CoordinateM(0, 0, 0),
+                new SpatialEqualityOptions { UseM = true }
+            )
+        );
+        Assert.False(
+            new CoordinateM(0, 0, 0).Equals(
+                new CoordinateM(0, 0, 10),
+                new SpatialEqualityOptions { UseM = true }
+            )
+        );
+        Assert.True(
+            new CoordinateM(0, 0, 0).Equals(
+                new CoordinateM(0, 0, 10),
+                new SpatialEqualityOptions { UseM = false }
+            )
+        );
+    }
+
+    [Fact]
+    public void Default_value_equality_holds_for_matching_coordinates()
+    {
+        var a = new Coordinate(1, 2);
+        var b = new Coordinate(1, 2);
+        var c = new Coordinate(3, 4);
+
+        Assert.True(a.Equals((object)b));
+        Assert.True(a == b);
+        Assert.False(a != b);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+
+        Assert.False(a == c);
+        Assert.True(a != c);
+    }
+
+    [Fact]
+    public void Equality_operators_handle_null()
+    {
+        var coordinate = new Coordinate(1, 2);
+
+        Assert.True((Coordinate)null == (Coordinate)null);
+        Assert.False(coordinate == null);
+        Assert.False(null == coordinate);
+        Assert.True(coordinate != null);
+    }
+
+    [Fact]
+    public void Coordinates_of_different_dimensions_are_not_equal()
+    {
+        var options = new SpatialEqualityOptions();
+        var flat = new Coordinate(1, 2);
+        var z = new CoordinateZ(1, 2, 0);
+        var m = new CoordinateM(1, 2, 0);
+        var zm = new CoordinateZM(1, 2, 0, 0);
+
+        Assert.False(flat.Equals(z, options));
+        Assert.False(z.Equals(flat, options));
+        Assert.False(z.Equals(m, options));
+        Assert.False(m.Equals(z, options));
+        Assert.False(zm.Equals(z, options));
+        Assert.False(zm.Equals(flat, options));
+    }
+
+    [Fact]
+    public void GetHashCode_matches_equality_across_options()
+    {
+        // Elevation excluded when UseElevation is false.
+        var without3D = new SpatialEqualityOptions { UseElevation = false };
+        Assert.True(new CoordinateZ(1, 2, 100).Equals(new CoordinateZ(1, 2, 200), without3D));
+        Assert.Equal(
+            new CoordinateZ(1, 2, 100).GetHashCode(without3D),
+            new CoordinateZ(1, 2, 200).GetHashCode(without3D)
+        );
+
+        // Measure excluded when UseM is false (measure must not be gated on UseElevation).
+        var withoutM = new SpatialEqualityOptions { UseM = false };
+        Assert.True(new CoordinateM(1, 2, 100).Equals(new CoordinateM(1, 2, 200), withoutM));
+        Assert.Equal(
+            new CoordinateM(1, 2, 100).GetHashCode(withoutM),
+            new CoordinateM(1, 2, 200).GetHashCode(withoutM)
+        );
+
+        // Pole longitudes collapse to a single hash bucket.
+        var options = new SpatialEqualityOptions();
+        Assert.Equal(
+            new Coordinate(90, 0).GetHashCode(options),
+            new Coordinate(90, 150).GetHashCode(options)
+        );
+
+        // The two anti-meridian longitudes hash together.
+        Assert.Equal(
+            new Coordinate(4, 180).GetHashCode(options),
+            new Coordinate(4, -180).GetHashCode(options)
+        );
+    }
+
+    [Fact]
     public void Equality_PoleCoordinates()
     {
         Assert.True(

--- a/Geo/CoordinateM.cs
+++ b/Geo/CoordinateM.cs
@@ -77,7 +77,7 @@ public class CoordinateM : Coordinate, IsMeasured
 
             var hashCode = latitude.GetHashCode();
             hashCode = (hashCode * 397) ^ longitude.GetHashCode();
-            if (options.UseElevation)
+            if (options.UseM)
                 hashCode = (hashCode * 397) ^ Measure.GetHashCode();
             return hashCode;
         }


### PR DESCRIPTION
## Summary

Fills out the `Coordinate` / `SpatialEqualityOptions` equality-and-hash matrix with direct tests, and fixes a hash-contract bug the matrix exposed in `CoordinateM`.

### Fix
- **`CoordinateM.GetHashCode`** included the measure in the hash based on `options.UseElevation` instead of `options.UseM`. A `CoordinateM` has no elevation, so with the default options (`UseElevation` true, `UseM` false) two coordinates that compare **equal** (measure ignored) produced **different** hash codes — violating the equality/hash contract and diverging from the correct `CoordinateZM` implementation. The measure is now gated on `UseM`, matching `Equals`.

### Tests
Added to `CoordinateTests`:
- `CoordinateM` measure toggle (symmetric to the existing `CoordinateZ` elevation test).
- Default value equality (`Equals`/`==`/`!=`/`GetHashCode`) and null-operator handling.
- Cross-dimension inequality between `Coordinate` / `CoordinateZ` / `CoordinateM` / `CoordinateZM`.
- `GetHashCode` agreement with equality across options — elevation, measure (this pins the fix above), and the pole / anti-meridian hash buckets.

## Testing
- `dotnet csharpier check .` — clean
- `dotnet test` — 356 passed, 1 pre-existing skip, 0 failed
- CI green on the branch head (`50ae908`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHRKnGtGKr3d6ZxrWWc8EB)_