### PR TITLE
test: cover GeoContext ambient state and longitude wrapping

### DIFF
--- a/Geo.Tests/AssemblyInfo.cs
+++ b/Geo.Tests/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using Xunit;
+
+// GeoContext.Current is a mutable, process-wide ambient singleton. Tests that swap
+// it (e.g. GeoContextTests toggling LongitudeWrapping) would otherwise race with any
+// other test that constructs a Coordinate on a parallel collection, so run the whole
+// assembly serially. The suite is small enough that the cost is negligible.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Geo.Tests/GeoContextTests.cs
+++ b/Geo.Tests/GeoContextTests.cs
@@ -1,0 +1,105 @@
+using System;
+using Geo;
+using Geo.Geodesy;
+using Xunit;
+
+namespace Geo.Tests;
+
+public class GeoContextTests : IDisposable
+{
+    // Snapshot the ambient context and restore it after every test so a swapped
+    // GeoContext.Current (or a toggled flag) never leaks into another test.
+    private readonly GeoContext _original = GeoContext.Current;
+
+    public void Dispose()
+    {
+        GeoContext.Current = _original;
+    }
+
+    [Fact]
+    public void A_new_context_has_sensible_defaults()
+    {
+        var context = new GeoContext();
+
+        Assert.Same(Spheroid.Default, context.Spheroid);
+        Assert.NotNull(context.GeodeticCalculator);
+        Assert.NotNull(context.GeomagnetismCalculator);
+        Assert.NotNull(context.EqualityOptions);
+        Assert.False(context.LongitudeWrapping);
+    }
+
+    [Fact]
+    public void Current_lazily_initialises_and_is_replaceable()
+    {
+        GeoContext.Current = null;
+        Assert.NotNull(GeoContext.Current);
+
+        var replacement = new GeoContext();
+        GeoContext.Current = replacement;
+        Assert.Same(replacement, GeoContext.Current);
+    }
+
+    [Fact]
+    public void Longitude_out_of_range_throws_when_wrapping_is_disabled()
+    {
+        GeoContext.Current = new GeoContext { LongitudeWrapping = false };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Coordinate(0, 200));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Coordinate(0, -200));
+    }
+
+    [Theory]
+    [InlineData(200, -160)]
+    [InlineData(-200, 160)]
+    [InlineData(360, 0)]
+    [InlineData(-360, 0)]
+    [InlineData(540, 180)]
+    [InlineData(-540, -180)]
+    [InlineData(181, -179)]
+    [InlineData(-181, 179)]
+    public void Longitude_is_wrapped_into_range_when_wrapping_is_enabled(
+        double longitude,
+        double expected
+    )
+    {
+        GeoContext.Current = new GeoContext { LongitudeWrapping = true };
+
+        var coordinate = new Coordinate(0, longitude);
+
+        Assert.Equal(expected, coordinate.Longitude);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(150)]
+    [InlineData(-150)]
+    [InlineData(180)]
+    [InlineData(-180)]
+    public void In_range_longitudes_are_untouched_by_wrapping(double longitude)
+    {
+        GeoContext.Current = new GeoContext { LongitudeWrapping = true };
+
+        var coordinate = new Coordinate(0, longitude);
+
+        Assert.Equal(longitude, coordinate.Longitude);
+    }
+
+    [Fact]
+    public void Wrapping_does_not_suppress_out_of_range_latitude()
+    {
+        GeoContext.Current = new GeoContext { LongitudeWrapping = true };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Coordinate(91, 200));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Coordinate(-91, 200));
+    }
+
+    [Fact]
+    public void Coordinate_construction_reads_the_current_context()
+    {
+        GeoContext.Current = new GeoContext { LongitudeWrapping = false };
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Coordinate(0, 200));
+
+        GeoContext.Current = new GeoContext { LongitudeWrapping = true };
+        Assert.Equal(-160, new Coordinate(0, 200).Longitude);
+    }
+}


### PR DESCRIPTION
## Summary

Adds test coverage for `GeoContext` — the process-wide ambient settings singleton — and the `Coordinate` longitude-wrapping behaviour it drives. Both were previously untested: the longitude-wrapping branch in the `Coordinate` constructor was never exercised, and `GeoContext.Current` / `LongitudeWrapping` had no direct tests.

## Changes

**`Geo.Tests/GeoContextTests.cs`** (new, 18 tests)
- Default context values (spheroid, geodetic/geomagnetism calculators, equality options, `LongitudeWrapping` off).
- `GeoContext.Current` lazy initialisation and replacement.
- Longitude out-of-range throws `ArgumentOutOfRangeException` when wrapping is disabled.
- Longitude wraps into `[-180, 180]` when enabled — theory covering `200→-160`, `-200→160`, `360→0`, `540→180`, `±181→∓179`, plus in-range and boundary (`180` / `-180`) values that must **not** wrap.
- Latitude range is still enforced while wrapping is enabled.
- `Coordinate` construction reads whichever context is current.

The tests use an `IDisposable` snapshot/restore so a swapped `GeoContext.Current` (or a toggled flag) never leaks between tests, even on assertion failure.

**`Geo.Tests/AssemblyInfo.cs`** (new)
- `[assembly: CollectionBehavior(DisableTestParallelization = true)]`. `GeoContext.Current` is a mutable, process-wide singleton, so a test toggling `LongitudeWrapping` would otherwise race with `Coordinate` construction on parallel test collections. The suite is small (~1s), so serialising it is a negligible cost that removes an entire class of shared-state flakiness.

## Validation

- `dotnet csharpier check .` — clean (232 files).
- `dotnet test` — **403 passed, 1 skipped (pre-existing), 0 failed** (up from 385).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5hYAMxJUcVtebHbjEK6Zx)_