### PR TITLE
test: harden and cover WKT/GeoJSON reader malformed-input paths

### DIFF
--- a/Geo.Tests/IO/GeoJson/GeoJsonTests.cs
+++ b/Geo.Tests/IO/GeoJson/GeoJsonTests.cs
@@ -49,6 +49,27 @@ public class GeoJsonTests
     }
 
     [Fact]
+    public void TryRead_returns_false_for_valid_json_that_is_not_geojson()
+    {
+        object result;
+        Assert.False(new GeoJsonReader().TryRead(@"{""foo"":1}", out result));
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData(@"{""type"":""Point""}")] // no coordinates member
+    [InlineData(@"{""type"":""Point"",""coordinates"":""nope""}")] // coordinates not an array
+    [InlineData(@"{""type"":""Point"",""coordinates"":[1]}")] // too few ordinates
+    [InlineData(@"{""type"":""GeometryCollection""}")] // no geometries member
+    [InlineData(@"{""type"":""FeatureCollection""}")] // no features member
+    [InlineData("[1,2,3]")] // a JSON array, not a GeoJSON object
+    [InlineData("null")] // JSON null
+    public void Read_malformed_geojson_throws_serialization(string json)
+    {
+        Assert.Throws<SerializationException>(() => new GeoJsonReader().Read(json));
+    }
+
+    [Fact]
     public void LineString()
     {
         var reader = new GeoJsonReader();

--- a/Geo.Tests/IO/Wkt/WktReaderTests.cs
+++ b/Geo.Tests/IO/Wkt/WktReaderTests.cs
@@ -43,6 +43,37 @@ public class WktReaderTests
     }
 
     [Fact]
+    public void Whitespace_only_input_returns_null()
+    {
+        var reader = new WktReader();
+
+        Assert.Null(reader.Read("   \t\r\n"));
+    }
+
+    [Theory]
+    [InlineData("POINT 1 2")] // missing opening parenthesis
+    [InlineData("POINT (1 $)")] // invalid character in the coordinate
+    [InlineData("LINESTRING (1 2,)")] // trailing comma with no coordinate
+    [InlineData("MULTIPOINT ((1 2)")] // token underflow: missing closing parenthesis
+    [InlineData("POLYGON (")] // truncated immediately after the opening parenthesis
+    public void Malformed_wkt_throws_serialization(string wkt)
+    {
+        var reader = new WktReader();
+
+        Assert.Throws<SerializationException>(() => reader.Read(wkt));
+    }
+
+    [Fact]
+    public void Truncated_geometry_throws_serialization()
+    {
+        var reader = new WktReader();
+
+        // Runs out of tokens before the closing parenthesis; must surface as a
+        // SerializationException rather than leaking an InvalidOperationException.
+        Assert.Throws<SerializationException>(() => reader.Read("POINT (1 2"));
+    }
+
+    [Fact]
     public void ExponentialNumber()
     {
         var reader = new WktReader();

--- a/Geo/IO/GeoJson/GeoJsonReader.cs
+++ b/Geo/IO/GeoJson/GeoJsonReader.cs
@@ -69,7 +69,7 @@ public class GeoJsonReader
             && typeString.ToLowerInvariant() == "featurecollection"
         )
         {
-            var features = obj["features"] as JsonArray;
+            var features = GetArray(obj, "features");
 
             if (features != null)
             {
@@ -122,6 +122,15 @@ public class GeoJsonReader
         return false;
     }
 
+    // JsonObject's indexer throws KeyNotFoundException for an absent key; use a safe
+    // lookup so a GeoJSON object missing "coordinates" / "geometries" / "features"
+    // fails the TryParse (and surfaces as a SerializationException) instead of leaking.
+    private static JsonArray GetArray(JsonObject obj, string key)
+    {
+        object value;
+        return obj.TryGetValue(key, out value) ? value as JsonArray : null;
+    }
+
     private bool TryParseGeometry(JsonObject obj, out object result)
     {
         result = null;
@@ -155,7 +164,7 @@ public class GeoJsonReader
     private bool TryParsePoint(JsonObject obj, out object result)
     {
         result = null;
-        var coordinates = obj["coordinates"] as JsonArray;
+        var coordinates = GetArray(obj, "coordinates");
         if (coordinates == null || coordinates.Count < 2)
             return false;
 
@@ -171,7 +180,7 @@ public class GeoJsonReader
 
     private bool TryParseLineString(JsonObject obj, out object result)
     {
-        var coordinates = obj["coordinates"] as JsonArray;
+        var coordinates = GetArray(obj, "coordinates");
         Coordinate[] co;
         if (coordinates != null && TryParseCoordinateArray(coordinates, out co))
         {
@@ -185,7 +194,7 @@ public class GeoJsonReader
 
     private bool TryParsePolygon(JsonObject obj, out object result)
     {
-        var coordinates = obj["coordinates"] as JsonArray;
+        var coordinates = GetArray(obj, "coordinates");
 
         Coordinate[][] temp;
         if (
@@ -207,7 +216,7 @@ public class GeoJsonReader
 
     private bool TryParseMultiPoint(JsonObject obj, out object result)
     {
-        var coordinates = obj["coordinates"] as JsonArray;
+        var coordinates = GetArray(obj, "coordinates");
         Coordinate[] co;
         if (coordinates != null && TryParseCoordinateArray(coordinates, out co))
         {
@@ -221,7 +230,7 @@ public class GeoJsonReader
 
     private bool TryParseMultiLineString(JsonObject obj, out object result)
     {
-        var coordinates = obj["coordinates"] as JsonArray;
+        var coordinates = GetArray(obj, "coordinates");
         Coordinate[][] co;
         if (coordinates != null && TryParseCoordinateArrayArray(coordinates, out co))
         {
@@ -235,7 +244,7 @@ public class GeoJsonReader
 
     private bool TryParseMultiPolygon(JsonObject obj, out object result)
     {
-        var coordinates = obj["coordinates"] as JsonArray;
+        var coordinates = GetArray(obj, "coordinates");
         Coordinate[][][] co;
         if (coordinates != null && TryParseCoordinateArrayArrayArray(coordinates, out co))
         {
@@ -255,7 +264,7 @@ public class GeoJsonReader
     private bool TryParseGeometryCollection(JsonObject obj, out object result)
     {
         result = null;
-        var geometries = obj["geometries"] as JsonArray;
+        var geometries = GetArray(obj, "geometries");
 
         if (geometries != null)
         {

--- a/Geo/IO/Wkt/WktReader.cs
+++ b/Geo/IO/Wkt/WktReader.cs
@@ -19,7 +19,7 @@ public class WktReader
             throw new ArgumentNullException("wkt");
 
         var tokens = new WktTokenQueue(_wktTokenizer.Tokenize(wkt));
-        return ParseGeometry(tokens);
+        return Parse(tokens);
     }
 
     public IGeometry Read(Stream stream)
@@ -30,7 +30,22 @@ public class WktReader
         using (var reader = new StreamReader(stream))
         {
             var tokens = new WktTokenQueue(_wktTokenizer.Tokenize(reader));
+            return Parse(tokens);
+        }
+    }
+
+    private IGeometry Parse(WktTokenQueue tokens)
+    {
+        try
+        {
             return ParseGeometry(tokens);
+        }
+        catch (InvalidOperationException)
+        {
+            // Running out of tokens (Queue.Dequeue / Enumerable.First on an empty
+            // sequence) means the WKT was truncated or otherwise malformed; surface it
+            // as a SerializationException like every other WKT parse failure.
+            throw new SerializationException("Invalid WKT string.");
         }
     }
 


### PR DESCRIPTION
## Summary

Improves robustness coverage for the serializer readers. WKB already rejects malformed input cleanly (null / empty / unknown type / truncation, across both byte orders), so this focuses on WKT and GeoJSON, where probing revealed two paths that leaked lower-level exceptions instead of the readers' intended `SerializationException`.

## Source hardening

- **`WktReader`** — a truncated geometry (running out of tokens, e.g. `POINT (1 2`) surfaced a raw `InvalidOperationException` from `Queue.Dequeue` / `Enumerable.First`. Parsing is now wrapped so it is translated to `SerializationException`, making *all* malformed WKT fail uniformly.
- **`GeoJsonReader`** — a geometry object missing its `coordinates` / `geometries` / `features` member (e.g. `{"type":"Point"}`) threw `KeyNotFoundException` from the `JsonObject` indexer. Those lookups now go through a safe `GetArray` helper, so the `TryParse` fails cleanly (`Read` → `SerializationException`, `TryRead` → `false`).

Both are pure robustness fixes with no change to valid-input behaviour.

## Tests

- **WKT** (7 new): whitespace-only input returns null; a theory of malformed inputs (missing parenthesis, invalid character, trailing comma, token underflow, truncation after `(`); and an explicit truncation → `SerializationException` regression test.
- **GeoJSON** (8 new): a theory of malformed inputs (missing / non-array `coordinates`, too-few ordinates, missing `geometries` / `features`, non-object JSON, JSON `null`); and `TryRead` returning `false` for valid JSON that is not GeoJSON.

## Validation

- `dotnet csharpier check .` — clean (233 files).
- `dotnet test` — **436 passed, 1 skipped (pre-existing), 0 failed** (up from 421).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5hYAMxJUcVtebHbjEK6Zx)_