### PR TITLE
Turn skipped Bug7 test into a real regression test

### DIFF
--- a/Geo.Tests/Geodesy/SpheroidCalculatorTests.cs
+++ b/Geo.Tests/Geodesy/SpheroidCalculatorTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Geo.Geodesy;
+﻿using Geo.Geodesy;
 using Geo.Geometries;
 using Geo.Measure;
 using Xunit;
@@ -107,18 +106,29 @@ public class SpheroidCalculatorTests
         Assert.Equal(lon2, result.Coordinate2.Longitude, Millionth);
     }
 
-    [Theory(Skip = "Need to re-visit")]
-    [InlineData(30, 175, -30, -3.5)]
-    [InlineData(30, 176, -30, -3.5)]
-    public void Bug7(double lat1, double lon1, double lat2, double lon2)
+    // Regression test for https://github.com/sibartlett/Geo/issues/7:
+    // near-antipodal points (lat1 == -lat2) used to make Vincenty's inverse
+    // routine fail to converge and throw an ArithmeticException.
+    [Theory]
+    [InlineData(30, 175, -30, -3.5, 10736.730329, 269.755739, 89.755739)]
+    [InlineData(30, 176, -30, -3.5, 10761.582116, 269.874999, 89.874999)]
+    public void CalculateOrthodromicLine_converges_for_near_antipodal_points(
+        double lat1,
+        double lon1,
+        double lat2,
+        double lon2,
+        double distance,
+        double bearing12,
+        double bearing21
+    )
     {
         var calculator = new SpheroidCalculator(Spheroid.Wgs84);
         var result = calculator.CalculateOrthodromicLine(
             new Point(lat1, lon1),
             new Point(lat2, lon2)
         );
-        Console.WriteLine(result.Distance);
-        Console.WriteLine(result.Bearing12);
-        Console.WriteLine(result.Bearing21);
+        Assert.Equal(distance, result.Distance.ConvertTo(DistanceUnit.Nm).Value, Millionth);
+        Assert.Equal(bearing12, result.Bearing12, Millionth);
+        Assert.Equal(bearing21, result.Bearing21, Millionth);
     }
 }


### PR DESCRIPTION
The Bug7 test guarded against the near-antipodal orthodromic-line failure
reported in issue #7, but it was skipped ('Need to re-visit') and had no
assertions -- it only wrote results to the console.

Issue #7 was fixed long ago (the flip-flop convergence handling in
CalculateOrthodromicLineInternal), and both inputs now converge instead of
throwing ArithmeticException. Un-skip the test, give it a descriptive name,
and assert the expected distance and bearings so it actually protects the
fix.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VmY2ALifRqwmNPcRDkzvpc