### PR TITLE
Harden SessionStart hook: agent-visible readiness + persisted env

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,6 +9,13 @@
 # install it here. Once `dotnet` is on PATH, build.sh uses it and skips the CDN.
 #
 # Runs only in remote (web) sessions. Idempotent and non-interactive.
+#
+# Two output channels are used deliberately:
+#   * stderr -> progress logs; shown in session/hook logs but NOT added to the
+#               agent's context.
+#   * stdout -> a short readiness summary. Claude Code injects a SessionStart
+#               hook's stdout into the agent context, so this is how the agent
+#               learns the toolchain is ready (or that setup failed).
 
 set -euo pipefail
 
@@ -19,6 +26,27 @@ fi
 
 log() { echo "[session-start] $*" >&2; }
 
+# Resolve the repo root. $CLAUDE_PROJECT_DIR is set when the harness runs the
+# hook; fall back to this script's own location so direct invocation also works.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$PROJECT_DIR" ]; then
+  PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
+# Persist env vars for the whole session. A plain `export` here dies with this
+# subshell; $CLAUDE_ENV_FILE is sourced into every subsequent session shell.
+persist_env() {
+  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    printf 'export %s\n' "$1" >> "$CLAUDE_ENV_FILE"
+  fi
+  export "${1?}"
+}
+persist_env "DOTNET_CLI_TELEMETRY_OPTOUT=1"
+persist_env "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1"
+persist_env "DOTNET_NOLOGO=1"
+# So build.sh's husky MSBuild target never reaches for the network-blocked CDN.
+persist_env "HUSKY=0"
+
 if command -v dotnet >/dev/null 2>&1; then
   log "dotnet already present ($(dotnet --version 2>/dev/null || echo unknown)); skipping SDK install."
 else
@@ -28,19 +56,42 @@ else
   export DEBIAN_FRONTEND=noninteractive
   # '|| true' on update so a single unrelated PPA 403 doesn't abort the install.
   $SUDO apt-get update -qq >&2 || true
-  $SUDO apt-get install -y -qq dotnet-sdk-8.0 >&2
+  if ! $SUDO apt-get install -y -qq dotnet-sdk-8.0 >&2; then
+    log "ERROR: 'apt-get install dotnet-sdk-8.0' failed."
+    echo "SessionStart hook: FAILED to install the .NET 8 SDK. Builds/tests via ./build.sh will not work until dotnet is installed manually."
+    exit 1
+  fi
   log "Installed dotnet $(dotnet --version)."
 fi
 
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+# Hard gate: if dotnet still isn't callable, report it on stdout (agent-visible)
+# rather than exiting 0 and letting the agent hit a broken toolchain later.
+if ! command -v dotnet >/dev/null 2>&1; then
+  log "ERROR: dotnet is not on PATH after install."
+  echo "SessionStart hook: .NET SDK is NOT on PATH. Builds/tests via ./build.sh will not work."
+  exit 1
+fi
+
+DOTNET_VERSION="$(dotnet --version 2>/dev/null || echo unknown)"
 
 # Restore the pinned local tools (CSharpier + Husky) so the linter / format gate
 # is runnable. NuGet (api.nuget.org) is on the default allowlist.
-if [ -f "${CLAUDE_PROJECT_DIR:-.}/.config/dotnet-tools.json" ]; then
+TOOLS_STATUS="ok"
+if [ -f "$PROJECT_DIR/.config/dotnet-tools.json" ]; then
   log "Restoring local dotnet tools (csharpier, husky)..."
-  (cd "${CLAUDE_PROJECT_DIR:-.}" && HUSKY=0 dotnet tool restore >&2) || \
+  if (cd "$PROJECT_DIR" && HUSKY=0 dotnet tool restore >&2); then
+    log "Local tools restored."
+  else
+    TOOLS_STATUS="failed"
     log "warning: 'dotnet tool restore' failed; the CSharpier/Husky lint gate may be unavailable."
+  fi
 fi
 
 log "Ready. Build/test with: ./build.sh Test"
+
+# Agent-visible readiness summary (stdout -> injected into context).
+if [ "$TOOLS_STATUS" = "ok" ]; then
+  echo "SessionStart hook: .NET SDK $DOTNET_VERSION ready and local tools (csharpier, husky) restored. Build/test with './build.sh Test'; format with 'dotnet csharpier format .'."
+else
+  echo "SessionStart hook: .NET SDK $DOTNET_VERSION ready, but 'dotnet tool restore' failed so the CSharpier/Husky lint gate may be unavailable. Build/test with './build.sh Test'."
+fi


### PR DESCRIPTION
The hook installed the .NET SDK but logged everything to stderr, so a
successful run injected nothing into the agent's context — the agent had no
signal the toolchain was ready. Its env exports also died with the hook's
subshell instead of persisting to the session.

- Emit a one-line readiness summary on stdout (Claude Code injects a
  SessionStart hook's stdout into agent context).
- Persist DOTNET_* and HUSKY=0 via $CLAUDE_ENV_FILE so they carry into every
  session shell.
- Fail loudly on stdout (non-zero exit) if the SDK install fails or dotnet is
  not on PATH, instead of exiting 0 with a broken toolchain.
- Report a failed 'dotnet tool restore' in the summary.
- Resolve the repo root from BASH_SOURCE when CLAUDE_PROJECT_DIR is unset.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pzewx35bjf1DWwnMdFN8Qa