### PR TITLE
Wire up packaged README and project URL for NuGet

### DIFF
--- a/Geo/Geo.csproj
+++ b/Geo/Geo.csproj
@@ -1,12 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Copyright>Copyright © Simon Bartlett 2012</Copyright>
+    <Copyright>Copyright © Simon Bartlett</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Simon Bartlett</Authors>
     <AssemblyName>Geo</AssemblyName>
     <Version>1.2.0</Version>
     <Description>A geospatial library for .NET</Description>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/sibartlett/Geo</PackageProjectUrl>
     <PackageTags>geo;spatial;gps;coordinates;wgs84;geography;WKT;WKB;GeoJSON;GPX;IGC;NMEA;Garmin;PocketFMS;SkyDemon;magnetic declination;magnetic variation;geomagnetism;igrf;wmm</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/sibartlett/Geo</RepositoryUrl>


### PR DESCRIPTION
## Summary

The README is already packed into the `.nupkg` (`Geo.csproj`), but it was never declared as the package readme — so NuGet.org wasn't rendering it on the package page. This follow-up to #83 wires that up and rounds out the package metadata.

## Changes

- Add `<PackageReadmeFile>README.md</PackageReadmeFile>` so NuGet.org renders the bundled README on the package page.
- Add `<PackageProjectUrl>` so the package page links back to the GitHub repo.
- Drop the stale year from the copyright notice (`Copyright © Simon Bartlett 2012` → `Copyright © Simon Bartlett`).

## Verification

Built the Release package locally (`dotnet build -c Release`): 0 warnings, 0 errors. The generated `.nuspec` now contains `<readme>README.md</readme>` and `<projectUrl>`, with `README.md` bundled at the package root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RT8r3KpxDtNzf9j8yBtVFq)_