### PR TITLE
Migrate and expand documentation into docs/, with a compile-checked examples suite

### DIFF
--- a/Geo.Tests/Documentation/DocumentationExamplesTests.cs
+++ b/Geo.Tests/Documentation/DocumentationExamplesTests.cs
@@ -54,6 +54,7 @@ public class DocumentationExamplesTests
         private readonly Circle circle = new Circle(0, 0, 1000);
         private readonly Envelope envelope = new Envelope(0, 0, 10, 10);
         private readonly GpsData gpsData = new GpsData();
+        private readonly GpsData data = new GpsData();
         private readonly Stream myStream = Stream.Null;
         ";
 

--- a/Geo.Tests/Documentation/DocumentationExamplesTests.cs
+++ b/Geo.Tests/Documentation/DocumentationExamplesTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Geo.Tests.Documentation;
+
+/// <summary>
+/// Compiles every C# code block in the docs/ folder so the examples cannot drift
+/// away from the public API (which is exactly what happened to the old wiki).
+///
+/// The snippets are illustrative fragments, so they are wrapped in methods over a
+/// shared set of example variables (see <see cref="Preamble"/>) before compiling.
+/// </summary>
+public class DocumentationExamplesTests
+{
+    private static readonly Regex CodeBlock = new(
+        "```csharp\\r?\\n(?<code>.*?)```",
+        RegexOptions.Singleline | RegexOptions.Compiled
+    );
+
+    // A `using X;` directive, as opposed to a `using var x = ...;` / `using (...)` statement.
+    private static readonly Regex UsingDirective = new(
+        "^\\s*using\\s+[A-Za-z_][A-Za-z0-9_.]*\\s*;\\s*$",
+        RegexOptions.Compiled
+    );
+
+    // Shared example variables the fragments refer to without declaring.
+    private const string Preamble =
+        @"
+        private readonly Coordinate london = new Coordinate(51.5074, -0.1278);
+        private readonly Coordinate newYork = new Coordinate(40.7128, -74.0060);
+        private readonly Distance distance = new Distance(5000);
+        private readonly LinearRing outerRing = new LinearRing(
+            new Coordinate(0, 0), new Coordinate(0, 10), new Coordinate(10, 10), new Coordinate(0, 0));
+        private readonly LinearRing innerRing = new LinearRing(
+            new Coordinate(2, 2), new Coordinate(2, 4), new Coordinate(4, 4), new Coordinate(2, 2));
+        private readonly LineString line = new LineString(new Coordinate(0, 0), new Coordinate(0, 10));
+        private readonly LineString line1 = new LineString(new Coordinate(0, 0), new Coordinate(0, 10));
+        private readonly LineString line2 = new LineString(new Coordinate(1, 0), new Coordinate(1, 10));
+        private readonly Point point = new Point(0, 0);
+        private readonly Polygon polygon = new Polygon(
+            new Coordinate(0, 0), new Coordinate(0, 10), new Coordinate(10, 10), new Coordinate(0, 0));
+        private readonly Polygon polygon1 = new Polygon(
+            new Coordinate(0, 0), new Coordinate(0, 10), new Coordinate(10, 10), new Coordinate(0, 0));
+        private readonly Polygon polygon2 = new Polygon(
+            new Coordinate(5, 5), new Coordinate(5, 15), new Coordinate(15, 15), new Coordinate(5, 5));
+        private readonly Circle circle = new Circle(0, 0, 1000);
+        private readonly Envelope envelope = new Envelope(0, 0, 10, 10);
+        private readonly GpsData gpsData = new GpsData();
+        private readonly Stream myStream = Stream.Null;
+        ";
+
+    [Fact]
+    public void All_csharp_examples_in_the_docs_compile()
+    {
+        var docsDirectory = FindDocsDirectory();
+        var snippets = Directory
+            .EnumerateFiles(docsDirectory, "*.md")
+            .OrderBy(x => x)
+            .SelectMany(ExtractSnippets)
+            .ToList();
+
+        Assert.NotEmpty(snippets);
+
+        var source = BuildProgram(snippets);
+        var errors = Compile(source).Where(x => x.Severity == DiagnosticSeverity.Error).ToList();
+
+        Assert.True(
+            errors.Count == 0,
+            "Documentation examples failed to compile:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, errors)
+        );
+    }
+
+    private static IEnumerable<(string File, string Code)> ExtractSnippets(string file)
+    {
+        var text = File.ReadAllText(file);
+        foreach (Match match in CodeBlock.Matches(text))
+            yield return (Path.GetFileName(file), match.Groups["code"].Value);
+    }
+
+    private static string BuildProgram(IReadOnlyList<(string File, string Code)> snippets)
+    {
+        var usings = new SortedSet<string>(StringComparer.Ordinal)
+        {
+            "using System;",
+            "using System.Collections.Generic;",
+            "using System.IO;",
+            "using System.Linq;",
+            "using Geo;",
+            "using Geo.Abstractions.Interfaces;",
+            "using Geo.Geodesy;",
+            "using Geo.Geomagnetism;",
+            "using Geo.Geometries;",
+            "using Geo.Gps;",
+            "using Geo.Gps.Serialization;",
+            "using Geo.IO.GeoJson;",
+            "using Geo.IO.Wkt;",
+            "using Geo.IO.Wkb;",
+            "using Geo.Measure;",
+            "using Xunit;",
+        };
+
+        var methods = new StringBuilder();
+        for (var i = 0; i < snippets.Count; i++)
+        {
+            var body = new StringBuilder();
+            foreach (var line in snippets[i].Code.Split('\n'))
+            {
+                if (UsingDirective.IsMatch(line))
+                    usings.Add(line.Trim());
+                else
+                    body.Append(line).Append('\n');
+            }
+
+            methods
+                .Append("    // ")
+                .Append(snippets[i].File)
+                .Append('\n')
+                .Append("    void Snippet_")
+                .Append(i)
+                .Append("()\n    {\n")
+                .Append(body)
+                .Append("\n    }\n\n");
+        }
+
+        return string.Join("\n", usings)
+            + "\n\nclass DocExamples\n{\n"
+            + Preamble
+            + "\n"
+            + methods
+            + "}\n";
+    }
+
+    private static IEnumerable<Diagnostic> Compile(string source)
+    {
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))
+            .Split(Path.PathSeparator)
+            .Where(x => !string.IsNullOrEmpty(x))
+            .Select(x => (MetadataReference)MetadataReference.CreateFromFile(x))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "DocExamples",
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        return compilation.GetDiagnostics();
+    }
+
+    private static string FindDocsDirectory()
+    {
+        var directory = new DirectoryInfo(
+            Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().Location).LocalPath)
+        );
+
+        while (directory != null)
+        {
+            var docs = Path.Combine(directory.FullName, "docs");
+            if (Directory.Exists(docs))
+                return docs;
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the docs/ directory.");
+    }
+}

--- a/Geo.Tests/Geo.Tests.csproj
+++ b/Geo.Tests/Geo.Tests.csproj
@@ -5,6 +5,7 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ coordinates on the surface of the Earth — rather than planar/projected data. I
 provides geometry and GPS types, serializers for common spatial and GPS file
 formats, and geodetic and geomagnetic calculations.
 
-[Wiki](https://github.com/sibartlett/Geo/wiki) · [Issues](https://github.com/sibartlett/Geo/issues) · [NuGet](https://nuget.org/packages/Geo)
+[Documentation](docs/) · [Issues](https://github.com/sibartlett/Geo/issues) · [NuGet](https://nuget.org/packages/Geo)
 
 ## Contents
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,15 @@ example.
 - [Envelope](envelope.md)
 - [Geometries](geometries.md)
 
+## Calculations
+
+- [Geodesy — distance, bearing, and lines](geodesy.md)
+- [Geomagnetism — declination, inclination, intensity](geomagnetism.md)
+
+## GPS
+
+- [GPS data and file formats](gps.md)
+
 ## Serialization
 
 - [Well-Known Text (WKT)](well-known-text.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,10 +14,15 @@ example.
 
 - [Geodesy — distance, bearing, and lines](geodesy.md)
 - [Geomagnetism — declination, inclination, intensity](geomagnetism.md)
+- [Measure — distances, areas, and speeds](measure.md)
 
 ## GPS
 
 - [GPS data and file formats](gps.md)
+
+## Configuration
+
+- [GeoContext — ambient settings](geocontext.md)
 
 ## Serialization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Geo documentation
+
+Geo is a geospatial library for .NET; its main focus is the geographical domain.
+See the [project README](../README.md) for installation and a quick-start
+example.
+
+## Core types
+
+- [Coordinate](coordinate.md)
+- [Envelope](envelope.md)
+- [Geometries](geometries.md)
+
+## Serialization
+
+- [Well-Known Text (WKT)](well-known-text.md)
+- [Well-Known Binary (WKB)](well-known-binary.md)
+- [GeoJSON](geojson.md)
+
+> These pages were migrated from the project wiki. Pages covering integrations
+> that are no longer part of the library (Spatial4n and RavenDB) were dropped
+> during the migration.

--- a/docs/coordinate.md
+++ b/docs/coordinate.md
@@ -1,0 +1,72 @@
+# Coordinate
+
+The `Coordinate` type represents a geographic position as a latitude/longitude
+pair (in degrees, WGS-84):
+
+- `Latitude`
+- `Longitude`
+
+```csharp
+var latitude = 34.869;
+var longitude = 67.98;
+var coordinate = new Coordinate(latitude, longitude);
+```
+
+## Elevation and measure
+
+`Coordinate` itself only carries latitude and longitude. Elevation and measure
+values live on the derived coordinate types:
+
+| Type | Adds |
+|------|------|
+| `Coordinate` | latitude, longitude |
+| `CoordinateZ` | + elevation (metres) |
+| `CoordinateM` | + measure |
+| `CoordinateZM` | + elevation and measure |
+
+```csharp
+var withElevation = new CoordinateZ(34.869, 67.98, 789.93);
+```
+
+Geo does not perform geodetic calculations on the elevation or measure
+ordinates. A coordinate's `Is3D` and `IsMeasured` properties report which
+variant you are holding.
+
+## Constraints
+
+The constructor throws an `ArgumentOutOfRangeException` if:
+
+- Latitude is greater than `90` or less than `-90`.
+- Longitude is greater than `180` or less than `-180`.
+
+## Longitude wrapping
+
+`Coordinate` supports longitude wrapping. When enabled, Geo wraps out-of-range
+longitude values into the `[-180, 180]` range instead of throwing — for example
+a longitude of `390` wraps to `30`:
+
+```csharp
+GeoContext.Current.LongitudeWrapping = true;
+
+var coordinate1 = new Coordinate(0, 30);
+var coordinate2 = new Coordinate(0, 390);
+
+// coordinate2.Longitude == 30, so the two coordinates are equal
+Assert.Equal(coordinate1, coordinate2);
+Assert.Equal(30d, coordinate2.Longitude);
+```
+
+Latitude is never wrapped; an out-of-range latitude always throws.
+
+## Parsing coordinate strings
+
+`Coordinate` has static methods for parsing a coordinate pair from a string,
+including degrees/minutes/seconds notation:
+
+```csharp
+var coordinate = Coordinate.Parse("12 34.56'N 123 45.55'E");
+
+// Non-throwing variants:
+var maybe = Coordinate.TryParse("12 34.56'N 123 45.55'E");     // returns null on failure
+if (Coordinate.TryParse("...", out var parsed)) { /* ... */ }
+```

--- a/docs/envelope.md
+++ b/docs/envelope.md
@@ -1,0 +1,26 @@
+# Envelope
+
+The `Envelope` type represents a rectangle/bounds. It has four properties:
+
+- `MinLat`
+- `MinLon`
+- `MaxLat`
+- `MaxLon`
+
+The horizontal edges run along parallels; the vertical edges run along
+meridians.
+
+```csharp
+var envelope = new Envelope(minLat: 0, minLon: 0, maxLat: 10, maxLon: 10);
+```
+
+## Calculations
+
+`Envelope` supports several calculations:
+
+- `Contains(Coordinate other)`
+- `Contains(Envelope other)`
+- `Contains(IGeometry other)`
+- `GetArea()` — returns an `Area`
+- `GetLength()` — returns a `Distance` (the perimeter)
+- `Intersects(Envelope other)`

--- a/docs/geocontext.md
+++ b/docs/geocontext.md
@@ -1,0 +1,69 @@
+# GeoContext — ambient settings
+
+`GeoContext` holds the settings that calculations read by default — the
+reference spheroid, the geodetic and geomagnetic calculators, spatial-equality
+options, and the longitude-wrapping flag. The active context is
+`GeoContext.Current`.
+
+```csharp
+using Geo;
+
+var context = GeoContext.Current;
+```
+
+## Settings
+
+| Property | Type | Default |
+|----------|------|---------|
+| `Spheroid` | `Spheroid` | `Spheroid.Wgs84` |
+| `GeodeticCalculator` | `IGeodeticCalculator` | `SpheroidCalculator` (WGS-84) |
+| `GeomagnetismCalculator` | `GeomagnetismCalculator` | `GeomagnetismCalculator` |
+| `EqualityOptions` | `SpatialEqualityOptions` | default options |
+| `LongitudeWrapping` | `bool` | `false` |
+
+## Changing the defaults
+
+You can set individual properties on the current context:
+
+```csharp
+using Geo;
+using Geo.Geodesy;
+
+// Use a spherical Earth model for geodetic calculations:
+GeoContext.Current.GeodeticCalculator = new SphereCalculator();
+
+// Enable longitude wrapping (see the Coordinate page):
+GeoContext.Current.LongitudeWrapping = true;
+```
+
+…or replace the whole context, optionally seeding it from a specific spheroid
+(which sets up matching geodetic and geomagnetic calculators):
+
+```csharp
+using Geo;
+using Geo.Geodesy;
+
+GeoContext.Current = new GeoContext(Spheroid.Grs80);
+```
+
+## Spatial equality options
+
+`EqualityOptions` controls how geometries compare for *spatial* equality
+(the `Equals(object, SpatialEqualityOptions)` overloads). Notable flags:
+
+- `UseElevation` — include the Z ordinate in comparisons.
+- `UseM` — include the measure ordinate.
+- `PoleCoordiantesAreEqual` — treat all coordinates at a pole as equal.
+- `AntiMeridianCoordinatesAreEqual` — treat longitude `-180` and `+180` as equal.
+
+The `To2D()` and `To3D()` helpers return option sets tuned for 2D or 3D
+comparison.
+
+## Scope
+
+`GeoContext.Current` is process-wide and mutable — changing it affects every
+calculation that reads from it. Treat it as global configuration you set up
+once at start-up, and be mindful when mutating it from multiple threads.
+
+See also: [Geodesy](geodesy.md), [Geomagnetism](geomagnetism.md), and
+[Coordinate](coordinate.md) for the features it configures.

--- a/docs/geodesy.md
+++ b/docs/geodesy.md
@@ -1,0 +1,96 @@
+# Geodesy — distance, bearing, and lines
+
+Geo computes distances and bearings on the surface of the Earth (not on a flat
+projection). The calculations are exposed as extension methods on any position
+(`Coordinate`, `Point`, `Waypoint`, … — anything implementing `IPosition`) and
+return strongly-typed results.
+
+```csharp
+using Geo;
+using Geo.Geodesy;
+using Geo.Measure;
+
+// Ordinate order is latitude, longitude.
+var london = new Coordinate(51.5074, -0.1278);
+var newYork = new Coordinate(40.7128, -74.0060);
+
+GeodeticLine line = london.CalculateShortestLine(newYork);
+
+Distance distance = line.Distance;          // a Distance (S.I.: metres)
+double km = distance.ConvertTo(DistanceUnit.Km).Value;   // ~5570
+double initialBearing = line.Bearing12;     // degrees, London -> New York
+double finalBearing = line.Bearing21;       // degrees, New York -> London
+```
+
+## Great-circle vs. rhumb lines
+
+| Method | Line | Notes |
+|--------|------|-------|
+| `CalculateShortestLine` | Geodesic (shortest path) | Same as `CalculateGreatCircleLine` |
+| `CalculateGreatCircleLine` | Great circle / orthodromic | Shortest path; bearing changes along the route |
+| `CalculateRhumbLine` | Rhumb line / loxodrome | Constant bearing; longer than the great circle |
+
+```csharp
+var greatCircle = london.CalculateGreatCircleLine(newYork);
+var rhumb = london.CalculateRhumbLine(newYork);
+// rhumb.Distance >= greatCircle.Distance
+```
+
+A `GeodeticLine` is a `LineSegment`, so it also carries its two end
+coordinates. The `Distance` and bearings are the interesting additions.
+
+## Projecting a point
+
+Given a start point, a heading, and a distance, the calculator can project the
+destination point:
+
+```csharp
+using Geo;
+using Geo.Geodesy;
+
+var start = new Coordinate(51.5074, -0.1278);
+GeodeticLine projected = GeoContext.Current.GeodeticCalculator
+    .CalculateOrthodromicLine(start, heading: 90, distance: 10000); // 10 km due east
+// projected.Coordinate2 is the destination
+```
+
+## Lengths and areas
+
+The active calculator computes lengths and areas for whole shapes:
+
+```csharp
+var calculator = GeoContext.Current.GeodeticCalculator;
+
+Distance perimeter = calculator.CalculateLength(polygon.Shell.Coordinates);
+Area area = calculator.CalculateArea(polygon.Shell.Coordinates);
+Distance circumference = calculator.CalculateLength(circle);
+```
+
+## Choosing the Earth model
+
+Calculations read their calculator from `GeoContext.Current.GeodeticCalculator`.
+Two implementations are provided:
+
+- **`SpheroidCalculator`** — models the Earth as an ellipsoid (spheroid). This is
+  the default, using the WGS-84 spheroid, and is the more accurate option.
+- **`SphereCalculator`** — models the Earth as a sphere. Faster and simpler, but
+  less accurate.
+
+```csharp
+using Geo;
+using Geo.Geodesy;
+
+// Use a spherical Earth model globally:
+GeoContext.Current.GeodeticCalculator = new SphereCalculator();
+
+// Or a different reference spheroid:
+GeoContext.Current.GeodeticCalculator = new SpheroidCalculator(Spheroid.Grs80);
+```
+
+Built-in spheroids include `Spheroid.Wgs84` (the default), `Spheroid.Grs80`,
+`Spheroid.International1924`, and `Spheroid.Clarke1866`. You can also construct a
+custom one with `new Spheroid(name, equatorialAxis, inverseFlattening)`.
+
+The `Distance` and `Area` result types (from the `Geo.Measure` namespace) carry
+their value in S.I. units and convert to others via `ConvertTo`, e.g.
+`distance.ConvertTo(DistanceUnit.Nm).Value`.

--- a/docs/geojson.md
+++ b/docs/geojson.md
@@ -24,3 +24,7 @@ var pointJson = writer.Write(new Point(68.389, 73.89));
 
 `GeoJsonWriter.Write` has overloads for `IGeometry`, `Feature`, and
 `FeatureCollection`.
+
+Writing anything that implements `IGeometry` works the same way — including
+geometries produced from GPS data. To convert a GPX track (or route) to GeoJSON,
+see the [GPX to GeoJSON recipe](gps.md#recipe-gpx-to-geojson).

--- a/docs/geojson.md
+++ b/docs/geojson.md
@@ -1,0 +1,26 @@
+# GeoJSON
+
+Geo can read and write GeoJSON. Objects that implement `IGeoJsonObject` can be
+read from and written to GeoJSON.
+
+There are two types specific to GeoJSON:
+
+- `Feature`
+- `FeatureCollection`
+
+## Reading
+
+```csharp
+var reader = new GeoJsonReader();
+IGeoJsonObject point = reader.Read("{ \"type\": \"Point\", \"coordinates\": [100.0, 0.0] }");
+```
+
+## Writing
+
+```csharp
+var writer = new GeoJsonWriter();
+var pointJson = writer.Write(new Point(68.389, 73.89));
+```
+
+`GeoJsonWriter.Write` has overloads for `IGeometry`, `Feature`, and
+`FeatureCollection`.

--- a/docs/geomagnetism.md
+++ b/docs/geomagnetism.md
@@ -1,0 +1,68 @@
+# Geomagnetism
+
+Geo computes the Earth's magnetic field at a given position and date using the
+standard spherical-harmonic models — the **World Magnetic Model (WMM)** and the
+**International Geomagnetic Reference Field (IGRF)**. This gives you magnetic
+declination (variation), inclination (dip), and field intensity.
+
+## Calculating declination
+
+Pick a model calculator, then call `TryCalculate` with a position and a date:
+
+```csharp
+using System;
+using Geo;
+using Geo.Geomagnetism;
+
+var london = new Coordinate(51.5, -0.12);
+
+var result = new WmmGeomagnetismCalculator()
+    .TryCalculate(london, new DateTime(2020, 1, 1));
+
+double declination = result.Declination;    // degrees, east positive
+double inclination = result.Inclination;    // degrees
+double intensity = result.TotalIntensity;   // nanoteslas
+```
+
+Two calculators are provided:
+
+- **`WmmGeomagnetismCalculator`** — the WMM models (epochs 1985 through 2025).
+- **`IgrfGeomagnetismCalculator`** — the IGRF models.
+
+Both come pre-loaded with their full set of epoch models and pick the correct
+one for the date you pass.
+
+## The result
+
+`TryCalculate(position, date)` returns a `GeomagnetismResult` with:
+
+| Property | Meaning |
+|----------|---------|
+| `Declination` | Angle between magnetic and true north, in degrees (east positive) |
+| `Inclination` | Dip angle, in degrees |
+| `TotalIntensity` | Total field strength, in nanoteslas |
+| `HorizontalIntensity` | Horizontal field strength, in nanoteslas |
+| `X`, `Y`, `Z` | North, east, and vertical field components |
+
+There are also `out`-parameter overloads that return a `bool` indicating
+success:
+
+```csharp
+if (new WmmGeomagnetismCalculator().TryCalculate(london, DateTime.UtcNow, out var r))
+{
+    Console.WriteLine($"Declination: {r.Declination:F2}°");
+}
+```
+
+## Elevation and dates
+
+- Position elevation is taken into account when you pass a `CoordinateZ`
+  (elevation in metres); a plain `Coordinate` is treated as sea level.
+- Dates are handled in UTC — `DateTimeOffset` overloads are available and are
+  converted to UTC internally.
+
+## Custom models
+
+Both calculators derive from `GeomagnetismCalculator`, which you can construct
+with your own set of `IGeomagneticModel` instances (and optionally a specific
+`Spheroid`) if you need to restrict or extend the available epochs.

--- a/docs/geometries.md
+++ b/docs/geometries.md
@@ -1,56 +1,114 @@
 # Geometries
 
 Geo's geometry types mirror the OGC simple-feature geometries, plus a `Circle`.
+All coordinates are latitude/longitude in degrees (WGS-84), and constructors take
+them in **latitude, longitude** order.
+
+```csharp
+using Geo;
+using Geo.Geometries;
+```
 
 ## Point
 
-Similar to the OGC Point.
+A single position. Similar to the OGC Point.
+
+```csharp
+var point = new Point(51.5074, -0.1278);          // lat, lon
+var fromCoordinate = new Point(new Coordinate(51.5074, -0.1278));
+```
 
 ## LineString
 
-Similar to the OGC LineString.
+An ordered sequence of coordinates. Similar to the OGC LineString.
+
+```csharp
+var line = new LineString(
+    new Coordinate(0, 0),
+    new Coordinate(0, 10),
+    new Coordinate(10, 10)
+);
+// also accepts IEnumerable<Coordinate> or a CoordinateSequence
+```
 
 ## LinearRing
 
-Similar to the OGC LinearRing.
+A closed `LineString` whose first and last coordinates are equal. Similar to the
+OGC LinearRing. (A plain `LineString` may happen to be closed too, but it is not
+necessarily *semantically* a ring.)
 
-A special type of `LineString` where the start and end coordinates are equal,
-forming a closed ring. A `LineString` may also have equal start and end
-coordinates, but it is not necessarily semantically closed.
+```csharp
+var ring = new LinearRing(
+    new Coordinate(0, 0),
+    new Coordinate(0, 10),
+    new Coordinate(10, 10),
+    new Coordinate(0, 0)   // closes the ring
+);
+```
 
 ## Polygon
 
-Similar to the OGC Polygon.
+An exterior ring (shell) plus zero or more interior rings (holes). Similar to
+the OGC Polygon.
 
-Though it is not enforced, it is advised that:
+```csharp
+// Simple polygon from a coordinate list (the shell):
+var polygon = new Polygon(
+    new Coordinate(0, 0),
+    new Coordinate(0, 10),
+    new Coordinate(10, 10),
+    new Coordinate(0, 0)
+);
 
-- the exterior ring/shell is CCW (counter-clockwise/anti-clockwise);
-- the interior rings/holes are CW (clockwise).
+// Polygon with a hole:
+var withHole = new Polygon(shell: outerRing, holes: innerRing);
+```
+
+Though it is not enforced, it is advised that the exterior ring is CCW
+(counter-clockwise) and the interior rings/holes are CW (clockwise).
 
 ## Triangle
 
-Similar to the OGC Triangle.
+A `Polygon` whose shell is limited to 3 distinct points. Similar to the OGC
+Triangle.
 
-The same as a `Polygon`, but the outer ring/shell is limited to 4 sets of
-coordinates (3 distinct points).
-
-## GeometryCollection
-
-Similar to the OGC GeometryCollection.
-
-## MultiPoint
-
-Similar to the OGC MultiPoint.
-
-## MultiLineString
-
-Similar to the OGC MultiLineString.
-
-## MultiPolygon
-
-Similar to the OGC MultiPolygon.
+```csharp
+var triangle = new Triangle(
+    new Coordinate(0, 0),
+    new Coordinate(0, 10),
+    new Coordinate(10, 0)
+);
+```
 
 ## Circle
 
-A geometry type representing a circle, consisting of a centre and a radius in
-metres. It does not map to an OGC-defined shape.
+A centre and a radius **in metres**. Does not map to an OGC-defined shape.
+
+```csharp
+var circle = new Circle(new Coordinate(51.5074, -0.1278), radius: 5000); // 5 km
+var circle2 = new Circle(51.5074, -0.1278, 5000);                        // lat, lon, radius
+```
+
+## Collections
+
+`GeometryCollection` holds any mix of geometries; the `Multi*` types hold a
+single geometry kind. Each accepts a `params` array or an `IEnumerable`.
+
+```csharp
+var multiPoint = new MultiPoint(
+    new Point(0, 0),
+    new Point(0, 10)
+);
+
+var multiLine = new MultiLineString(line1, line2);
+var multiPolygon = new MultiPolygon(polygon1, polygon2);
+var collection = new GeometryCollection(point, line, polygon);
+```
+
+- `MultiPoint` — similar to the OGC MultiPoint.
+- `MultiLineString` — similar to the OGC MultiLineString.
+- `MultiPolygon` — similar to the OGC MultiPolygon.
+- `GeometryCollection` — similar to the OGC GeometryCollection.
+
+See also: [WKT](well-known-text.md), [WKB](well-known-binary.md), and
+[GeoJSON](geojson.md) for reading and writing these geometries.

--- a/docs/geometries.md
+++ b/docs/geometries.md
@@ -1,0 +1,56 @@
+# Geometries
+
+Geo's geometry types mirror the OGC simple-feature geometries, plus a `Circle`.
+
+## Point
+
+Similar to the OGC Point.
+
+## LineString
+
+Similar to the OGC LineString.
+
+## LinearRing
+
+Similar to the OGC LinearRing.
+
+A special type of `LineString` where the start and end coordinates are equal,
+forming a closed ring. A `LineString` may also have equal start and end
+coordinates, but it is not necessarily semantically closed.
+
+## Polygon
+
+Similar to the OGC Polygon.
+
+Though it is not enforced, it is advised that:
+
+- the exterior ring/shell is CCW (counter-clockwise/anti-clockwise);
+- the interior rings/holes are CW (clockwise).
+
+## Triangle
+
+Similar to the OGC Triangle.
+
+The same as a `Polygon`, but the outer ring/shell is limited to 4 sets of
+coordinates (3 distinct points).
+
+## GeometryCollection
+
+Similar to the OGC GeometryCollection.
+
+## MultiPoint
+
+Similar to the OGC MultiPoint.
+
+## MultiLineString
+
+Similar to the OGC MultiLineString.
+
+## MultiPolygon
+
+Similar to the OGC MultiPolygon.
+
+## Circle
+
+A geometry type representing a circle, consisting of a centre and a radius in
+metres. It does not map to an OGC-defined shape.

--- a/docs/gps.md
+++ b/docs/gps.md
@@ -1,0 +1,90 @@
+# GPS data and file formats
+
+Geo models GPS data and reads/writes the common GPS interchange formats.
+
+## The data model
+
+| Type | Description |
+|------|-------------|
+| `GpsData` | Top-level container: `Routes`, `Tracks`, `Waypoints`, and `Metadata` |
+| `Route` | A planned ordered list of `Waypoints` |
+| `Track` | A recorded path, made up of `TrackSegment`s |
+| `TrackSegment` | A continuous run of `Waypoints` (fixes) |
+| `Waypoint` | A single point — position, optional elevation and timestamp |
+
+`Route`, `Track`, and `TrackSegment` implement `IHasLength`, and the track types
+expose helpers such as `GetLength()` (a `Distance`), `GetDuration()` (a
+`TimeSpan`), and `GetAverageSpeed()` (a `Speed`):
+
+```csharp
+using Geo.Gps;
+
+var track = gpsData.Tracks[0];
+var length = track.GetLength();           // Distance
+var duration = track.GetDuration();       // TimeSpan
+var averageSpeed = track.GetAverageSpeed(); // Speed
+```
+
+## Reading a file
+
+`GpsData.Parse` auto-detects the format from the stream and deserializes it,
+returning `null` if no reader recognises the content:
+
+```csharp
+using System.IO;
+using Geo.Gps;
+
+using var stream = File.OpenRead("activity.gpx");
+GpsData data = GpsData.Parse(stream);
+
+foreach (var track in data.Tracks)
+foreach (var fix in track.GetAllFixes()) // every Waypoint across the track's segments
+{
+    // ...
+}
+```
+
+### Supported formats
+
+| Format | Read | Write |
+|--------|:----:|:-----:|
+| GPX 1.0 / 1.1 | ✓ | ✓ |
+| NMEA | ✓ | |
+| IGC | ✓ | |
+| Garmin flightplan | ✓ | |
+| SkyDemon flightplan | ✓ | |
+| PocketFMS flightplan | ✓ | |
+
+Call `GpsData.SupportedGpsFileFormats()` to enumerate the formats known at
+runtime. If you want to force a specific reader instead of auto-detecting, each
+deserializer implements `IGpsFileDeSerializer` and can be used directly:
+
+```csharp
+using Geo.Gps.Serialization;
+
+using var stream = File.OpenRead("flight.igc");
+var data = new IgcDeSerializer().DeSerialize(new StreamWrapper(stream));
+```
+
+## Writing GPX
+
+GPX is the only format with a writer. Build a `GpsData` and call `ToGpx`:
+
+```csharp
+using Geo.Gps;
+
+var data = new GpsData();
+data.Waypoints.Add(new Waypoint(51.5074, -0.1278));
+
+string gpx11 = data.ToGpx();     // GPX 1.1 (default)
+string gpx10 = data.ToGpx(1m);   // GPX 1.0
+```
+
+A `Waypoint` can be constructed from a latitude/longitude pair, optionally with
+elevation and a timestamp:
+
+```csharp
+var w1 = new Waypoint(51.5074, -0.1278);
+var w2 = new Waypoint(51.5074, -0.1278, elevation: 35);
+var w3 = new Waypoint(51.5074, -0.1278, 35, DateTime.UtcNow);
+```

--- a/docs/gps.md
+++ b/docs/gps.md
@@ -25,6 +25,11 @@ var duration = track.GetDuration();       // TimeSpan
 var averageSpeed = track.GetAverageSpeed(); // Speed
 ```
 
+`Route`, `Track`, and `TrackSegment` also expose `ToLineString()`, and a
+`Waypoint` exposes its `Coordinate` and `Point`. These are the bridge from the
+GPS types to the [geometry](geometries.md) types, so you can serialize GPS data
+with any of the geometry writers (see the recipe below).
+
 ## Reading a file
 
 `GpsData.Parse` auto-detects the format from the stream and deserializes it,
@@ -64,6 +69,46 @@ using Geo.Gps.Serialization;
 
 using var stream = File.OpenRead("flight.igc");
 var data = new IgcDeSerializer().DeSerialize(new StreamWrapper(stream));
+```
+
+## Converting GPS data to geometries
+
+GPS types live in `Geo.Gps` and geometries live in `Geo.Geometries`, but they are
+easy to bridge: `Route`, `Track`, and `TrackSegment` each have a `ToLineString()`
+method, and a `Waypoint` exposes its `Coordinate` and `Point`. Once you have a
+geometry you can hand it to any geometry writer — [WKT](well-known-text.md),
+[WKB](well-known-binary.md), or [GeoJSON](geojson.md).
+
+### Recipe: GPX to GeoJSON
+
+```csharp
+using System.IO;
+using System.Linq;
+using Geo.Geometries;
+using Geo.Gps;
+using Geo.IO.GeoJson;
+
+using var stream = File.OpenRead("activity.gpx");
+GpsData data = GpsData.Parse(stream);
+
+// Turn the first recorded track into a LineString geometry...
+LineString line = data.Tracks[0].ToLineString();
+
+// ...and write it as GeoJSON.
+string geoJson = new GeoJsonWriter().Write(line);
+```
+
+The same `ToLineString()` bridge works for a planned `Route` or a single
+`TrackSegment`. To emit the individual waypoints as points instead, build a
+`MultiPoint` from their coordinates:
+
+```csharp
+using System.Linq;
+using Geo.Geometries;
+using Geo.IO.GeoJson;
+
+var points = new MultiPoint(data.Waypoints.Select(w => new Point(w.Coordinate)));
+string waypointJson = new GeoJsonWriter().Write(points);
 ```
 
 ## Writing GPX

--- a/docs/measure.md
+++ b/docs/measure.md
@@ -1,0 +1,85 @@
+# Measure — distances, areas, and speeds
+
+Calculations in Geo return strongly-typed measurements from the `Geo.Measure`
+namespace rather than bare `double`s, so the unit is always explicit. Each type
+stores its value internally in **S.I. units** and converts on demand.
+
+## Distance
+
+`Distance` stores metres internally (`SiValue`) and converts to other units with
+`ConvertTo`.
+
+```csharp
+using Geo.Measure;
+
+var distance = new Distance(5000);              // 5000 metres
+double km = distance.ConvertTo(DistanceUnit.Km).Value;   // 5
+double miles = distance.ConvertTo(DistanceUnit.Mile).Value;
+
+// Construct in a specific unit:
+var nauticalMiles = new Distance(3, DistanceUnit.Nm);
+double metres = nauticalMiles.SiValue;          // 5556
+```
+
+`DistanceUnit` values: `M` (metres), `Nm` (nautical miles), `Km` (kilometres),
+`Mile` (statute miles), `Ft` (feet).
+
+`ToString()` formats with the measurement's unit; `ToString(unit)` converts
+first:
+
+```csharp
+distance.ToString();                 // e.g. "5000 m"
+distance.ToString(DistanceUnit.Km);  // e.g. "5 km"
+```
+
+`Distance` values support arithmetic (`+`, `-`) and comparison operators
+(`<`, `>`, `<=`, `>=`, `==`, `!=`), all evaluated on the underlying S.I. value.
+
+## Speed
+
+`Speed` stores metres per second internally.
+
+```csharp
+using System;
+using Geo.Measure;
+
+var speed = new Speed(10);                        // 10 m/s
+double kph = speed.ConvertTo(SpeedUnit.Kph).Value; // 36
+
+// From a distance covered over a time span:
+var average = new Speed(1000 /* metres */, TimeSpan.FromMinutes(5));
+double mph = average.ConvertTo(SpeedUnit.Mph).Value;
+```
+
+`SpeedUnit` values: `Ms` (metres/second), `Knots`, `Kph` (km/h), `Mph`
+(miles/hour).
+
+## Area
+
+`Area` stores square metres internally (`SiValue`) and is what area calculations
+return (for example `Envelope.GetArea()` and
+`IGeodeticCalculator.CalculateArea`).
+
+```csharp
+using Geo.Measure;
+
+Area area = envelope.GetArea();
+double squareMetres = area.SiValue;
+```
+
+> Note: `Area` is currently modelled on `DistanceUnit` and its `SiValue` is in
+> square metres. Prefer working with `SiValue` (m²) directly.
+
+## Converting bare doubles
+
+The unit enums also provide extension methods for converting plain `double`
+values, which is handy when you are not holding a measurement type:
+
+```csharp
+using Geo.Measure;
+
+double km = 5000d.ConvertTo(DistanceUnit.Km);   // 5
+```
+
+See also: [Geodesy](geodesy.md), whose distance/length/area calculations return
+these types.

--- a/docs/well-known-binary.md
+++ b/docs/well-known-binary.md
@@ -1,0 +1,41 @@
+# Well-Known Binary (WKB)
+
+Geo can read and write WKB (Well-Known Binary). Geometries that implement
+`IGeometry` can be read from and written to WKB.
+
+## Reading
+
+```csharp
+var reader = new WkbReader();
+IGeometry geometry1 = reader.Read(new byte[] { /* ... */ }); // reading a byte array
+IGeometry geometry2 = reader.Read(myStream);                 // reading a stream
+```
+
+## Writing
+
+```csharp
+var writer = new WkbWriter();
+byte[] bytes = writer.Write(new Point(68.389, 73.89));
+```
+
+A number of settings are available to customise the output. The code below shows
+their default values:
+
+```csharp
+var settings = new WkbWriterSettings
+{
+    Encoding = WkbEncoding.LittleEndian,
+    Triangle = false,
+    MaxDimesions = 4,
+    ConvertCirclesToRegularPolygons = false,
+    CircleSides = 36,
+};
+
+var writer = new WkbWriter(settings); // pass the settings into the writer's constructor
+```
+
+There is also a static factory for settings that are compatible with NTS/JTS:
+
+```csharp
+var writer = new WkbWriter(WkbWriterSettings.NtsCompatible);
+```

--- a/docs/well-known-text.md
+++ b/docs/well-known-text.md
@@ -1,0 +1,40 @@
+# Well-Known Text (WKT)
+
+Geo can read and write WKT (Well-Known Text). Geometries that implement
+`IGeometry` can be read from and written to WKT.
+
+## Reading
+
+```csharp
+var reader = new WktReader();
+IGeometry point = reader.Read("POINT (73.89 68.389)");   // reading a string
+IGeometry geometry = reader.Read(myStream);              // reading a stream
+```
+
+## Writing
+
+```csharp
+var writer = new WktWriter();
+var pointString = writer.Write(new Point(68.389, 73.89));
+```
+
+A number of settings are available to customise the output. The code below shows
+their default values:
+
+```csharp
+var settings = new WktWriterSettings
+{
+    LinearRing = false,
+    Triangle = false,
+    DimensionFlag = true,
+    ConvertCirclesToRegularPolygons = false,
+};
+
+var writer = new WktWriter(settings); // pass the settings into the writer's constructor
+```
+
+There is also a static factory for settings that are compatible with NTS/JTS:
+
+```csharp
+var writer = new WktWriter(WktWriterSettings.NtsCompatible);
+```


### PR DESCRIPTION
## Summary

Brings the project's documentation in-repo under `docs/`, migrating the still-relevant wiki pages, expanding coverage to the library's distinctive features, and adding a CI check that keeps every example compiling against the real API.

## What's included

**Migrated from the wiki** (corrected against the current API):
- `coordinate.md`, `envelope.md`, `geometries.md`, `geojson.md`, `well-known-text.md`, `well-known-binary.md`, and a docs index (`docs/README.md`).
- Notable fixes: the `Coordinate`/`CoordinateZ/M/ZM` split (elevation is no longer a `Coordinate` ctor arg), the longitude-wrapping description, and `IOgcGeometry` → `IGeometry` in the WKT/WKB pages.
- Dropped the **Spatial4n** and **RavenDB** pages — those types and integrations no longer exist in the library.

**New pages** for previously-undocumented features:
- `geodesy.md` — distance/bearing, great-circle vs. rhumb lines, point projection, length/area, sphere vs. spheroid.
- `geomagnetism.md` — WMM/IGRF declination, inclination, and intensity.
- `gps.md` — the GpsData/Route/Track/Waypoint model, format auto-detection, GPX writing, and a **GPX-to-GeoJSON recipe** (documents the `ToLineString()` bridge that [#20](https://github.com/sibartlett/Geo/issues/20) got stuck on).
- `measure.md` — `Distance`/`Speed`/`Area` and unit conversions.
- `geocontext.md` — the ambient `GeoContext.Current` settings.

**Deepened** `geometries.md` with real constructor examples for every type (ring ordering, polygon holes, `Circle` radius, collections).

## Keeping examples honest

`Geo.Tests/Documentation/DocumentationExamplesTests.cs` extracts every `csharp` block from `docs/*.md` and compiles it against the Geo assembly via Roslyn, so the examples can't drift out of date the way the old wiki did. It runs as part of the normal test suite.

## Other

- Points the README at `docs/` instead of the wiki.

## Verification

- Full test suite green (439 tests, including the new documentation-examples test).
- `dotnet csharpier check .` clean.
- No broken internal doc links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RT8r3KpxDtNzf9j8yBtVFq)_