### PR TITLE
Add regression tests for polygons with holes in WKT and GeoJSON readers (#30, #31)

### DIFF
--- a/Geo.Tests/IO/GeoJson/GeoJsonTests.cs
+++ b/Geo.Tests/IO/GeoJson/GeoJsonTests.cs
@@ -98,6 +98,49 @@ public class GeoJsonTests
     }
 
     [Fact]
+    public void Polygon_with_holes()
+    {
+        // Regression test for issue #31: a Polygon with interior rings (holes)
+        // used to throw "Invalid GeoJSON string". This is the GeoJSON
+        // counterpart of the WKT hole-parsing issue #30.
+        var reader = new GeoJsonReader();
+
+        var polygon = (Polygon)
+            reader.Read(
+                @"{""type"":""Polygon"",""coordinates"":["
+                    + @"[[-87.93939,41.98667],[-87.93933,41.98729],[-87.93906,41.98911],[-87.93939,41.98667]],"
+                    + @"[[-87.83493,41.98116],[-87.83434,41.98115],[-87.83433,41.98082],[-87.83493,41.98116]],"
+                    + @"[[-87.69615,41.69896],[-87.69589,41.69161],[-87.69574,41.69162],[-87.69615,41.69896]]]}"
+            );
+
+        Assert.Equal(
+            new Polygon(
+                new LinearRing(
+                    new Coordinate(41.98667, -87.93939),
+                    new Coordinate(41.98729, -87.93933),
+                    new Coordinate(41.98911, -87.93906),
+                    new Coordinate(41.98667, -87.93939)
+                ),
+                new LinearRing(
+                    new Coordinate(41.98116, -87.83493),
+                    new Coordinate(41.98115, -87.83434),
+                    new Coordinate(41.98082, -87.83433),
+                    new Coordinate(41.98116, -87.83493)
+                ),
+                new LinearRing(
+                    new Coordinate(41.69896, -87.69615),
+                    new Coordinate(41.69161, -87.69589),
+                    new Coordinate(41.69162, -87.69574),
+                    new Coordinate(41.69896, -87.69615)
+                )
+            ),
+            polygon
+        );
+
+        Assert.Equal(2, polygon.Holes.Count);
+    }
+
+    [Fact]
     public void MultiPoint()
     {
         var reader = new GeoJsonReader();

--- a/Geo.Tests/IO/Wkt/WktReaderTests.cs
+++ b/Geo.Tests/IO/Wkt/WktReaderTests.cs
@@ -164,6 +164,48 @@ public class WktReaderTests
     }
 
     [Fact]
+    public void Polygon_with_holes()
+    {
+        // Regression test for issue #30: a POLYGON with one or more interior
+        // rings (holes) used to throw "Invalid WKT String".
+        var reader = new WktReader();
+
+        var polygon = (Polygon)
+            reader.Read(
+                "POLYGON ("
+                    + "(-87.93939 41.98667, -87.93933 41.98729, -87.93906 41.98911, -87.93939 41.98667), "
+                    + "(-87.83493 41.98116, -87.83434 41.98115, -87.83433 41.98082, -87.83493 41.98116), "
+                    + "(-87.69615 41.69896, -87.69589 41.69161, -87.69574 41.69162, -87.69615 41.69896))"
+            );
+
+        Assert.Equal(
+            new Polygon(
+                new LinearRing(
+                    new Coordinate(41.98667, -87.93939),
+                    new Coordinate(41.98729, -87.93933),
+                    new Coordinate(41.98911, -87.93906),
+                    new Coordinate(41.98667, -87.93939)
+                ),
+                new LinearRing(
+                    new Coordinate(41.98116, -87.83493),
+                    new Coordinate(41.98115, -87.83434),
+                    new Coordinate(41.98082, -87.83433),
+                    new Coordinate(41.98116, -87.83493)
+                ),
+                new LinearRing(
+                    new Coordinate(41.69896, -87.69615),
+                    new Coordinate(41.69161, -87.69589),
+                    new Coordinate(41.69162, -87.69574),
+                    new Coordinate(41.69896, -87.69615)
+                )
+            ),
+            polygon
+        );
+
+        Assert.Equal(2, polygon.Holes.Count);
+    }
+
+    [Fact]
     public void Triangle()
     {
         var reader = new WktReader();


### PR DESCRIPTION
## Summary

Two long-standing issues reported that the Chicago city boundary — a polygon with interior rings (holes) — failed to parse:

- **#30**: `WktReader.Read` threw `"Invalid WKT String"` on the WKT form.
- **#31**: `GeoJsonReader.Read` threw `"Invalid GeoJSON String"` on the GeoJSON form.

Both turned out to be the **same underlying problem** — parsing a polygon with multiple interior rings — surfacing through two different readers of the same vintage. Both readers already handle holes correctly in the current codebase, so **no library change is needed**; the gap was purely missing test coverage. Verified against the reporters' actual Chicago data: the WKT parses to a `Polygon` with the exterior ring plus 2 holes, and the GeoJSON (as valid double-quoted JSON) parses to a `Polygon` with 3 holes.

This PR adds regression tests so the fix can't silently regress.

## Changes

- **`Geo.Tests/IO/Wkt/WktReaderTests.cs`** — new `Polygon_with_holes` test reading a Chicago-style `POLYGON` with an exterior ring and two holes, asserting full geometry equality and hole count (#30).
- **`Geo.Tests/IO/GeoJson/GeoJsonTests.cs`** — new `Polygon_with_holes` test reading the equivalent GeoJSON `Polygon` with holes, asserting the same (#31).

Both existing `Polygon` tests only covered single-ring polygons; these fill that gap.

## Notes on #31

The example in #31 used single-quoted JSON, which is invalid JSON and would fail regardless. The reporter's real code used valid double-quoted JSON, where the failure was the same hole-parsing issue as #30. The test uses valid double-quoted JSON accordingly.

## Testing

- `dotnet test Geo.Tests/Geo.Tests.csproj` — WKT and GeoJSON reader suites pass.
- `dotnet csharpier check .` — clean.

Closes #30
Closes #31