### PR TITLE
Document coordinate frame of geomagnetism result components

### DIFF
--- a/Geo/Geomagnetism/GeomagnetismResult.cs
+++ b/Geo/Geomagnetism/GeomagnetismResult.cs
@@ -25,12 +25,51 @@ public class GeomagnetismResult
     public CoordinateZ Coordinate { get; }
     public DateTime Date { get; }
 
+    /// <summary>
+    /// The northerly intensity of the magnetic field, in nanoteslas.
+    /// This is the north component of the NED (North, East, Down) geodetic
+    /// reference frame used by the World Magnetic Model. To convert to an
+    /// ENU (East, North, Up) frame, use (East, North, Up) = (<see cref="Y" />,
+    /// <see cref="X" />, -<see cref="Z" />).
+    /// </summary>
     public double X { get; }
+
+    /// <summary>
+    /// The easterly intensity of the magnetic field, in nanoteslas.
+    /// This is the east component of the NED (North, East, Down) geodetic
+    /// reference frame used by the World Magnetic Model.
+    /// </summary>
     public double Y { get; }
+
+    /// <summary>
+    /// The vertical (downward) intensity of the magnetic field, in nanoteslas.
+    /// This is the down component of the NED (North, East, Down) geodetic
+    /// reference frame used by the World Magnetic Model, so positive values
+    /// point towards the centre of the Earth.
+    /// </summary>
     public double Z { get; }
+
+    /// <summary>
+    /// The magnetic declination (D) in degrees: the angle between magnetic
+    /// north and true (geographic) north, measured positive eastwards.
+    /// </summary>
     public double Declination { get; }
+
+    /// <summary>
+    /// The magnetic inclination (I), or dip angle, in degrees: the angle
+    /// between the horizontal plane and the magnetic field vector, measured
+    /// positive downwards.
+    /// </summary>
     public double Inclination { get; }
+
+    /// <summary>
+    /// The total intensity (F) of the magnetic field, in nanoteslas.
+    /// </summary>
     public double TotalIntensity { get; }
+
+    /// <summary>
+    /// The horizontal intensity (H) of the magnetic field, in nanoteslas.
+    /// </summary>
     public double HorizontalIntensity { get; }
 
     public override string ToString()


### PR DESCRIPTION
Add XML doc comments to GeomagnetismResult clarifying that the X, Y, Z
magnetic field components are expressed in the NED (North, East, Down)
geodetic reference frame used by the World Magnetic Model, including a
note on converting to an ENU frame. Also document the derived
declination, inclination, and intensity properties.

Addresses #52.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LiG2WGwg4RuVER1A5RuPMV