### PR TITLE
Document geomagnetism component coordinate frame in guide

### DIFF
--- a/docs/geomagnetism.md
+++ b/docs/geomagnetism.md
@@ -42,7 +42,23 @@ one for the date you pass.
 | `Inclination` | Dip angle, in degrees |
 | `TotalIntensity` | Total field strength, in nanoteslas |
 | `HorizontalIntensity` | Horizontal field strength, in nanoteslas |
-| `X`, `Y`, `Z` | North, east, and vertical field components |
+| `X`, `Y`, `Z` | North, east, and downward field components (see below) |
+
+### Component coordinate frame
+
+`X`, `Y`, and `Z` are given in the **NED (North, East, Down)** geodetic
+reference frame used by the World Magnetic Model — `X` points north, `Y`
+points east, and `Z` points down (positive towards the centre of the Earth),
+all in nanoteslas.
+
+If you are working with device sensors that use an **ENU (East, North, Up)**
+frame (as Android and iOS do), convert with:
+
+```csharp
+double east = result.Y;
+double north = result.X;
+double up = -result.Z;
+```
 
 There are also `out`-parameter overloads that return a `bool` indicating
 success:

--- a/docs/geomagnetism.md
+++ b/docs/geomagnetism.md
@@ -55,6 +55,9 @@ If you are working with device sensors that use an **ENU (East, North, Up)**
 frame (as Android and iOS do), convert with:
 
 ```csharp
+var result = new WmmGeomagnetismCalculator()
+    .TryCalculate(london, new DateTime(2020, 1, 1));
+
 double east = result.Y;
 double north = result.X;
 double up = -result.Z;


### PR DESCRIPTION
## Summary

Follow-up to #52. The [`GeomagnetismResult`](Geo/Geomagnetism/GeomagnetismResult.cs) XML docs were clarified to state the NED frame in #87; this applies the same clarification to the user-facing guide, which still only described `X`/`Y`/`Z` as "North, east, and vertical field components" without naming the coordinate frame.

## Changes

`docs/geomagnetism.md`:
- Updated the result table so `X`/`Y`/`Z` read as "North, east, and **downward** field components".
- Added a **"Component coordinate frame"** section spelling out that the components are in the **NED (North, East, Down)** frame used by the World Magnetic Model (X = north, Y = east, Z = down, in nanoteslas).
- Added an **ENU (East, North, Up)** conversion snippet for users working with Android/iOS device sensors — the exact scenario raised in #52.

## Notes

Docs-only change; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiG2WGwg4RuVER1A5RuPMV)_