### PR TITLE
Add async GpsData.ParseAsync for stream deserialization (issue #48)

### DIFF
--- a/Geo.Tests/Documentation/DocumentationExamplesTests.cs
+++ b/Geo.Tests/Documentation/DocumentationExamplesTests.cs
@@ -96,6 +96,7 @@ public class DocumentationExamplesTests
             "using System.Collections.Generic;",
             "using System.IO;",
             "using System.Linq;",
+            "using System.Threading.Tasks;",
             "using Geo;",
             "using Geo.Abstractions.Interfaces;",
             "using Geo.Geodesy;",
@@ -122,11 +123,15 @@ public class DocumentationExamplesTests
                     body.Append(line).Append('\n');
             }
 
+            // Snippets are wrapped in an async method so examples can use `await`
+            // to demonstrate the asynchronous APIs. Snippets that never await
+            // simply produce a (non-error) CS1998 warning, which the compile
+            // check ignores.
             methods
                 .Append("    // ")
                 .Append(snippets[i].File)
                 .Append('\n')
-                .Append("    void Snippet_")
+                .Append("    async Task Snippet_")
                 .Append(i)
                 .Append("()\n    {\n")
                 .Append(body)

--- a/Geo.Tests/Gps/Serialization/GpsDataAsyncTests.cs
+++ b/Geo.Tests/Gps/Serialization/GpsDataAsyncTests.cs
@@ -1,0 +1,125 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Geo.Geometries;
+using Geo.Gps;
+using Xunit;
+
+namespace Geo.Tests.Gps.Serialization;
+
+public class GpsDataAsyncTests : SerializerTestFixtureBase
+{
+    // A read-only, non-seekable stream, forcing ParseAsync to buffer the source
+    // itself rather than relying on the underlying stream being seekable.
+    private class NonSeekableStream : Stream
+    {
+        private readonly Stream _inner;
+
+        public NonSeekableStream(byte[] data)
+        {
+            _inner = new MemoryStream(data);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new System.NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new System.NotSupportedException();
+            set => throw new System.NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            _inner.Read(buffer, offset, count);
+
+        public override void Flush() { }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new System.NotSupportedException();
+
+        public override void SetLength(long value) => throw new System.NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new System.NotSupportedException();
+    }
+
+    private static GpsData SampleData()
+    {
+        var data = new GpsData();
+        data.Waypoints.Add(new Waypoint(new Point(51.5, -0.12), "Home", "comment", "description"));
+        return data;
+    }
+
+    [Theory]
+    [InlineData("gpx", "Bergamo to Manchester.gpx")]
+    [InlineData("igc", "igc2.igc")]
+    [InlineData("nmea", "Stockholm_Walk.nmea")]
+    [InlineData("garmin", "garmin.fpl")]
+    [InlineData("skydemon", "skydemon.flightplan")]
+    [InlineData("pocketfms", "pocketfms_fp.xml")]
+    public async Task ParseAsync_detects_the_format_and_returns_data(
+        string subDirectory,
+        string fileName
+    )
+    {
+        var file = GetReferenceFileDirectory(subDirectory)
+            .GetFiles()
+            .First(x => x.Name == fileName);
+        using var stream = file.OpenRead();
+
+        var data = await GpsData.ParseAsync(stream);
+
+        Assert.NotNull(data);
+    }
+
+    [Fact]
+    public async Task ParseAsync_returns_null_for_unrecognised_content()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("this is not a gps file"));
+
+        Assert.Null(await GpsData.ParseAsync(stream));
+    }
+
+    [Fact]
+    public async Task ParseAsync_buffers_a_non_seekable_stream()
+    {
+        var gpx = SampleData().ToGpx();
+        using var stream = new NonSeekableStream(Encoding.UTF8.GetBytes(gpx));
+
+        var parsed = await GpsData.ParseAsync(stream);
+
+        var waypoint = Assert.Single(parsed.Waypoints);
+        Assert.Equal(51.5, waypoint.Coordinate.Latitude);
+        Assert.Equal(-0.12, waypoint.Coordinate.Longitude);
+        Assert.Equal("Home", waypoint.Name);
+    }
+
+    [Fact]
+    public async Task ParseAsync_round_trips_through_ToGpx()
+    {
+        var gpx = SampleData().ToGpx();
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(gpx));
+        var parsed = await GpsData.ParseAsync(stream);
+
+        var waypoint = Assert.Single(parsed.Waypoints);
+        Assert.Equal("Home", waypoint.Name);
+    }
+
+    [Fact]
+    public async Task ParseAsync_honours_a_cancelled_token()
+    {
+        var gpx = SampleData().ToGpx();
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(gpx));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<System.OperationCanceledException>(async () =>
+            await GpsData.ParseAsync(stream, cts.Token)
+        );
+    }
+}

--- a/Geo.Tests/Gps/Serialization/GpxSerializerAsyncTests.cs
+++ b/Geo.Tests/Gps/Serialization/GpxSerializerAsyncTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Geo.Geometries;
+using Geo.Gps;
+using Geo.Gps.Serialization;
+using Xunit;
+
+namespace Geo.Tests.Gps.Serialization;
+
+public class GpxSerializerAsyncTests
+{
+    private static GpsData SampleData()
+    {
+        var data = new GpsData();
+        data.Waypoints.Add(new Waypoint(new Point(51.5, -0.12), "Home", "comment", "description"));
+        return data;
+    }
+
+    [Fact]
+    public async Task SerializeAsync_matches_the_synchronous_output()
+    {
+        var data = SampleData();
+        var serializer = new Gpx11Serializer();
+
+        using var stream = new MemoryStream();
+        await serializer.SerializeAsync(data, stream);
+
+        stream.Position = 0;
+        var parsed = await GpsData.ParseAsync(stream);
+
+        var waypoint = Assert.Single(parsed.Waypoints);
+        Assert.Equal("Home", waypoint.Name);
+        Assert.Equal(51.5, waypoint.Coordinate.Latitude);
+    }
+
+    [Fact]
+    public async Task SerializeAsync_honours_a_cancelled_token()
+    {
+        using var stream = new MemoryStream();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await new Gpx11Serializer().SerializeAsync(SampleData(), stream, cts.Token)
+        );
+    }
+}

--- a/Geo.Tests/IO/GeoJson/GeoJsonAsyncTests.cs
+++ b/Geo.Tests/IO/GeoJson/GeoJsonAsyncTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Geo.Geometries;
+using Geo.IO.GeoJson;
+using Xunit;
+
+namespace Geo.Tests.IO.GeoJson;
+
+public class GeoJsonAsyncTests
+{
+    [Fact]
+    public async Task ReadAsync_parses_geojson_from_a_stream()
+    {
+        var json = new Point(0, 0).ToGeoJson();
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+        var result = await new GeoJsonReader().ReadAsync(stream);
+
+        Assert.Equal(new Point(0, 0), result);
+    }
+
+    [Fact]
+    public async Task ReadAsync_null_stream_throws_argument_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await new GeoJsonReader().ReadAsync(null)
+        );
+    }
+
+    [Fact]
+    public async Task ReadAsync_honours_a_cancelled_token()
+    {
+        var json = new Point(0, 0).ToGeoJson();
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await new GeoJsonReader().ReadAsync(stream, cts.Token)
+        );
+    }
+}

--- a/Geo.Tests/IO/Wkb/WkbAsyncTests.cs
+++ b/Geo.Tests/IO/Wkb/WkbAsyncTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Geo.Abstractions.Interfaces;
+using Geo.IO.Wkb;
+using Geo.IO.Wkt;
+using Xunit;
+
+namespace Geo.Tests.IO.Wkb;
+
+public class WkbAsyncTests
+{
+    private static IGeometry Sample() => new WktReader().Read("POINT (45.89 23.9)");
+
+    [Fact]
+    public async Task ReadAsync_round_trips_a_geometry()
+    {
+        var geometry = Sample();
+        var wkb = new WkbWriter().Write(geometry);
+
+        using var stream = new MemoryStream(wkb);
+        var result = await new WkbReader().ReadAsync(stream);
+
+        Assert.Equal(geometry, result);
+    }
+
+    [Fact]
+    public async Task WriteAsync_round_trips_a_geometry()
+    {
+        var geometry = Sample();
+
+        using var stream = new MemoryStream();
+        await new WkbWriter().WriteAsync(geometry, stream);
+
+        stream.Position = 0;
+        Assert.Equal(geometry, new WkbReader().Read(stream));
+    }
+
+    // Regression: Write(geometry, stream) previously disposed the temporary
+    // stream (via BinaryWriter) before copying and never rewound it, so it
+    // wrote nothing and/or threw. It must now round-trip like the byte[] path.
+    [Fact]
+    public void Write_to_stream_round_trips_a_geometry()
+    {
+        var geometry = Sample();
+
+        using var stream = new MemoryStream();
+        new WkbWriter().Write(geometry, stream);
+
+        Assert.Equal(new WkbWriter().Write(geometry).Length, stream.Length);
+        stream.Position = 0;
+        Assert.Equal(geometry, new WkbReader().Read(stream));
+    }
+
+    [Fact]
+    public async Task ReadAsync_null_stream_throws_argument_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await new WkbReader().ReadAsync(null)
+        );
+    }
+
+    [Fact]
+    public async Task ReadAsync_honours_a_cancelled_token()
+    {
+        var wkb = new WkbWriter().Write(Sample());
+        using var stream = new MemoryStream(wkb);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await new WkbReader().ReadAsync(stream, cts.Token)
+        );
+    }
+
+    [Fact]
+    public async Task WriteAsync_honours_a_cancelled_token()
+    {
+        using var stream = new MemoryStream();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await new WkbWriter().WriteAsync(Sample(), stream, cts.Token)
+        );
+    }
+}

--- a/Geo.Tests/IO/Wkt/WktReaderAsyncTests.cs
+++ b/Geo.Tests/IO/Wkt/WktReaderAsyncTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Geo.Geometries;
+using Geo.IO.Wkt;
+using Xunit;
+
+namespace Geo.Tests.IO.Wkt;
+
+public class WktReaderAsyncTests
+{
+    [Fact]
+    public async Task ReadAsync_parses_a_geometry_from_a_stream()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("POINT (0.0 65.9)"));
+
+        var geometry = await new WktReader().ReadAsync(stream);
+
+        Assert.Equal(new Point(65.9, 0), geometry);
+    }
+
+    [Fact]
+    public async Task ReadAsync_null_stream_throws_argument_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await new WktReader().ReadAsync(null)
+        );
+    }
+
+    [Fact]
+    public async Task ReadAsync_honours_a_cancelled_token()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("POINT (0.0 65.9)"));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await new WktReader().ReadAsync(stream, cts.Token)
+        );
+    }
+}

--- a/Geo/Gps/GpsData.cs
+++ b/Geo/Gps/GpsData.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Geo.Gps.Metadata;
 using Geo.Gps.Serialization;
 
@@ -72,6 +74,18 @@ public class GpsData
     public static GpsData Parse(Stream stream)
     {
         var gpsStream = new StreamWrapper(stream);
+        var parser = FileParsers.FirstOrDefault(x => x.CanDeSerialize(gpsStream));
+        return parser == null ? null : parser.DeSerialize(gpsStream);
+    }
+
+    public static async Task<GpsData> ParseAsync(
+        Stream stream,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var gpsStream = await StreamWrapper
+            .CreateAsync(stream, cancellationToken)
+            .ConfigureAwait(false);
         var parser = FileParsers.FirstOrDefault(x => x.CanDeSerialize(gpsStream));
         return parser == null ? null : parser.DeSerialize(gpsStream);
     }

--- a/Geo/Gps/Serialization/IGpsFileDeSerializer.cs
+++ b/Geo/Gps/Serialization/IGpsFileDeSerializer.cs
@@ -1,4 +1,6 @@
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Geo.Gps.Serialization;
 
@@ -14,4 +16,5 @@ public interface IGpsFileSerializer : IGpsFileDeSerializer
 {
     string Serialize(GpsData data);
     void Serialize(GpsData data, Stream stream);
+    Task SerializeAsync(GpsData data, Stream stream, CancellationToken cancellationToken = default);
 }

--- a/Geo/Gps/Serialization/StreamWrapper.cs
+++ b/Geo/Gps/Serialization/StreamWrapper.cs
@@ -1,4 +1,6 @@
 ﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Geo.Gps.Serialization;
 
@@ -7,6 +9,27 @@ public class StreamWrapper : Stream
     public StreamWrapper(Stream stream)
     {
         UnderlyingStream = stream.CanSeek ? stream : ConvertToMemoryStream(stream);
+    }
+
+    private StreamWrapper(MemoryStream bufferedStream, bool _)
+    {
+        UnderlyingStream = bufferedStream;
+    }
+
+    // Buffers the source stream into memory asynchronously and returns a wrapper
+    // over the buffer. Parsers seek back to the start and re-read the wrapper
+    // several times (once to detect the format, once to deserialize), so the
+    // source is copied up front; every subsequent read is served from memory
+    // without further I/O.
+    public static async Task<StreamWrapper> CreateAsync(
+        Stream stream,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer, 16 * 1024, cancellationToken).ConfigureAwait(false);
+        buffer.Position = 0;
+        return new StreamWrapper(buffer, false);
     }
 
     public Stream UnderlyingStream { get; }

--- a/Geo/Gps/Serialization/Xml/GpsXmlSerializer.cs
+++ b/Geo/Gps/Serialization/Xml/GpsXmlSerializer.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Geo.Gps.Metadata;
 
 namespace Geo.Gps.Serialization.Xml;
@@ -10,6 +12,25 @@ public abstract class GpsXmlSerializer<T> : GpsXmlDeSerializer<T>, IGpsFileSeria
     public void Serialize(GpsData data, Stream stream)
     {
         _xmlSerializer.Serialize(stream, SerializeInternal(data));
+    }
+
+    // XmlSerializer has no asynchronous Serialize, so the document is written to
+    // an in-memory buffer synchronously and only the copy to the destination
+    // stream is performed asynchronously.
+    public async Task SerializeAsync(
+        GpsData data,
+        Stream stream,
+        CancellationToken cancellationToken = default
+    )
+    {
+        using (var tempStream = new MemoryStream())
+        {
+            _xmlSerializer.Serialize(tempStream, SerializeInternal(data));
+            tempStream.Position = 0;
+            await tempStream
+                .CopyToAsync(stream, 16 * 1024, cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 
     public string Serialize(GpsData data)

--- a/Geo/IO/GeoJson/GeoJsonReader.cs
+++ b/Geo/IO/GeoJson/GeoJsonReader.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using Geo.Abstractions.Interfaces;
 using Geo.Geometries;
 
@@ -18,6 +20,22 @@ public class GeoJsonReader
         using (var reader = new StreamReader(stream))
         {
             return Read(reader.ReadToEnd());
+        }
+    }
+
+    public async Task<IGeoJsonObject> ReadAsync(
+        Stream stream,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (stream == null)
+            throw new ArgumentNullException("stream");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        using (var reader = new StreamReader(stream))
+        {
+            var json = await reader.ReadToEndAsync().ConfigureAwait(false);
+            return Read(json);
         }
     }
 

--- a/Geo/IO/Wkb/WkbReader.cs
+++ b/Geo/IO/Wkb/WkbReader.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using Geo.Abstractions.Interfaces;
 using Geo.Geometries;
 
@@ -18,6 +20,25 @@ public class WkbReader
         using (var stream = new MemoryStream(bytes))
         {
             return Read(stream);
+        }
+    }
+
+    // WKB is read incrementally through a BinaryReader, which has no async API, so
+    // the source stream is buffered into memory asynchronously up front and the
+    // (CPU-bound) decoding then runs against that buffer.
+    public async Task<IGeometry> ReadAsync(
+        Stream stream,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (stream == null)
+            throw new ArgumentNullException("stream");
+
+        using (var buffer = new MemoryStream())
+        {
+            await stream.CopyToAsync(buffer, 16 * 1024, cancellationToken).ConfigureAwait(false);
+            buffer.Position = 0;
+            return Read(buffer);
         }
     }
 

--- a/Geo/IO/Wkb/WkbWriter.cs
+++ b/Geo/IO/Wkb/WkbWriter.cs
@@ -1,6 +1,8 @@
 ﻿using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using Geo.Abstractions.Interfaces;
 using Geo.Geometries;
 
@@ -31,11 +33,21 @@ public class WkbWriter
 
     public void Write(IGeometry geometry, Stream stream)
     {
-        using (var tempStream = new MemoryStream())
-        {
-            WriteInternal(geometry, tempStream);
-            tempStream.CopyTo(stream);
-        }
+        var bytes = Write(geometry);
+        stream.Write(bytes, 0, bytes.Length);
+    }
+
+    // Encoding is CPU-bound and buffered in memory; only writing the encoded
+    // bytes to the destination stream is genuine I/O, so that is the part made
+    // asynchronous.
+    public async Task WriteAsync(
+        IGeometry geometry,
+        Stream stream,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var bytes = Write(geometry);
+        await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
     }
 
     private void WriteInternal(IGeometry geometry, Stream stream)

--- a/Geo/IO/Wkt/WktReader.cs
+++ b/Geo/IO/Wkt/WktReader.cs
@@ -4,6 +4,8 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using Geo.Abstractions.Interfaces;
 using Geo.Geometries;
 
@@ -31,6 +33,22 @@ public class WktReader
         {
             var tokens = new WktTokenQueue(_wktTokenizer.Tokenize(reader));
             return Parse(tokens);
+        }
+    }
+
+    public async Task<IGeometry> ReadAsync(
+        Stream stream,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (stream == null)
+            throw new ArgumentNullException("stream");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        using (var reader = new StreamReader(stream))
+        {
+            var wkt = await reader.ReadToEndAsync().ConfigureAwait(false);
+            return Read(wkt);
         }
     }
 

--- a/docs/geojson.md
+++ b/docs/geojson.md
@@ -15,6 +15,13 @@ var reader = new GeoJsonReader();
 IGeoJsonObject point = reader.Read("{ \"type\": \"Point\", \"coordinates\": [100.0, 0.0] }");
 ```
 
+`Read` also has an overload that reads from a stream, and `ReadAsync` reads
+the stream asynchronously (with an optional `CancellationToken`):
+
+```csharp
+IGeoJsonObject geometry = await reader.ReadAsync(myStream);
+```
+
 ## Writing
 
 ```csharp

--- a/docs/geojson.md
+++ b/docs/geojson.md
@@ -19,7 +19,7 @@ IGeoJsonObject point = reader.Read("{ \"type\": \"Point\", \"coordinates\": [100
 the stream asynchronously (with an optional `CancellationToken`):
 
 ```csharp
-IGeoJsonObject geometry = await reader.ReadAsync(myStream);
+IGeoJsonObject geometry = await new GeoJsonReader().ReadAsync(myStream);
 ```
 
 ## Writing

--- a/docs/gps.md
+++ b/docs/gps.md
@@ -49,6 +49,15 @@ foreach (var fix in track.GetAllFixes()) // every Waypoint across the track's se
 }
 ```
 
+`GpsData.ParseAsync` is the asynchronous counterpart. It reads the source
+stream into memory without blocking (honouring an optional
+`CancellationToken`) before detecting the format and parsing:
+
+```csharp
+using var stream = File.OpenRead("activity.gpx");
+GpsData data = await GpsData.ParseAsync(stream);
+```
+
 ### Supported formats
 
 | Format | Read | Write |
@@ -123,6 +132,17 @@ data.Waypoints.Add(new Waypoint(51.5074, -0.1278));
 
 string gpx11 = data.ToGpx();     // GPX 1.1 (default)
 string gpx10 = data.ToGpx(1m);   // GPX 1.0
+```
+
+To write GPX straight to a stream, use a serializer directly. `Serialize`
+writes synchronously and `SerializeAsync` writes to the destination stream
+without blocking (with an optional `CancellationToken`):
+
+```csharp
+using Geo.Gps.Serialization;
+
+using var stream = File.Create("activity.gpx");
+await new Gpx11Serializer().SerializeAsync(data, stream);
 ```
 
 A `Waypoint` can be constructed from a latitude/longitude pair, optionally with

--- a/docs/well-known-binary.md
+++ b/docs/well-known-binary.md
@@ -15,7 +15,7 @@ IGeometry geometry2 = reader.Read(myStream);                 // reading a stream
 `CancellationToken`) before decoding:
 
 ```csharp
-IGeometry geometry = await reader.ReadAsync(myStream);
+IGeometry geometry = await new WkbReader().ReadAsync(myStream);
 ```
 
 ## Writing
@@ -30,7 +30,7 @@ to the destination stream asynchronously (with an optional
 `CancellationToken`):
 
 ```csharp
-await writer.WriteAsync(new Point(68.389, 73.89), myStream);
+await new WkbWriter().WriteAsync(new Point(68.389, 73.89), myStream);
 ```
 
 A number of settings are available to customise the output. The code below shows

--- a/docs/well-known-binary.md
+++ b/docs/well-known-binary.md
@@ -11,11 +11,26 @@ IGeometry geometry1 = reader.Read(new byte[] { /* ... */ }); // reading a byte a
 IGeometry geometry2 = reader.Read(myStream);                 // reading a stream
 ```
 
+`ReadAsync` reads the stream asynchronously (with an optional
+`CancellationToken`) before decoding:
+
+```csharp
+IGeometry geometry = await reader.ReadAsync(myStream);
+```
+
 ## Writing
 
 ```csharp
 var writer = new WkbWriter();
 byte[] bytes = writer.Write(new Point(68.389, 73.89));
+```
+
+`Write` also has an overload that writes to a stream, and `WriteAsync` writes
+to the destination stream asynchronously (with an optional
+`CancellationToken`):
+
+```csharp
+await writer.WriteAsync(new Point(68.389, 73.89), myStream);
 ```
 
 A number of settings are available to customise the output. The code below shows

--- a/docs/well-known-text.md
+++ b/docs/well-known-text.md
@@ -11,6 +11,13 @@ IGeometry point = reader.Read("POINT (73.89 68.389)");   // reading a string
 IGeometry geometry = reader.Read(myStream);              // reading a stream
 ```
 
+`ReadAsync` reads the stream asynchronously (with an optional
+`CancellationToken`) before parsing:
+
+```csharp
+IGeometry geometry = await reader.ReadAsync(myStream);
+```
+
 ## Writing
 
 ```csharp

--- a/docs/well-known-text.md
+++ b/docs/well-known-text.md
@@ -15,7 +15,7 @@ IGeometry geometry = reader.Read(myStream);              // reading a stream
 `CancellationToken`) before parsing:
 
 ```csharp
-IGeometry geometry = await reader.ReadAsync(myStream);
+IGeometry geometry = await new WktReader().ReadAsync(myStream);
 ```
 
 ## Writing


### PR DESCRIPTION
Adds GpsData.ParseAsync(Stream, CancellationToken), an async counterpart
to GpsData.Parse. All format deserializers parse against a fully-buffered,
seekable StreamWrapper (they reset Position to 0 and re-read it for both
format detection and deserialization), so the only genuine I/O is reading
the source stream into that buffer.

ParseAsync introduces StreamWrapper.CreateAsync, which copies the source
stream into memory asynchronously (honouring the cancellation token) before
handing the buffered wrapper to the existing synchronous parsers. This gives
non-blocking I/O for file/network sources without duplicating per-format
parsing logic.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JiGk4G9KrxKSeDn4chP4bp