### PR TITLE
Add format-detecting geo string parser (issue #15)

### DIFF
--- a/Geo.Tests/IO/GeoFormatTests.cs
+++ b/Geo.Tests/IO/GeoFormatTests.cs
@@ -1,0 +1,131 @@
+using System;
+using Geo.Geometries;
+using Geo.IO;
+using Xunit;
+
+namespace Geo.Tests.IO;
+
+public class GeoFormatTests
+{
+    [Theory]
+    [InlineData("42.294498, -89.637901")]
+    [InlineData("12.345N 123.456E")]
+    [InlineData("50°03'46.461\"S 125°48'26.533\"E")]
+    [InlineData("(42.294498, -89.637901)")]
+    public void Detect_identifies_coordinate_strings(string input)
+    {
+        Assert.Equal(GeoStringFormat.Coordinate, GeoFormat.Detect(input));
+    }
+
+    [Theory]
+    [InlineData("POINT (30 10)")]
+    [InlineData("LINESTRING (30 10, 10 30, 40 40)")]
+    [InlineData("POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))")]
+    [InlineData("point (30 10)")]
+    public void Detect_identifies_wkt(string input)
+    {
+        Assert.Equal(GeoStringFormat.Wkt, GeoFormat.Detect(input));
+    }
+
+    [Theory]
+    [InlineData("{ \"type\": \"Point\", \"coordinates\": [30, 10] }")]
+    [InlineData(
+        "{ \"type\": \"Feature\", \"geometry\": { \"type\": \"Point\", \"coordinates\": [30, 10] }, \"properties\": {} }"
+    )]
+    public void Detect_identifies_geojson(string input)
+    {
+        Assert.Equal(GeoStringFormat.GeoJson, GeoFormat.Detect(input));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("not a geo string")]
+    [InlineData("{ \"type\": \"Nonsense\" }")]
+    [InlineData("POINT (nope)")]
+    public void Detect_returns_unknown_for_unrecognised_input(string input)
+    {
+        Assert.Equal(GeoStringFormat.Unknown, GeoFormat.Detect(input));
+    }
+
+    [Fact]
+    public void TryParse_returns_coordinate()
+    {
+        var success = GeoFormat.TryParse("42.294498, -89.637901", out var result, out var format);
+
+        Assert.True(success);
+        Assert.Equal(GeoStringFormat.Coordinate, format);
+        var coordinate = Assert.IsType<Coordinate>(result);
+        Assert.Equal(42.294498, coordinate.Latitude);
+        Assert.Equal(-89.637901, coordinate.Longitude);
+    }
+
+    [Fact]
+    public void TryParse_returns_wkt_geometry()
+    {
+        var success = GeoFormat.TryParse("POINT (30 10)", out var result, out var format);
+
+        Assert.True(success);
+        Assert.Equal(GeoStringFormat.Wkt, format);
+        var point = Assert.IsType<Point>(result);
+        Assert.Equal(10, point.Coordinate.Latitude);
+        Assert.Equal(30, point.Coordinate.Longitude);
+    }
+
+    [Fact]
+    public void TryParse_returns_geojson_object()
+    {
+        var success = GeoFormat.TryParse(
+            "{ \"type\": \"Point\", \"coordinates\": [30, 10] }",
+            out var result,
+            out var format
+        );
+
+        Assert.True(success);
+        Assert.Equal(GeoStringFormat.GeoJson, format);
+        var point = Assert.IsType<Point>(result);
+        Assert.Equal(10, point.Coordinate.Latitude);
+        Assert.Equal(30, point.Coordinate.Longitude);
+    }
+
+    [Fact]
+    public void TryParse_returns_false_for_unrecognised_input()
+    {
+        var success = GeoFormat.TryParse("not a geo string", out var result, out var format);
+
+        Assert.False(success);
+        Assert.Null(result);
+        Assert.Equal(GeoStringFormat.Unknown, format);
+    }
+
+    [Fact]
+    public void TryParse_braced_coordinate_falls_back_from_geojson()
+    {
+        // A braced coordinate string starts with '{' like GeoJSON, but is not valid JSON.
+        var success = GeoFormat.TryParse("{42.294498, -89.637901}", out var result, out var format);
+
+        Assert.True(success);
+        Assert.Equal(GeoStringFormat.Coordinate, format);
+        Assert.IsType<Coordinate>(result);
+    }
+
+    [Fact]
+    public void Parse_returns_parsed_value()
+    {
+        var result = GeoFormat.Parse("POINT (30 10)");
+        Assert.IsType<Point>(result);
+    }
+
+    [Fact]
+    public void Parse_null_throws_argument_null_exception()
+    {
+        Assert.Throws<ArgumentNullException>(() => GeoFormat.Parse(null));
+    }
+
+    [Fact]
+    public void Parse_unrecognised_format_throws_format_exception()
+    {
+        Assert.Throws<FormatException>(() => GeoFormat.Parse("not a geo string"));
+    }
+}

--- a/Geo/IO/GeoFormat.cs
+++ b/Geo/IO/GeoFormat.cs
@@ -1,0 +1,177 @@
+using System;
+using Geo.IO.GeoJson;
+using Geo.IO.Wkt;
+
+namespace Geo.IO;
+
+/// <summary>
+/// Detects which textual geospatial format a string is in and parses it, without the
+/// caller having to know the format up front. Supported formats are coordinate strings
+/// (<see cref="Coordinate" />), Well-Known Text (<see cref="WktReader" />) and GeoJSON
+/// (<see cref="GeoJsonReader" />).
+/// </summary>
+public static class GeoFormat
+{
+    /// <summary>
+    /// Detects the format of <paramref name="input" /> without returning the parsed value.
+    /// This performs a full parse attempt, so <see cref="Detect" /> and <see cref="TryParse" />
+    /// always agree on the format.
+    /// </summary>
+    /// <param name="input">The string to inspect.</param>
+    /// <returns>
+    /// The detected <see cref="GeoStringFormat" />, or <see cref="GeoStringFormat.Unknown" />
+    /// if the string matched no supported format.
+    /// </returns>
+    public static GeoStringFormat Detect(string input)
+    {
+        TryParse(input, out _, out var format);
+        return format;
+    }
+
+    /// <summary>
+    /// Detects the format of <paramref name="input" /> and parses it.
+    /// </summary>
+    /// <param name="input">The string to parse.</param>
+    /// <returns>
+    /// The parsed value: a <see cref="Coordinate" />, an
+    /// <see cref="Geo.Abstractions.Interfaces.IGeometry" /> (WKT) or an
+    /// <see cref="Geo.Abstractions.Interfaces.IGeoJsonObject" /> (GeoJSON).
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="input" /> is <c>null</c>.</exception>
+    /// <exception cref="FormatException"><paramref name="input" /> matched no supported format.</exception>
+    public static object Parse(string input)
+    {
+        if (input == null)
+            throw new ArgumentNullException(nameof(input));
+
+        if (!TryParse(input, out var result, out _))
+            throw new FormatException("Value (" + input + ") is not a supported geo format.");
+
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to detect the format of <paramref name="input" /> and parse it.
+    /// </summary>
+    /// <param name="input">The string to parse.</param>
+    /// <param name="result">
+    /// When this method returns <c>true</c>, the parsed value (a <see cref="Coordinate" />, WKT
+    /// <see cref="Geo.Abstractions.Interfaces.IGeometry" /> or GeoJSON
+    /// <see cref="Geo.Abstractions.Interfaces.IGeoJsonObject" />); otherwise <c>null</c>.
+    /// </param>
+    /// <param name="format">
+    /// When this method returns <c>true</c>, the detected format; otherwise
+    /// <see cref="GeoStringFormat.Unknown" />.
+    /// </param>
+    /// <returns><c>true</c> if the string was recognised and parsed; otherwise <c>false</c>.</returns>
+    public static bool TryParse(string input, out object result, out GeoStringFormat format)
+    {
+        result = null;
+        format = GeoStringFormat.Unknown;
+
+        if (string.IsNullOrWhiteSpace(input))
+            return false;
+
+        // Pick a candidate parser from the first meaningful character, then delegate to the
+        // existing reader. A leading brace/bracket can be either GeoJSON or a braced coordinate
+        // string (the coordinate regex allows { [ ( wrappers), so GeoJSON is tried first and
+        // falls back to a coordinate parse. A leading ASCII letter means WKT. Anything else is
+        // treated as a coordinate string.
+        var first = FirstNonWhitespace(input);
+
+        if (first == '{' || first == '[')
+        {
+            if (TryGeoJson(input, out result))
+            {
+                format = GeoStringFormat.GeoJson;
+                return true;
+            }
+
+            if (TryCoordinate(input, out result))
+            {
+                format = GeoStringFormat.Coordinate;
+                return true;
+            }
+
+            return false;
+        }
+
+        if ((first >= 'A' && first <= 'Z') || (first >= 'a' && first <= 'z'))
+        {
+            if (TryWkt(input, out result))
+            {
+                format = GeoStringFormat.Wkt;
+                return true;
+            }
+
+            return false;
+        }
+
+        if (TryCoordinate(input, out result))
+        {
+            format = GeoStringFormat.Coordinate;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static char FirstNonWhitespace(string input)
+    {
+        foreach (var c in input)
+            if (!char.IsWhiteSpace(c))
+                return c;
+        return '\0';
+    }
+
+    private static bool TryCoordinate(string input, out object result)
+    {
+        if (Coordinate.TryParse(input, out var coordinate))
+        {
+            result = coordinate;
+            return true;
+        }
+
+        result = null;
+        return false;
+    }
+
+    private static bool TryWkt(string input, out object result)
+    {
+        try
+        {
+            var geometry = new WktReader().Read(input);
+            if (geometry != null)
+            {
+                result = geometry;
+                return true;
+            }
+        }
+        catch (Exception)
+        {
+            // Not valid WKT; fall through.
+        }
+
+        result = null;
+        return false;
+    }
+
+    private static bool TryGeoJson(string input, out object result)
+    {
+        try
+        {
+            if (new GeoJsonReader().TryRead(input, out var obj) && obj != null)
+            {
+                result = obj;
+                return true;
+            }
+        }
+        catch (Exception)
+        {
+            // Not valid GeoJSON; fall through.
+        }
+
+        result = null;
+        return false;
+    }
+}

--- a/Geo/IO/GeoStringFormat.cs
+++ b/Geo/IO/GeoStringFormat.cs
@@ -1,0 +1,19 @@
+namespace Geo.IO;
+
+/// <summary>
+/// Identifies the textual geospatial format detected by <see cref="GeoFormat" />.
+/// </summary>
+public enum GeoStringFormat
+{
+    /// <summary>The string did not match any supported format.</summary>
+    Unknown = 0,
+
+    /// <summary>A coordinate string, e.g. <c>42.29, -89.63</c> or <c>50°03'46"S 125°48'26"E</c>.</summary>
+    Coordinate = 1,
+
+    /// <summary>A Well-Known Text (WKT) geometry, e.g. <c>POINT (30 10)</c>.</summary>
+    Wkt = 2,
+
+    /// <summary>A GeoJSON object, e.g. <c>{ "type": "Point", "coordinates": [30, 10] }</c>.</summary>
+    GeoJson = 3,
+}

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Coordinates come in four flavours: `Coordinate` (lat/lon), `CoordinateZ`
 | WKB (Well-Known Binary) | ✓ | ✓ |
 | GeoJSON                 | ✓ | ✓ |
 
+Don't know a string's format up front? `GeoFormat.Detect` / `GeoFormat.TryParse`
+sniff whether it is a coordinate pair, WKT, or GeoJSON and parse it — see the
+[parsing guide](docs/parsing.md).
+
 ### Serialize / deserialize GPS files
 
 | Format | Read | Write |

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ example.
 - [Well-Known Text (WKT)](well-known-text.md)
 - [Well-Known Binary (WKB)](well-known-binary.md)
 - [GeoJSON](geojson.md)
+- [Detecting and parsing geo strings](parsing.md)
 
 > These pages were migrated from the project wiki. Pages covering integrations
 > that are no longer part of the library (Spatial4n and RavenDB) were dropped

--- a/docs/coordinate.md
+++ b/docs/coordinate.md
@@ -70,3 +70,6 @@ var coordinate = Coordinate.Parse("12 34.56'N 123 45.55'E");
 var maybe = Coordinate.TryParse("12 34.56'N 123 45.55'E");     // returns null on failure
 if (Coordinate.TryParse("...", out var parsed)) { /* ... */ }
 ```
+
+If you don't know whether a string is a coordinate pair, WKT, or GeoJSON, use
+[`GeoFormat`](parsing.md) to detect the format and parse it in one step.

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -1,0 +1,66 @@
+# Detecting and parsing geo strings
+
+Sometimes you have a geospatial string but don't know its format up front — it
+might be a coordinate pair, Well-Known Text, or GeoJSON. `GeoFormat` (in the
+`Geo.IO` namespace) detects the format and parses the string in one step.
+
+```csharp
+using Geo.IO;
+
+GeoStringFormat format = GeoFormat.Detect("POINT (30 10)");   // GeoStringFormat.Wkt
+```
+
+The supported formats are reported by the `GeoStringFormat` enum:
+
+| Value | Example input |
+|-------|---------------|
+| `GeoStringFormat.Coordinate` | `42.29, -89.63`, `50°03'46"S 125°48'26"E` |
+| `GeoStringFormat.Wkt` | `POINT (30 10)` |
+| `GeoStringFormat.GeoJson` | `{ "type": "Point", "coordinates": [30, 10] }` |
+| `GeoStringFormat.Unknown` | anything unrecognised |
+
+## Parsing
+
+`TryParse` returns both the parsed value and the format it detected:
+
+```csharp
+if (GeoFormat.TryParse(input, out object result, out GeoStringFormat format))
+{
+    switch (format)
+    {
+        case GeoStringFormat.Coordinate:
+            var coordinate = (Coordinate)result;
+            break;
+        case GeoStringFormat.Wkt:
+            var geometry = (Geo.Abstractions.Interfaces.IGeometry)result;
+            break;
+        case GeoStringFormat.GeoJson:
+            var geoJson = (Geo.Abstractions.Interfaces.IGeoJsonObject)result;
+            break;
+    }
+}
+```
+
+The returned type depends on the detected format: a `Coordinate` for a
+coordinate string, an `IGeometry` for WKT, and an `IGeoJsonObject` for GeoJSON.
+
+A throwing variant is also available:
+
+```csharp
+object result = GeoFormat.Parse(input);   // throws FormatException on an unknown format
+```
+
+`Parse` throws `ArgumentNullException` for a `null` input and `FormatException`
+when the string matches no supported format.
+
+## How detection works
+
+`GeoFormat` delegates to the existing [`Coordinate`](coordinate.md) parser,
+[`WktReader`](well-known-text.md), and [`GeoJsonReader`](geojson.md), so it never
+duplicates parsing logic and `Detect` always agrees with `TryParse`. A string
+that begins with `{` could be either GeoJSON or a braced coordinate pair such as
+`{42.29, -89.63}`; GeoFormat tries GeoJSON first and falls back to a coordinate
+parse.
+
+Detection covers textual formats only. Well-Known Binary is binary, not a
+string, so parse it directly with [`WkbReader`](well-known-binary.md).

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -24,6 +24,8 @@ The supported formats are reported by the `GeoStringFormat` enum:
 `TryParse` returns both the parsed value and the format it detected:
 
 ```csharp
+var input = "POINT (30 10)";
+
 if (GeoFormat.TryParse(input, out object result, out GeoStringFormat format))
 {
     switch (format)
@@ -47,6 +49,7 @@ coordinate string, an `IGeometry` for WKT, and an `IGeoJsonObject` for GeoJSON.
 A throwing variant is also available:
 
 ```csharp
+var input = "POINT (30 10)";
 object result = GeoFormat.Parse(input);   // throws FormatException on an unknown format
 ```
 


### PR DESCRIPTION
Introduce GeoFormat, a static sniff-and-parse entry point that takes an
unknown geospatial string, detects its format and parses it without the
caller knowing the format up front. Supported formats are coordinate
strings, Well-Known Text and GeoJSON, reported via the new GeoStringFormat
enum.

- GeoFormat.Detect(string) -> GeoStringFormat
- GeoFormat.TryParse(string, out object, out GeoStringFormat)
- GeoFormat.Parse(string) -> object (throws on unknown/null)

Detection delegates to the existing Coordinate, WktReader and GeoJsonReader
parsers, so there is no duplicated parsing logic and Detect always agrees
with TryParse. A leading brace is disambiguated between GeoJSON and a braced
coordinate string by trying GeoJSON first and falling back to a coordinate
parse.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LThnTYLWY3XaTYjjMYGBdP