### PR TITLE
Enable nullable reference types across the library (incremental)

### DIFF
--- a/Geo.Tests/Geometries/CircleTests.cs
+++ b/Geo.Tests/Geometries/CircleTests.cs
@@ -59,6 +59,14 @@ public class CircleTests
     }
 
     [Fact]
+    public void Empty_circle_has_no_bounds()
+    {
+        Assert.True(new Circle().IsEmpty);
+        Assert.Null(new Circle().GetBounds());
+        Assert.Null(Circle.Empty.GetBounds());
+    }
+
+    [Fact]
     public void GetArea_approximates_pi_r_squared()
     {
         const double radius = 111000;

--- a/Geo.Tests/Geometries/PointTests.cs
+++ b/Geo.Tests/Geometries/PointTests.cs
@@ -52,6 +52,13 @@ public class PointTests
     }
 
     [Fact]
+    public void Empty_point_has_no_bounds()
+    {
+        Assert.Null(new Point().GetBounds());
+        Assert.Null(Point.Empty.GetBounds());
+    }
+
+    [Fact]
     public void Equality_compares_coordinates()
     {
         Assert.True(new Point(1, 2) == new Point(1, 2));

--- a/Geo.Tests/Geometries/PolygonTests.cs
+++ b/Geo.Tests/Geometries/PolygonTests.cs
@@ -35,6 +35,13 @@ public class PolygonTests
     }
 
     [Fact]
+    public void Empty_polygon_has_no_bounds()
+    {
+        Assert.Null(new Polygon().GetBounds());
+        Assert.Null(Polygon.Empty.GetBounds());
+    }
+
+    [Fact]
     public void GetArea_is_positive_for_a_real_polygon()
     {
         var polygon = new Polygon(Square(1));

--- a/Geo/Abstractions/Geometry.cs
+++ b/Geo/Abstractions/Geometry.cs
@@ -1,4 +1,5 @@
-﻿using Geo.Abstractions.Interfaces;
+﻿#nullable enable
+using Geo.Abstractions.Interfaces;
 using Geo.IO.GeoJson;
 using Geo.IO.Wkb;
 using Geo.IO.Wkt;
@@ -7,7 +8,7 @@ namespace Geo.Abstractions;
 
 public abstract class Geometry : SpatialObject, IGeometry
 {
-    public abstract Envelope GetBounds();
+    public abstract Envelope? GetBounds();
     public abstract bool IsEmpty { get; }
     public abstract bool Is3D { get; }
     public abstract bool IsMeasured { get; }

--- a/Geo/Abstractions/Interfaces/IGeoJsonObject.cs
+++ b/Geo/Abstractions/Interfaces/IGeoJsonObject.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Geo.Abstractions.Interfaces;
 
 public interface IGeoJsonObject

--- a/Geo/Abstractions/Interfaces/IGeodeticCalculator.cs
+++ b/Geo/Abstractions/Interfaces/IGeodeticCalculator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Geo.Geodesy;
 using Geo.Geometries;
 using Geo.Measure;
@@ -7,8 +8,8 @@ namespace Geo.Abstractions.Interfaces;
 public interface IGeodeticCalculator
 {
     GeodeticLine CalculateOrthodromicLine(IPosition point, double heading, double distance);
-    GeodeticLine CalculateOrthodromicLine(IPosition point1, IPosition point2);
-    GeodeticLine CalculateLoxodromicLine(IPosition point1, IPosition point2);
+    GeodeticLine? CalculateOrthodromicLine(IPosition point1, IPosition point2);
+    GeodeticLine? CalculateLoxodromicLine(IPosition point1, IPosition point2);
 
     Distance CalculateLength(Circle circle);
     Distance CalculateLength(CoordinateSequence coordinates);

--- a/Geo/Abstractions/Interfaces/IGeometry.cs
+++ b/Geo/Abstractions/Interfaces/IGeometry.cs
@@ -1,4 +1,5 @@
-﻿using Geo.IO.Wkb;
+﻿#nullable enable
+using Geo.IO.Wkb;
 using Geo.IO.Wkt;
 
 namespace Geo.Abstractions.Interfaces;
@@ -8,7 +9,7 @@ public interface IGeometry : ISpatialEquatable, IGeoJsonObject
     bool IsEmpty { get; }
     bool Is3D { get; }
     bool IsMeasured { get; }
-    Envelope GetBounds();
+    Envelope? GetBounds();
 
     string ToWktString();
     string ToWktString(WktWriterSettings settings);

--- a/Geo/Abstractions/Interfaces/IHasArea.cs
+++ b/Geo/Abstractions/Interfaces/IHasArea.cs
@@ -1,4 +1,5 @@
-﻿using Geo.Measure;
+﻿#nullable enable
+using Geo.Measure;
 
 namespace Geo.Abstractions.Interfaces;
 

--- a/Geo/Abstractions/Interfaces/IHasLength.cs
+++ b/Geo/Abstractions/Interfaces/IHasLength.cs
@@ -1,4 +1,5 @@
-﻿using Geo.Measure;
+﻿#nullable enable
+using Geo.Measure;
 
 namespace Geo.Abstractions.Interfaces;
 

--- a/Geo/Abstractions/Interfaces/IMeasure.cs
+++ b/Geo/Abstractions/Interfaces/IMeasure.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Geo.Abstractions.Interfaces;
 
 public interface IMeasure

--- a/Geo/Abstractions/Interfaces/IPosition.cs
+++ b/Geo/Abstractions/Interfaces/IPosition.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Geo.Abstractions.Interfaces;
 
 public interface IPosition

--- a/Geo/Abstractions/Interfaces/ISpatialEquatable.cs
+++ b/Geo/Abstractions/Interfaces/ISpatialEquatable.cs
@@ -1,9 +1,10 @@
-﻿namespace Geo.Abstractions.Interfaces;
+﻿#nullable enable
+namespace Geo.Abstractions.Interfaces;
 
 public interface ISpatialEquatable
 {
-    bool Equals(object obj, SpatialEqualityOptions options);
-    bool Equals2D(object obj);
-    bool Equals3D(object obj);
+    bool Equals(object? obj, SpatialEqualityOptions options);
+    bool Equals2D(object? obj);
+    bool Equals3D(object? obj);
     int GetHashCode(SpatialEqualityOptions options);
 }

--- a/Geo/Abstractions/Interfaces/Is3D.cs
+++ b/Geo/Abstractions/Interfaces/Is3D.cs
@@ -1,4 +1,5 @@
-﻿namespace Geo.Abstractions.Interfaces;
+﻿#nullable enable
+namespace Geo.Abstractions.Interfaces;
 
 public interface Is3D
 {

--- a/Geo/Abstractions/Interfaces/IsMeasured.cs
+++ b/Geo/Abstractions/Interfaces/IsMeasured.cs
@@ -1,4 +1,5 @@
-﻿namespace Geo.Abstractions.Interfaces;
+﻿#nullable enable
+namespace Geo.Abstractions.Interfaces;
 
 public interface IsMeasured
 {

--- a/Geo/Abstractions/SpatialObject.cs
+++ b/Geo/Abstractions/SpatialObject.cs
@@ -1,19 +1,20 @@
-﻿using Geo.Abstractions.Interfaces;
+﻿#nullable enable
+using Geo.Abstractions.Interfaces;
 
 namespace Geo.Abstractions;
 
 public abstract class SpatialObject : ISpatialEquatable
 {
-    public abstract bool Equals(object obj, SpatialEqualityOptions options);
+    public abstract bool Equals(object? obj, SpatialEqualityOptions options);
 
     public abstract int GetHashCode(SpatialEqualityOptions options);
 
-    public bool Equals2D(object obj)
+    public bool Equals2D(object? obj)
     {
         return Equals(obj, GeoContext.Current.EqualityOptions.To2D());
     }
 
-    public bool Equals3D(object obj)
+    public bool Equals3D(object? obj)
     {
         return Equals(obj, GeoContext.Current.EqualityOptions.To3D());
     }
@@ -23,12 +24,12 @@ public abstract class SpatialObject : ISpatialEquatable
         return GetHashCode(GeoContext.Current.EqualityOptions);
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return Equals(obj, GeoContext.Current.EqualityOptions);
     }
 
-    public static bool Equals(object obj1, object obj2, SpatialEqualityOptions options)
+    public static bool Equals(object? obj1, object? obj2, SpatialEqualityOptions options)
     {
         var spatialObj = obj1 as ISpatialEquatable;
         if (!ReferenceEquals(null, spatialObj))
@@ -37,12 +38,12 @@ public abstract class SpatialObject : ISpatialEquatable
         return Equals(obj1, obj2);
     }
 
-    public static bool Equals2D(object obj1, object obj2)
+    public static bool Equals2D(object? obj1, object? obj2)
     {
         return Equals(obj1, obj2, GeoContext.Current.EqualityOptions.To2D());
     }
 
-    public static bool Equals3D(object obj1, object obj2)
+    public static bool Equals3D(object? obj1, object? obj2)
     {
         return Equals(obj1, obj2, GeoContext.Current.EqualityOptions.To3D());
     }

--- a/Geo/Abstractions/SpatialReadOnlyCollection.cs
+++ b/Geo/Abstractions/SpatialReadOnlyCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Geo.Abstractions.Interfaces;
@@ -13,7 +14,7 @@ public class SpatialReadOnlyCollection<TElement> : ReadOnlyCollection<TElement>,
 
     public bool IsEmpty => Count == 0;
 
-    public bool Equals(object obj, SpatialEqualityOptions options)
+    public bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as SpatialReadOnlyCollection<TElement>;
 
@@ -32,12 +33,12 @@ public class SpatialReadOnlyCollection<TElement> : ReadOnlyCollection<TElement>,
             .Aggregate(0, (current, result) => (current * 397) ^ result);
     }
 
-    public bool Equals2D(object obj)
+    public bool Equals2D(object? obj)
     {
         return Equals(obj, GeoContext.Current.EqualityOptions.To2D());
     }
 
-    public bool Equals3D(object obj)
+    public bool Equals3D(object? obj)
     {
         return Equals(obj, GeoContext.Current.EqualityOptions.To3D());
     }
@@ -47,12 +48,12 @@ public class SpatialReadOnlyCollection<TElement> : ReadOnlyCollection<TElement>,
         return GetHashCode(GeoContext.Current.EqualityOptions);
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return Equals(obj, GeoContext.Current.EqualityOptions);
     }
 
-    public static bool Equals(object obj1, object obj2, SpatialEqualityOptions options)
+    public static bool Equals(object? obj1, object? obj2, SpatialEqualityOptions options)
     {
         var spatialObj = obj1 as ISpatialEquatable;
         if (!ReferenceEquals(null, spatialObj))

--- a/Geo/Constants.cs
+++ b/Geo/Constants.cs
@@ -1,4 +1,5 @@
-﻿namespace Geo;
+﻿#nullable enable
+namespace Geo;
 
 internal class Constants
 {

--- a/Geo/Coordinate.cs
+++ b/Geo/Coordinate.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Geo.Abstractions;
@@ -68,21 +70,19 @@ public class Coordinate : SpatialObject, IPosition
         if (string.IsNullOrWhiteSpace(coordinate))
             throw new ArgumentException("Value was empty", "coordinate");
 
-        Coordinate result;
-        if (!TryParse(coordinate, out result))
+        if (!TryParse(coordinate, out var result))
             throw new FormatException("Coordinate (" + coordinate + ") is not a supported format.");
 
         return result;
     }
 
-    public static Coordinate TryParse(string coordinate)
+    public static Coordinate? TryParse(string coordinate)
     {
-        Coordinate result;
-        TryParse(coordinate, out result);
+        TryParse(coordinate, out var result);
         return result;
     }
 
-    public static bool TryParse(string coordinate, out Coordinate result)
+    public static bool TryParse(string coordinate, [NotNullWhen(true)] out Coordinate? result)
     {
         var match = Regex.Match(coordinate, CoordinateRegex);
 
@@ -132,7 +132,7 @@ public class Coordinate : SpatialObject, IPosition
 
     #region Equality methods
 
-    public override bool Equals(object obj, SpatialEqualityOptions options)
+    public override bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as Coordinate;
 
@@ -161,7 +161,7 @@ public class Coordinate : SpatialObject, IPosition
         return false;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return Equals(obj, GeoContext.Current.EqualityOptions);
     }
@@ -189,14 +189,14 @@ public class Coordinate : SpatialObject, IPosition
         }
     }
 
-    public static bool operator ==(Coordinate left, Coordinate right)
+    public static bool operator ==(Coordinate? left, Coordinate? right)
     {
         if (ReferenceEquals(left, null) && ReferenceEquals(right, null))
             return true;
         return !ReferenceEquals(left, null) && !ReferenceEquals(right, null) && left.Equals(right);
     }
 
-    public static bool operator !=(Coordinate left, Coordinate right)
+    public static bool operator !=(Coordinate? left, Coordinate? right)
     {
         return !(left == right);
     }

--- a/Geo/CoordinateM.cs
+++ b/Geo/CoordinateM.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using Geo.Abstractions.Interfaces;
 
 namespace Geo;
@@ -20,7 +21,7 @@ public class CoordinateM : Coordinate, IsMeasured
 
     #region Equality methods
 
-    public override bool Equals(object obj, SpatialEqualityOptions options)
+    public override bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as Coordinate;
 
@@ -53,7 +54,7 @@ public class CoordinateM : Coordinate, IsMeasured
         return false;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return Equals(obj, GeoContext.Current.EqualityOptions);
     }

--- a/Geo/CoordinateSequence.cs
+++ b/Geo/CoordinateSequence.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions;
 
@@ -27,7 +28,7 @@ public class CoordinateSequence : SpatialReadOnlyCollection<Coordinate>
 
     public bool IsClosed => Count > 2 && this[0].Equals(this[Count - 1]);
 
-    public Envelope GetBounds()
+    public Envelope? GetBounds()
     {
         return IsEmpty
             ? null
@@ -41,7 +42,7 @@ public class CoordinateSequence : SpatialReadOnlyCollection<Coordinate>
 
     public IEnumerable<LineSegment> ToLineSegments()
     {
-        Coordinate last = null;
+        Coordinate? last = null;
         foreach (var coordinate in this)
         {
             if (last != null)
@@ -52,7 +53,7 @@ public class CoordinateSequence : SpatialReadOnlyCollection<Coordinate>
 
     #region Equality methods
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return base.Equals(obj);
     }
@@ -62,14 +63,14 @@ public class CoordinateSequence : SpatialReadOnlyCollection<Coordinate>
         return base.GetHashCode();
     }
 
-    public static bool operator ==(CoordinateSequence left, CoordinateSequence right)
+    public static bool operator ==(CoordinateSequence? left, CoordinateSequence? right)
     {
         if (ReferenceEquals(left, null) && ReferenceEquals(right, null))
             return true;
         return !ReferenceEquals(left, null) && !ReferenceEquals(right, null) && left.Equals(right);
     }
 
-    public static bool operator !=(CoordinateSequence left, CoordinateSequence right)
+    public static bool operator !=(CoordinateSequence? left, CoordinateSequence? right)
     {
         return !(left == right);
     }

--- a/Geo/CoordinateZ.cs
+++ b/Geo/CoordinateZ.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using Geo.Abstractions.Interfaces;
 
 namespace Geo;
@@ -20,7 +21,7 @@ public class CoordinateZ : Coordinate, Is3D
 
     #region Equality methods
 
-    public override bool Equals(object obj, SpatialEqualityOptions options)
+    public override bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as Coordinate;
 
@@ -53,7 +54,7 @@ public class CoordinateZ : Coordinate, Is3D
         return false;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return Equals(obj, GeoContext.Current.EqualityOptions);
     }

--- a/Geo/CoordinateZM.cs
+++ b/Geo/CoordinateZM.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using Geo.Abstractions.Interfaces;
 
 namespace Geo;
@@ -27,7 +28,7 @@ public class CoordinateZM : Coordinate, Is3D, IsMeasured
 
     #region Equality methods
 
-    public override bool Equals(object obj, SpatialEqualityOptions options)
+    public override bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as Coordinate;
 
@@ -63,7 +64,7 @@ public class CoordinateZM : Coordinate, Is3D, IsMeasured
         return false;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return Equals(obj, GeoContext.Current.EqualityOptions);
     }

--- a/Geo/Envelope.cs
+++ b/Geo/Envelope.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions.Interfaces;
@@ -31,7 +32,7 @@ public class Envelope : IHasArea, IHasLength, IEquatable<Envelope>
         return GeoContext.Current.GeodeticCalculator.CalculateLength(this);
     }
 
-    public Envelope Combine(Envelope other)
+    public Envelope Combine(Envelope? other)
     {
         if (other == null)
             return this;
@@ -50,7 +51,7 @@ public class Envelope : IHasArea, IHasLength, IEquatable<Envelope>
             || GetExtremeCoordinates().Any(envelope.Contains);
     }
 
-    public bool Contains(Envelope envelope)
+    public bool Contains(Envelope? envelope)
     {
         return envelope != null
             && envelope.MinLat > MinLat
@@ -67,7 +68,7 @@ public class Envelope : IHasArea, IHasLength, IEquatable<Envelope>
             && coordinate.Longitude < MaxLon;
     }
 
-    public bool Contains(IGeometry geometry)
+    public bool Contains(IGeometry? geometry)
     {
         return geometry != null && Contains(geometry.GetBounds());
     }
@@ -86,7 +87,7 @@ public class Envelope : IHasArea, IHasLength, IEquatable<Envelope>
 
     #region Equality methods
 
-    public bool Equals(Envelope other)
+    public bool Equals(Envelope? other)
     {
         return !ReferenceEquals(null, other)
             && MinLat.Equals(other.MinLat)
@@ -95,7 +96,7 @@ public class Envelope : IHasArea, IHasLength, IEquatable<Envelope>
             && MaxLon.Equals(other.MaxLon);
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj))
             return false;
@@ -118,14 +119,14 @@ public class Envelope : IHasArea, IHasLength, IEquatable<Envelope>
         }
     }
 
-    public static bool operator ==(Envelope left, Envelope right)
+    public static bool operator ==(Envelope? left, Envelope? right)
     {
         if (ReferenceEquals(left, null) && ReferenceEquals(right, null))
             return true;
         return !ReferenceEquals(left, null) && !ReferenceEquals(right, null) && left.Equals(right);
     }
 
-    public static bool operator !=(Envelope left, Envelope right)
+    public static bool operator !=(Envelope? left, Envelope? right)
     {
         return !(left == right);
     }

--- a/Geo/GeoContext.cs
+++ b/Geo/GeoContext.cs
@@ -1,4 +1,5 @@
-﻿using Geo.Abstractions.Interfaces;
+﻿#nullable enable
+using Geo.Abstractions.Interfaces;
 using Geo.Geodesy;
 using Geo.Geomagnetism;
 
@@ -6,7 +7,7 @@ namespace Geo;
 
 public class GeoContext
 {
-    private static GeoContext _current;
+    private static GeoContext? _current;
 
     public GeoContext()
         : this(Spheroid.Default) { }

--- a/Geo/Geodesy/GeodeticCalculations.cs
+++ b/Geo/Geodesy/GeodeticCalculations.cs
@@ -1,4 +1,5 @@
-﻿using Geo.Abstractions.Interfaces;
+﻿#nullable enable
+using Geo.Abstractions.Interfaces;
 using Geo.Measure;
 
 namespace Geo.Geodesy;

--- a/Geo/Geodesy/GeodeticCalculations.cs
+++ b/Geo/Geodesy/GeodeticCalculations.cs
@@ -22,17 +22,17 @@ public static class GeodeticCalculations
         );
     }
 
-    public static GeodeticLine CalculateShortestLine(this IPosition point1, IPosition point2)
+    public static GeodeticLine? CalculateShortestLine(this IPosition point1, IPosition point2)
     {
         return GeoContext.Current.GeodeticCalculator.CalculateOrthodromicLine(point1, point2);
     }
 
-    public static GeodeticLine CalculateGreatCircleLine(this IPosition point1, IPosition point2)
+    public static GeodeticLine? CalculateGreatCircleLine(this IPosition point1, IPosition point2)
     {
         return GeoContext.Current.GeodeticCalculator.CalculateOrthodromicLine(point1, point2);
     }
 
-    public static GeodeticLine CalculateRhumbLine(this IPosition point1, IPosition point2)
+    public static GeodeticLine? CalculateRhumbLine(this IPosition point1, IPosition point2)
     {
         return GeoContext.Current.GeodeticCalculator.CalculateLoxodromicLine(point1, point2);
     }

--- a/Geo/Geodesy/GeodeticLine.cs
+++ b/Geo/Geodesy/GeodeticLine.cs
@@ -1,4 +1,5 @@
-﻿using Geo.Measure;
+﻿#nullable enable
+using Geo.Measure;
 
 namespace Geo.Geodesy;
 
@@ -24,7 +25,7 @@ public class GeodeticLine : LineSegment
 
     #region Equality methods
 
-    public override bool Equals(object obj, SpatialEqualityOptions options)
+    public override bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as GeodeticLine;
         return !ReferenceEquals(null, other)
@@ -49,7 +50,7 @@ public class GeodeticLine : LineSegment
         }
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return base.Equals(obj);
     }
@@ -59,14 +60,14 @@ public class GeodeticLine : LineSegment
         return base.GetHashCode();
     }
 
-    public static bool operator ==(GeodeticLine left, GeodeticLine right)
+    public static bool operator ==(GeodeticLine? left, GeodeticLine? right)
     {
         if (ReferenceEquals(left, null) && ReferenceEquals(right, null))
             return true;
         return !ReferenceEquals(left, null) && !ReferenceEquals(right, null) && left.Equals(right);
     }
 
-    public static bool operator !=(GeodeticLine left, GeodeticLine right)
+    public static bool operator !=(GeodeticLine? left, GeodeticLine? right)
     {
         return !(left == right);
     }

--- a/Geo/Geodesy/GeodeticLine.cs
+++ b/Geo/Geodesy/GeodeticLine.cs
@@ -40,9 +40,8 @@ public class GeodeticLine : LineSegment
     {
         unchecked
         {
-            var hashCode = Coordinate1 != null ? Coordinate1.GetHashCode(options) : 0;
-            hashCode =
-                (hashCode * 397) ^ (Coordinate2 != null ? Coordinate2.GetHashCode(options) : 0);
+            var hashCode = Coordinate1.GetHashCode(options);
+            hashCode = (hashCode * 397) ^ Coordinate2.GetHashCode(options);
             hashCode = (hashCode * 397) ^ Distance.GetHashCode();
             hashCode = (hashCode * 397) ^ Bearing12.GetHashCode();
             hashCode = (hashCode * 397) ^ Bearing21.GetHashCode();

--- a/Geo/Geodesy/SphereCalculator.cs
+++ b/Geo/Geodesy/SphereCalculator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using Geo.Abstractions.Interfaces;
 using Geo.Geometries;

--- a/Geo/Geodesy/Spheroid.cs
+++ b/Geo/Geodesy/Spheroid.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 namespace Geo.Geodesy;
 

--- a/Geo/Geodesy/SpheroidCalculator.cs
+++ b/Geo/Geodesy/SpheroidCalculator.cs
@@ -2,6 +2,7 @@
 // http://williams.best.vwh.net/
 // https://github.com/geotools/geotools/blob/master/modules/library/referencing/src/main/java/org/geotools/referencing/datum/DefaultEllipsoid.java
 
+#nullable enable
 using System;
 using Geo.Abstractions.Interfaces;
 using Geo.Geometries;
@@ -102,7 +103,7 @@ public class SpheroidCalculator : IGeodeticCalculator
         );
     }
 
-    public GeodeticLine CalculateOrthodromicLine(IPosition position1, IPosition position2)
+    public GeodeticLine? CalculateOrthodromicLine(IPosition position1, IPosition position2)
     {
         var result = CalculateOrthodromicLineInternal(position1, position2);
         if (result == null)
@@ -116,7 +117,7 @@ public class SpheroidCalculator : IGeodeticCalculator
         );
     }
 
-    public GeodeticLine CalculateLoxodromicLine(IPosition position1, IPosition position2)
+    public GeodeticLine? CalculateLoxodromicLine(IPosition position1, IPosition position2)
     {
         var point1 = position1.GetCoordinate();
         var point2 = position2.GetCoordinate();
@@ -279,7 +280,7 @@ public class SpheroidCalculator : IGeodeticCalculator
         return mod(x + Math.PI / 2, 2 * Math.PI) - Math.PI / 2;
     }
 
-    private double[] CalculateOrthodromicLineInternal(IPosition position1, IPosition position2)
+    private double[]? CalculateOrthodromicLineInternal(IPosition position1, IPosition position2)
     {
         var point1 = position1.GetCoordinate();
         var point2 = position2.GetCoordinate();

--- a/Geo/Geomagnetism/GeomagnetismCalculator.cs
+++ b/Geo/Geomagnetism/GeomagnetismCalculator.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Geo.Abstractions.Interfaces;
 using Geo.Geodesy;
@@ -26,7 +28,7 @@ public class GeomagnetismCalculator
 
     public GeomagnetismCalculator(
         Spheroid spheroid,
-        IEnumerable<IGeomagneticModel> geomagneticModels
+        IEnumerable<IGeomagneticModel>? geomagneticModels
     )
     {
         _spheroid = spheroid;
@@ -36,24 +38,31 @@ public class GeomagnetismCalculator
 
     public List<IGeomagneticModel> Models { get; } = new();
 
-    public GeomagnetismResult TryCalculate(IPosition position, DateTimeOffset date)
+    public GeomagnetismResult? TryCalculate(IPosition position, DateTimeOffset date)
     {
         return TryCalculate(position, date.UtcDateTime);
     }
 
-    public GeomagnetismResult TryCalculate(IPosition position, DateTime utcDate)
+    public GeomagnetismResult? TryCalculate(IPosition position, DateTime utcDate)
     {
-        GeomagnetismResult result;
-        TryCalculate(position, utcDate, out result);
+        TryCalculate(position, utcDate, out var result);
         return result;
     }
 
-    public bool TryCalculate(IPosition position, DateTimeOffset date, out GeomagnetismResult result)
+    public bool TryCalculate(
+        IPosition position,
+        DateTimeOffset date,
+        [NotNullWhen(true)] out GeomagnetismResult? result
+    )
     {
         return TryCalculate(position, date.UtcDateTime, out result);
     }
 
-    public bool TryCalculate(IPosition position, DateTime utcDate, out GeomagnetismResult result)
+    public bool TryCalculate(
+        IPosition position,
+        DateTime utcDate,
+        [NotNullWhen(true)] out GeomagnetismResult? result
+    )
     {
         var coordinate = position.GetCoordinate();
         var coordinateZ =

--- a/Geo/Geomagnetism/GeomagnetismResult.cs
+++ b/Geo/Geomagnetism/GeomagnetismResult.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Globalization;
 
 namespace Geo.Geomagnetism;

--- a/Geo/Geomagnetism/IGeomagneticModel.cs
+++ b/Geo/Geomagnetism/IGeomagneticModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 namespace Geo.Geomagnetism;
 

--- a/Geo/Geomagnetism/IgrfGeomagnetismCalculator.cs
+++ b/Geo/Geomagnetism/IgrfGeomagnetismCalculator.cs
@@ -1,4 +1,5 @@
-﻿using Geo.Geodesy;
+﻿#nullable enable
+using Geo.Geodesy;
 using Geo.Geomagnetism.Models;
 
 namespace Geo.Geomagnetism;

--- a/Geo/Geomagnetism/JulianDate.cs
+++ b/Geo/Geomagnetism/JulianDate.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 namespace Geo.Geomagnetism;
 

--- a/Geo/Geomagnetism/WmmGeomagnetismCalculator.cs
+++ b/Geo/Geomagnetism/WmmGeomagnetismCalculator.cs
@@ -1,4 +1,5 @@
-﻿using Geo.Geodesy;
+﻿#nullable enable
+using Geo.Geodesy;
 using Geo.Geomagnetism.Models;
 
 namespace Geo.Geomagnetism;

--- a/Geo/Geometries/Circle.cs
+++ b/Geo/Geometries/Circle.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using Geo.Abstractions;
 using Geo.Abstractions.Interfaces;
@@ -46,20 +47,21 @@ public class Circle : Geometry, ISurface
         Radius = radius;
     }
 
-    public Coordinate Center { get; }
+    public Coordinate? Center { get; }
     public double Radius { get; }
 
     public override Envelope GetBounds()
     {
+        var center = Center!;
         var latitudinalRadiusDeg = Radius / (Constants.NauticalMile * 60);
         var longditudinalRadiusDeg =
-            Radius / (Constants.NauticalMile * 60) * Math.Cos(Center.Latitude.ToRadians());
+            Radius / (Constants.NauticalMile * 60) * Math.Cos(center.Latitude.ToRadians());
 
         return new Envelope(
-            Center.Latitude - latitudinalRadiusDeg,
-            Center.Longitude - longditudinalRadiusDeg,
-            Center.Latitude + latitudinalRadiusDeg,
-            Center.Longitude + longditudinalRadiusDeg
+            center.Latitude - latitudinalRadiusDeg,
+            center.Longitude - longditudinalRadiusDeg,
+            center.Latitude + latitudinalRadiusDeg,
+            center.Longitude + longditudinalRadiusDeg
         );
     }
 
@@ -86,7 +88,7 @@ public class Circle : Geometry, ISurface
 
         var angle = -360d / sides;
         var coordinates = new List<Coordinate>();
-        Coordinate first = null;
+        Coordinate? first = null;
         for (var i = 0; i < sides; i++)
         {
             var coord = GeoContext
@@ -97,13 +99,13 @@ public class Circle : Geometry, ISurface
             coordinates.Add(coord);
         }
 
-        coordinates.Add(first);
+        coordinates.Add(first!);
         return new Polygon(new LinearRing(coordinates));
     }
 
     #region Equality methods
 
-    public override bool Equals(object obj, SpatialEqualityOptions options)
+    public override bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as Circle;
         return !ReferenceEquals(null, other)
@@ -111,7 +113,7 @@ public class Circle : Geometry, ISurface
             && Equals(Center, other.Center, options);
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return base.Equals(obj);
     }
@@ -130,14 +132,14 @@ public class Circle : Geometry, ISurface
         }
     }
 
-    public static bool operator ==(Circle left, Circle right)
+    public static bool operator ==(Circle? left, Circle? right)
     {
         if (ReferenceEquals(left, null) && ReferenceEquals(right, null))
             return true;
         return !ReferenceEquals(left, null) && !ReferenceEquals(right, null) && left.Equals(right);
     }
 
-    public static bool operator !=(Circle left, Circle right)
+    public static bool operator !=(Circle? left, Circle? right)
     {
         return !(left == right);
     }

--- a/Geo/Geometries/Circle.cs
+++ b/Geo/Geometries/Circle.cs
@@ -50,9 +50,12 @@ public class Circle : Geometry, ISurface
     public Coordinate? Center { get; }
     public double Radius { get; }
 
-    public override Envelope GetBounds()
+    public override Envelope? GetBounds()
     {
-        var center = Center!;
+        if (Center == null)
+            return null;
+
+        var center = Center;
         var latitudinalRadiusDeg = Radius / (Constants.NauticalMile * 60);
         var longditudinalRadiusDeg =
             Radius / (Constants.NauticalMile * 60) * Math.Cos(center.Latitude.ToRadians());

--- a/Geo/Geometries/Circle.cs
+++ b/Geo/Geometries/Circle.cs
@@ -95,7 +95,7 @@ public class Circle : Geometry, ISurface
         for (var i = 0; i < sides; i++)
         {
             var coord = GeoContext
-                .Current.GeodeticCalculator.CalculateOrthodromicLine(Center, angle * i, Radius)
+                .Current.GeodeticCalculator.CalculateOrthodromicLine(Center!, angle * i, Radius)
                 .Coordinate2;
             if (i == 0)
                 first = coord;

--- a/Geo/Geometries/GeometryCollection.cs
+++ b/Geo/Geometries/GeometryCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions;
 using Geo.Abstractions.Interfaces;
@@ -14,7 +15,7 @@ public class GeometryCollection : Geometry
         Geometries = new SpatialReadOnlyCollection<IGeometry>(new IGeometry[0]);
     }
 
-    public GeometryCollection(IEnumerable<IGeometry> geometries)
+    public GeometryCollection(IEnumerable<IGeometry>? geometries)
     {
         var items = (geometries ?? new IGeometry[0]).ToList();
         Geometries = new SpatialReadOnlyCollection<IGeometry>(items);
@@ -37,9 +38,9 @@ public class GeometryCollection : Geometry
         get { return Geometries.Any(x => x.IsMeasured); }
     }
 
-    public override Envelope GetBounds()
+    public override Envelope? GetBounds()
     {
-        Envelope envelope = null;
+        Envelope? envelope = null;
         foreach (var geometry in Geometries)
             if (envelope == null)
                 envelope = geometry.GetBounds();
@@ -50,7 +51,7 @@ public class GeometryCollection : Geometry
 
     #region Equality methods
 
-    public override bool Equals(object obj, SpatialEqualityOptions options)
+    public override bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as GeometryCollection;
 
@@ -63,7 +64,7 @@ public class GeometryCollection : Geometry
         return !Geometries.Where((t, i) => !t.Equals(other.Geometries[i], options)).Any();
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return base.Equals(obj);
     }

--- a/Geo/Geometries/LineString.cs
+++ b/Geo/Geometries/LineString.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions;
 using Geo.Abstractions.Interfaces;
@@ -19,7 +20,7 @@ public class LineString : Geometry, ICurve
     public LineString(params Coordinate[] coordinates)
         : this(new CoordinateSequence(coordinates)) { }
 
-    public LineString(CoordinateSequence coordinates)
+    public LineString(CoordinateSequence? coordinates)
     {
         Coordinates = coordinates ?? new CoordinateSequence();
     }
@@ -28,7 +29,7 @@ public class LineString : Geometry, ICurve
 
     public Coordinate this[int index] => Coordinates[index];
 
-    public override Envelope GetBounds()
+    public override Envelope? GetBounds()
     {
         return IsEmpty
             ? null
@@ -55,7 +56,7 @@ public class LineString : Geometry, ICurve
 
     #region Equality methods
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return base.Equals(obj);
     }
@@ -65,7 +66,7 @@ public class LineString : Geometry, ICurve
         return base.GetHashCode();
     }
 
-    public override bool Equals(object obj, SpatialEqualityOptions options)
+    public override bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as LineString;
         return !ReferenceEquals(null, other) && Equals(Coordinates, other.Coordinates, options);
@@ -73,17 +74,17 @@ public class LineString : Geometry, ICurve
 
     public override int GetHashCode(SpatialEqualityOptions options)
     {
-        return Coordinates != null ? Coordinates.GetHashCode(options) : 0;
+        return Coordinates.GetHashCode(options);
     }
 
-    public static bool operator ==(LineString left, LineString right)
+    public static bool operator ==(LineString? left, LineString? right)
     {
         if (ReferenceEquals(left, null) && ReferenceEquals(right, null))
             return true;
         return !ReferenceEquals(left, null) && !ReferenceEquals(right, null) && left.Equals(right);
     }
 
-    public static bool operator !=(LineString left, LineString right)
+    public static bool operator !=(LineString? left, LineString? right)
     {
         return !(left == right);
     }

--- a/Geo/Geometries/LinearRing.cs
+++ b/Geo/Geometries/LinearRing.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 
 namespace Geo.Geometries;
@@ -16,7 +17,7 @@ public class LinearRing : LineString
     public LinearRing(params Coordinate[] coordinates)
         : this(new CoordinateSequence(coordinates)) { }
 
-    public LinearRing(CoordinateSequence coordinates)
+    public LinearRing(CoordinateSequence? coordinates)
         : base(coordinates)
     {
         if (coordinates != null && !coordinates.IsEmpty && !coordinates.IsClosed)

--- a/Geo/Geometries/MultiLineString.cs
+++ b/Geo/Geometries/MultiLineString.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions.Interfaces;

--- a/Geo/Geometries/MultiPoint.cs
+++ b/Geo/Geometries/MultiPoint.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions.Interfaces;

--- a/Geo/Geometries/MultiPolygon.cs
+++ b/Geo/Geometries/MultiPolygon.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions.Interfaces;

--- a/Geo/Geometries/Point.cs
+++ b/Geo/Geometries/Point.cs
@@ -1,4 +1,5 @@
-﻿using Geo.Abstractions;
+﻿#nullable enable
+using Geo.Abstractions;
 using Geo.Abstractions.Interfaces;
 
 namespace Geo.Geometries;
@@ -25,12 +26,12 @@ public class Point : Geometry, IPosition
         Coordinate = new CoordinateZM(latitude, longitude, elevation, measure);
     }
 
-    public Point(Coordinate coordinate)
+    public Point(Coordinate? coordinate)
     {
         Coordinate = coordinate;
     }
 
-    public Coordinate Coordinate { get; set; }
+    public Coordinate? Coordinate { get; set; }
 
     public override bool IsEmpty => Coordinate == null;
 
@@ -40,17 +41,17 @@ public class Point : Geometry, IPosition
 
     Coordinate IPosition.GetCoordinate()
     {
-        return Coordinate;
+        return Coordinate!;
     }
 
     public override Envelope GetBounds()
     {
-        return Coordinate.GetBounds();
+        return Coordinate!.GetBounds();
     }
 
     #region Equality methods
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return base.Equals(obj);
     }
@@ -60,7 +61,7 @@ public class Point : Geometry, IPosition
         return base.GetHashCode();
     }
 
-    public override bool Equals(object obj, SpatialEqualityOptions options)
+    public override bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as Point;
         return !ReferenceEquals(null, other) && Equals(Coordinate, other.Coordinate, options);
@@ -71,14 +72,14 @@ public class Point : Geometry, IPosition
         return Coordinate != null ? Coordinate.GetHashCode(options) : 0;
     }
 
-    public static bool operator ==(Point left, Point right)
+    public static bool operator ==(Point? left, Point? right)
     {
         if (ReferenceEquals(left, null) && ReferenceEquals(right, null))
             return true;
         return !ReferenceEquals(left, null) && !ReferenceEquals(right, null) && left.Equals(right);
     }
 
-    public static bool operator !=(Point left, Point right)
+    public static bool operator !=(Point? left, Point? right)
     {
         return !(left == right);
     }

--- a/Geo/Geometries/Point.cs
+++ b/Geo/Geometries/Point.cs
@@ -44,9 +44,9 @@ public class Point : Geometry, IPosition
         return Coordinate!;
     }
 
-    public override Envelope GetBounds()
+    public override Envelope? GetBounds()
     {
-        return Coordinate!.GetBounds();
+        return Coordinate?.GetBounds();
     }
 
     #region Equality methods

--- a/Geo/Geometries/Polygon.cs
+++ b/Geo/Geometries/Polygon.cs
@@ -40,7 +40,7 @@ public class Polygon : Geometry, ISurface
 
     public override Envelope? GetBounds()
     {
-        return Shell!.GetBounds();
+        return Shell?.GetBounds();
     }
 
     public Area GetArea()

--- a/Geo/Geometries/Polygon.cs
+++ b/Geo/Geometries/Polygon.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions;
 using Geo.Abstractions.Interfaces;
@@ -11,15 +12,15 @@ public class Polygon : Geometry, ISurface
     public static readonly Polygon Empty = new();
 
     public Polygon()
-        : this((LinearRing)null) { }
+        : this((LinearRing?)null) { }
 
-    public Polygon(LinearRing shell, IEnumerable<LinearRing> holes)
+    public Polygon(LinearRing? shell, IEnumerable<LinearRing>? holes)
     {
         Shell = shell;
         Holes = new SpatialReadOnlyCollection<LinearRing>(holes ?? new LinearRing[0]);
     }
 
-    public Polygon(LinearRing shell, params LinearRing[] holes)
+    public Polygon(LinearRing? shell, params LinearRing[] holes)
         : this(shell, (IEnumerable<LinearRing>)holes) { }
 
     public Polygon(params Coordinate[] shell)
@@ -28,24 +29,24 @@ public class Polygon : Geometry, ISurface
     public Polygon(IEnumerable<Coordinate> shell)
         : this(new LinearRing(shell)) { }
 
-    public LinearRing Shell { get; }
+    public LinearRing? Shell { get; }
     public SpatialReadOnlyCollection<LinearRing> Holes { get; }
 
     public override bool IsEmpty => Shell == null || Shell.IsEmpty;
 
-    public override bool Is3D => !IsEmpty && Shell.Is3D;
+    public override bool Is3D => !IsEmpty && Shell!.Is3D;
 
-    public override bool IsMeasured => !IsEmpty && Shell.IsMeasured;
+    public override bool IsMeasured => !IsEmpty && Shell!.IsMeasured;
 
-    public override Envelope GetBounds()
+    public override Envelope? GetBounds()
     {
-        return Shell.GetBounds();
+        return Shell!.GetBounds();
     }
 
     public Area GetArea()
     {
         var calculator = GeoContext.Current.GeodeticCalculator;
-        var area = calculator.CalculateArea(Shell.Coordinates);
+        var area = calculator.CalculateArea(Shell!.Coordinates);
         return Holes.Aggregate(
             area,
             (current, hole) => current - calculator.CalculateArea(hole.Coordinates)
@@ -54,7 +55,7 @@ public class Polygon : Geometry, ISurface
 
     #region Equality methods
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return base.Equals(obj);
     }
@@ -64,7 +65,7 @@ public class Polygon : Geometry, ISurface
         return base.GetHashCode();
     }
 
-    public override bool Equals(object obj, SpatialEqualityOptions options)
+    public override bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as Polygon;
 
@@ -74,7 +75,7 @@ public class Polygon : Geometry, ISurface
         if (IsEmpty && other.IsEmpty)
             return true;
 
-        return Shell.Equals(other.Shell, options)
+        return Shell!.Equals(other.Shell, options)
             && Holes.Count == other.Holes.Count
             && !Holes.Where((t, i) => !t.Equals(other.Holes[i], options)).Any();
     }
@@ -84,18 +85,18 @@ public class Polygon : Geometry, ISurface
         unchecked
         {
             return ((Shell != null ? Shell.GetHashCode(options) : 0) * 397)
-                ^ (Holes != null ? Holes.GetHashCode(options) : 0);
+                ^ Holes.GetHashCode(options);
         }
     }
 
-    public static bool operator ==(Polygon left, Polygon right)
+    public static bool operator ==(Polygon? left, Polygon? right)
     {
         if (ReferenceEquals(left, null) && ReferenceEquals(right, null))
             return true;
         return !ReferenceEquals(left, null) && !ReferenceEquals(right, null) && left.Equals(right);
     }
 
-    public static bool operator !=(Polygon left, Polygon right)
+    public static bool operator !=(Polygon? left, Polygon? right)
     {
         return !(left == right);
     }

--- a/Geo/Geometries/Triangle.cs
+++ b/Geo/Geometries/Triangle.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 
 namespace Geo.Geometries;

--- a/Geo/Gps/GpsData.cs
+++ b/Geo/Gps/GpsData.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -71,14 +72,14 @@ public class GpsData
             .ThenBy(x => x.Name);
     }
 
-    public static GpsData Parse(Stream stream)
+    public static GpsData? Parse(Stream stream)
     {
         var gpsStream = new StreamWrapper(stream);
         var parser = FileParsers.FirstOrDefault(x => x.CanDeSerialize(gpsStream));
         return parser == null ? null : parser.DeSerialize(gpsStream);
     }
 
-    public static async Task<GpsData> ParseAsync(
+    public static async Task<GpsData?> ParseAsync(
         Stream stream,
         CancellationToken cancellationToken = default
     )

--- a/Geo/Gps/GpsFeaturesExtensions.cs
+++ b/Geo/Gps/GpsFeaturesExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Geo.Gps;
 
 public static class GpsFeaturesExtensions

--- a/Geo/Gps/GpsFileFormat.cs
+++ b/Geo/Gps/GpsFileFormat.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 namespace Geo.Gps;
 
@@ -19,5 +20,5 @@ public class GpsFileFormat
 
     public string Extension { get; }
     public string Name { get; }
-    public Uri SpecificationUri { get; }
+    public Uri? SpecificationUri { get; }
 }

--- a/Geo/Gps/Metadata/GpsMetadata.cs
+++ b/Geo/Gps/Metadata/GpsMetadata.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Geo.Gps.Metadata;
 
 public class GpsMetadata : Metadata<GpsMetadata.MetadataKeys>

--- a/Geo/Gps/Metadata/Metadata.cs
+++ b/Geo/Gps/Metadata/Metadata.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 
@@ -12,20 +13,19 @@ public abstract class Metadata<TKeys> : Dictionary<string, string>
         _metadataKeys = metadataKeys;
     }
 
-    public string Attribute(Func<TKeys, string> attribute)
+    public string? Attribute(Func<TKeys, string> attribute)
     {
         var key = attribute(_metadataKeys);
-        string result;
-        TryGetValue(key, out result);
+        TryGetValue(key, out var result);
         return result;
     }
 
-    public void Attribute(Func<TKeys, string> attribute, string value)
+    public void Attribute(Func<TKeys, string> attribute, string? value)
     {
         if (!string.IsNullOrWhiteSpace(value))
         {
             var key = attribute(_metadataKeys);
-            this[key] = value.Trim();
+            this[key] = value!.Trim();
         }
     }
 

--- a/Geo/Gps/Metadata/RouteMetadata.cs
+++ b/Geo/Gps/Metadata/RouteMetadata.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Geo.Gps.Metadata;
 
 public class RouteMetadata : Metadata<RouteMetadata.MetadataKeys>

--- a/Geo/Gps/Metadata/TrackMetadata.cs
+++ b/Geo/Gps/Metadata/TrackMetadata.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Geo.Gps.Metadata;
 
 public class TrackMetadata : Metadata<TrackMetadata.MetadataKeys>

--- a/Geo/Gps/Route.cs
+++ b/Geo/Gps/Route.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions.Interfaces;

--- a/Geo/Gps/Serialization/IGpsFileDeSerializer.cs
+++ b/Geo/Gps/Serialization/IGpsFileDeSerializer.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ public interface IGpsFileDeSerializer
     GpsFileFormat[] FileFormats { get; }
     GpsFeatures SupportedFeatures { get; }
     bool CanDeSerialize(StreamWrapper streamWrapper);
-    GpsData DeSerialize(StreamWrapper streamWrapper);
+    GpsData? DeSerialize(StreamWrapper streamWrapper);
 }
 
 public interface IGpsFileSerializer : IGpsFileDeSerializer

--- a/Geo/Gps/Serialization/IgcDeSerializer.cs
+++ b/Geo/Gps/Serialization/IgcDeSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -42,7 +43,7 @@ public class IgcDeSerializer : IGpsFileDeSerializer
         streamWrapper.Position = 0;
         using (var reader = new StreamReader(streamWrapper))
         {
-            string line;
+            string? line;
             while ((line = reader.ReadLine()) != null)
                 if (Regex.IsMatch(line, B_LINE_REGEX))
                     return true;
@@ -60,7 +61,7 @@ public class IgcDeSerializer : IGpsFileDeSerializer
         streamWrapper.Position = 0;
         using (var reader = new StreamReader(streamWrapper))
         {
-            string line;
+            string? line;
             while ((line = reader.ReadLine()) != null)
             {
                 if (date == default)

--- a/Geo/Gps/Serialization/NmeaDeSerializer.cs
+++ b/Geo/Gps/Serialization/NmeaDeSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -25,7 +26,7 @@ public class NmeaDeSerializer : IGpsFileDeSerializer
         streamWrapper.Position = 0;
         using (var reader = new StreamReader(streamWrapper))
         {
-            string line;
+            string? line;
             while ((line = reader.ReadLine()) != null)
                 if (Regex.IsMatch(line, FIX_SENTENCE) || Regex.IsMatch(line, WPT_SENTENCE))
                     return true;
@@ -41,7 +42,7 @@ public class NmeaDeSerializer : IGpsFileDeSerializer
         streamWrapper.Position = 0;
         using (var reader = new StreamReader(streamWrapper))
         {
-            string line;
+            string? line;
             while ((line = reader.ReadLine()) != null)
             {
                 if (ParseFix(line, trackSegment))

--- a/Geo/Gps/Serialization/StreamWrapper.cs
+++ b/Geo/Gps/Serialization/StreamWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿#nullable enable
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Geo/Gps/Serialization/Xml/GpsXmlDeSerializer.cs
+++ b/Geo/Gps/Serialization/Xml/GpsXmlDeSerializer.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Xml;
 using System.Xml.Serialization;
@@ -16,7 +17,7 @@ public abstract class GpsXmlDeSerializer<T> : IGpsFileDeSerializer
     // lets malformed files (e.g. GPX exports without the default xmlns) parse
     // against the namespace-qualified models. Formats that do not need this
     // (or want strict matching) leave it null.
-    protected virtual string Namespace => null;
+    protected virtual string? Namespace => null;
 
     public bool CanDeSerialize(StreamWrapper streamWrapper)
     {
@@ -42,7 +43,7 @@ public abstract class GpsXmlDeSerializer<T> : IGpsFileDeSerializer
         }
     }
 
-    public GpsData DeSerialize(StreamWrapper streamWrapper)
+    public GpsData? DeSerialize(StreamWrapper streamWrapper)
     {
         streamWrapper.Position = 0;
         T doc;
@@ -78,5 +79,5 @@ public abstract class GpsXmlDeSerializer<T> : IGpsFileDeSerializer
     }
 
     protected abstract bool CanDeSerialize(XmlReader xml);
-    protected abstract GpsData DeSerialize(T xml);
+    protected abstract GpsData? DeSerialize(T xml);
 }

--- a/Geo/Gps/Serialization/Xml/GpsXmlSerializer.cs
+++ b/Geo/Gps/Serialization/Xml/GpsXmlSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -51,7 +52,7 @@ public abstract class GpsXmlSerializer<T> : GpsXmlDeSerializer<T>, IGpsFileSeria
     {
         var value = data.Metadata.Attribute(attribute);
         if (!string.IsNullOrWhiteSpace(value))
-            action(xml, value);
+            action(xml, value!);
     }
 
     protected void SerializeTrackMetadata<TTrack>(
@@ -63,7 +64,7 @@ public abstract class GpsXmlSerializer<T> : GpsXmlDeSerializer<T>, IGpsFileSeria
     {
         var value = data.Metadata.Attribute(attribute);
         if (!string.IsNullOrWhiteSpace(value))
-            action(xml, value);
+            action(xml, value!);
     }
 
     protected void SerializeRouteMetadata<TRoute>(
@@ -75,7 +76,7 @@ public abstract class GpsXmlSerializer<T> : GpsXmlDeSerializer<T>, IGpsFileSeria
     {
         var value = data.Metadata.Attribute(attribute);
         if (!string.IsNullOrWhiteSpace(value))
-            action(xml, value);
+            action(xml, value!);
     }
 
     private class EncodingStringWriter : StringWriter

--- a/Geo/Gps/Serialization/Xml/NamespaceCoercingXmlReader.cs
+++ b/Geo/Gps/Serialization/Xml/NamespaceCoercingXmlReader.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml;
 
 namespace Geo.Gps.Serialization.Xml;

--- a/Geo/Gps/Track.cs
+++ b/Geo/Gps/Track.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,12 +30,12 @@ public class Track : IHasLength
         return new LineString(Segments.SelectMany(x => x.Waypoints).Select(x => x.Coordinate));
     }
 
-    public TrackSegment GetFirstSegment()
+    public TrackSegment? GetFirstSegment()
     {
         return Segments.Count == 0 ? default : Segments[0];
     }
 
-    public TrackSegment GetLastSegment()
+    public TrackSegment? GetLastSegment()
     {
         return Segments.Count == 0 ? default : Segments[Segments.Count - 1];
     }
@@ -44,13 +45,13 @@ public class Track : IHasLength
         return Segments.SelectMany(x => x.Waypoints);
     }
 
-    public Waypoint GetFirstWaypoint()
+    public Waypoint? GetFirstWaypoint()
     {
         var segment = GetFirstSegment();
         return segment == null ? default : segment.GetFirstWaypoint();
     }
 
-    public Waypoint GetLastWaypoint()
+    public Waypoint? GetLastWaypoint()
     {
         var segment = GetLastSegment();
         return segment == null ? default : segment.GetLastWaypoint();

--- a/Geo/Gps/TrackSegment.cs
+++ b/Geo/Gps/TrackSegment.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,12 +32,12 @@ public class TrackSegment : IHasLength
         return Waypoints.Count == 0;
     }
 
-    public Waypoint GetFirstWaypoint()
+    public Waypoint? GetFirstWaypoint()
     {
         return IsEmpty() ? default : Waypoints[0];
     }
 
-    public Waypoint GetLastWaypoint()
+    public Waypoint? GetLastWaypoint()
     {
         return IsEmpty() ? default : Waypoints[Waypoints.Count - 1];
     }
@@ -63,11 +64,11 @@ public class TrackSegment : IHasLength
             );
 
         var waypoints = new List<Waypoint>();
-        Waypoint lastWaypoint = null;
+        Waypoint? lastWaypoint = null;
         foreach (var waypoint in Waypoints)
             if (
                 lastWaypoint == null
-                || Math.Abs((waypoint.TimeUtc.Value - lastWaypoint.TimeUtc.Value).TotalSeconds)
+                || Math.Abs((waypoint.TimeUtc!.Value - lastWaypoint.TimeUtc!.Value).TotalSeconds)
                     >= seconds
             )
             {

--- a/Geo/Gps/Waypoint.cs
+++ b/Geo/Gps/Waypoint.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using Geo.Abstractions.Interfaces;
 using Geo.Geometries;
 using Geo.Measure;
@@ -29,7 +30,7 @@ public class Waypoint : IHasLength
         TimeUtc = dateTime;
     }
 
-    public Waypoint(Point point, string name, string comment, string description)
+    public Waypoint(Point point, string? name, string? comment, string? description)
     {
         Name = name;
         Comment = comment;
@@ -40,9 +41,9 @@ public class Waypoint : IHasLength
     public Waypoint(
         Point point,
         DateTime? dateTime,
-        string name,
-        string comment,
-        string description
+        string? name,
+        string? comment,
+        string? description
     )
     {
         Name = name;
@@ -52,14 +53,14 @@ public class Waypoint : IHasLength
         TimeUtc = dateTime;
     }
 
-    public string Name { get; }
-    public string Comment { get; }
-    public string Description { get; }
+    public string? Name { get; }
+    public string? Comment { get; }
+    public string? Description { get; }
 
     public Point Point { get; set; }
     public DateTime? TimeUtc { get; set; }
 
-    public Coordinate Coordinate => Point.Coordinate;
+    public Coordinate Coordinate => Point.Coordinate!;
 
     public Distance GetLength()
     {
@@ -68,6 +69,6 @@ public class Waypoint : IHasLength
 
     public LineString ToLineString()
     {
-        return new LineString(Point.Coordinate);
+        return new LineString(Point.Coordinate!);
     }
 }

--- a/Geo/IO/GeoFormat.cs
+++ b/Geo/IO/GeoFormat.cs
@@ -1,4 +1,6 @@
+#nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Geo.IO.GeoJson;
 using Geo.IO.Wkt;
 
@@ -64,7 +66,11 @@ public static class GeoFormat
     /// <see cref="GeoStringFormat.Unknown" />.
     /// </param>
     /// <returns><c>true</c> if the string was recognised and parsed; otherwise <c>false</c>.</returns>
-    public static bool TryParse(string input, out object result, out GeoStringFormat format)
+    public static bool TryParse(
+        string input,
+        [NotNullWhen(true)] out object? result,
+        out GeoStringFormat format
+    )
     {
         result = null;
         format = GeoStringFormat.Unknown;
@@ -124,7 +130,7 @@ public static class GeoFormat
         return '\0';
     }
 
-    private static bool TryCoordinate(string input, out object result)
+    private static bool TryCoordinate(string input, [NotNullWhen(true)] out object? result)
     {
         if (Coordinate.TryParse(input, out var coordinate))
         {
@@ -136,7 +142,7 @@ public static class GeoFormat
         return false;
     }
 
-    private static bool TryWkt(string input, out object result)
+    private static bool TryWkt(string input, [NotNullWhen(true)] out object? result)
     {
         try
         {
@@ -156,7 +162,7 @@ public static class GeoFormat
         return false;
     }
 
-    private static bool TryGeoJson(string input, out object result)
+    private static bool TryGeoJson(string input, [NotNullWhen(true)] out object? result)
     {
         try
         {

--- a/Geo/IO/GeoJson/Feature.cs
+++ b/Geo/IO/GeoJson/Feature.cs
@@ -1,19 +1,20 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using Geo.Abstractions.Interfaces;
 
 namespace Geo.IO.GeoJson;
 
 public class Feature : IGeoJsonObject
 {
-    public Feature(IGeometry geometry = null, Dictionary<string, object> properties = null)
+    public Feature(IGeometry? geometry = null, Dictionary<string, object?>? properties = null)
     {
         Geometry = geometry;
-        Properties = properties ?? new Dictionary<string, object>();
+        Properties = properties ?? new Dictionary<string, object?>();
     }
 
-    public IGeometry Geometry { get; set; }
-    public Dictionary<string, object> Properties { get; set; }
-    public object Id { get; set; }
+    public IGeometry? Geometry { get; set; }
+    public Dictionary<string, object?> Properties { get; set; }
+    public object? Id { get; set; }
 
     public string ToGeoJson()
     {

--- a/Geo/IO/GeoJson/FeatureCollection.cs
+++ b/Geo/IO/GeoJson/FeatureCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using Geo.Abstractions.Interfaces;
 
 namespace Geo.IO.GeoJson;

--- a/Geo/IO/GeoJson/GeoJson.cs
+++ b/Geo/IO/GeoJson/GeoJson.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿#nullable enable
+using System.IO;
 using Geo.Abstractions.Interfaces;
 
 namespace Geo.IO.GeoJson;

--- a/Geo/IO/GeoJson/GeoJsonReader.cs
+++ b/Geo/IO/GeoJson/GeoJsonReader.cs
@@ -1,5 +1,7 @@
-﻿using System;
+#nullable enable
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -41,18 +43,16 @@ public class GeoJsonReader
 
     public IGeoJsonObject Read(string json)
     {
-        object obj;
-        if (TryRead(json, out obj))
+        if (TryRead(json, out var obj))
             return (IGeoJsonObject)obj;
         throw new SerializationException("Invalid GeoJSON string");
     }
 
-    public bool TryRead(string json, out object result)
+    public bool TryRead(string json, [NotNullWhen(true)] out object? result)
     {
         result = null;
-        object obj;
 
-        if (!SimpleJson.TryDeserializeObject(json, out obj))
+        if (!SimpleJson.TryDeserializeObject(json, out var obj))
             return false;
 
         if (obj is JsonObject)
@@ -68,9 +68,9 @@ public class GeoJsonReader
         return false;
     }
 
-    private bool TryParseTypeString(JsonObject obj, out string result)
+    private bool TryParseTypeString(JsonObject? obj, out string? result)
     {
-        object type = null;
+        object? type = null;
         if (obj != null)
             obj.TryGetValue("type", out type);
 
@@ -78,20 +78,19 @@ public class GeoJsonReader
         return type != null;
     }
 
-    private bool TryParseFeatureCollection(JsonObject obj, out object result)
+    private bool TryParseFeatureCollection(JsonObject obj, [NotNullWhen(true)] out object? result)
     {
         result = null;
-        string typeString;
         if (
-            TryParseTypeString(obj, out typeString)
-            && typeString.ToLowerInvariant() == "featurecollection"
+            TryParseTypeString(obj, out var typeString)
+            && typeString!.ToLowerInvariant() == "featurecollection"
         )
         {
             var features = GetArray(obj, "features");
 
             if (features != null)
             {
-                var temp = new object[features.Count];
+                var temp = new object?[features.Count];
                 for (var index = 0; index < features.Count; index++)
                 {
                     var geometry = features[index];
@@ -107,30 +106,29 @@ public class GeoJsonReader
         return false;
     }
 
-    private bool TryParseFeature(JsonObject obj, out object result)
+    private bool TryParseFeature(JsonObject obj, [NotNullWhen(true)] out object? result)
     {
-        string typeString;
-        if (TryParseTypeString(obj, out typeString) && typeString.ToLowerInvariant() == "feature")
+        if (
+            TryParseTypeString(obj, out var typeString)
+            && typeString!.ToLowerInvariant() == "feature"
+        )
         {
-            object geometry;
-            object geo = null;
-            object prop;
-            Dictionary<string, object> pr = null;
+            object? geo = null;
+            Dictionary<string, object?>? pr = null;
 
-            if (obj.TryGetValue("geometry", out geometry))
+            if (obj.TryGetValue("geometry", out var geometry))
                 TryParseGeometry((JsonObject)geometry, out geo);
 
-            if (obj.TryGetValue("properties", out prop) && prop is JsonObject)
+            if (obj.TryGetValue("properties", out var prop) && prop is JsonObject)
             {
                 var props = (JsonObject)prop;
                 if (props.Count > 0)
                     pr = props.ToDictionary(x => x.Key, x => SantizeJsonObjects(x.Value));
             }
 
-            result = new Feature((IGeometry)geo, pr);
+            result = new Feature((IGeometry?)geo, pr);
 
-            object id;
-            if (obj.TryGetValue("id", out id))
+            if (obj.TryGetValue("id", out var id))
                 ((Feature)result).Id = SantizeJsonObjects(id);
 
             return true;
@@ -143,20 +141,18 @@ public class GeoJsonReader
     // JsonObject's indexer throws KeyNotFoundException for an absent key; use a safe
     // lookup so a GeoJSON object missing "coordinates" / "geometries" / "features"
     // fails the TryParse (and surfaces as a SerializationException) instead of leaking.
-    private static JsonArray GetArray(JsonObject obj, string key)
+    private static JsonArray? GetArray(JsonObject obj, string key)
     {
-        object value;
-        return obj.TryGetValue(key, out value) ? value as JsonArray : null;
+        return obj.TryGetValue(key, out var value) ? value as JsonArray : null;
     }
 
-    private bool TryParseGeometry(JsonObject obj, out object result)
+    private bool TryParseGeometry(JsonObject obj, [NotNullWhen(true)] out object? result)
     {
         result = null;
-        string typeString;
-        if (!TryParseTypeString(obj, out typeString))
+        if (!TryParseTypeString(obj, out var typeString))
             return false;
 
-        typeString = typeString.ToLowerInvariant();
+        typeString = typeString!.ToLowerInvariant();
 
         switch (typeString)
         {
@@ -179,15 +175,14 @@ public class GeoJsonReader
         }
     }
 
-    private bool TryParsePoint(JsonObject obj, out object result)
+    private bool TryParsePoint(JsonObject obj, [NotNullWhen(true)] out object? result)
     {
         result = null;
         var coordinates = GetArray(obj, "coordinates");
         if (coordinates == null || coordinates.Count < 2)
             return false;
 
-        Coordinate coordinate;
-        if (TryParseCoordinate(coordinates, out coordinate))
+        if (TryParseCoordinate(coordinates, out var coordinate))
         {
             result = new Point(coordinate);
             return true;
@@ -196,11 +191,10 @@ public class GeoJsonReader
         return false;
     }
 
-    private bool TryParseLineString(JsonObject obj, out object result)
+    private bool TryParseLineString(JsonObject obj, [NotNullWhen(true)] out object? result)
     {
         var coordinates = GetArray(obj, "coordinates");
-        Coordinate[] co;
-        if (coordinates != null && TryParseCoordinateArray(coordinates, out co))
+        if (coordinates != null && TryParseCoordinateArray(coordinates, out var co))
         {
             result = new LineString(co);
             return true;
@@ -210,15 +204,14 @@ public class GeoJsonReader
         return false;
     }
 
-    private bool TryParsePolygon(JsonObject obj, out object result)
+    private bool TryParsePolygon(JsonObject obj, [NotNullWhen(true)] out object? result)
     {
         var coordinates = GetArray(obj, "coordinates");
 
-        Coordinate[][] temp;
         if (
             coordinates != null
             && coordinates.Count > 0
-            && TryParseCoordinateArrayArray(coordinates, out temp)
+            && TryParseCoordinateArrayArray(coordinates, out var temp)
         )
         {
             result = new Polygon(
@@ -232,11 +225,10 @@ public class GeoJsonReader
         return false;
     }
 
-    private bool TryParseMultiPoint(JsonObject obj, out object result)
+    private bool TryParseMultiPoint(JsonObject obj, [NotNullWhen(true)] out object? result)
     {
         var coordinates = GetArray(obj, "coordinates");
-        Coordinate[] co;
-        if (coordinates != null && TryParseCoordinateArray(coordinates, out co))
+        if (coordinates != null && TryParseCoordinateArray(coordinates, out var co))
         {
             result = new MultiPoint(co.Select(x => new Point(x)));
             return true;
@@ -246,11 +238,10 @@ public class GeoJsonReader
         return false;
     }
 
-    private bool TryParseMultiLineString(JsonObject obj, out object result)
+    private bool TryParseMultiLineString(JsonObject obj, [NotNullWhen(true)] out object? result)
     {
         var coordinates = GetArray(obj, "coordinates");
-        Coordinate[][] co;
-        if (coordinates != null && TryParseCoordinateArrayArray(coordinates, out co))
+        if (coordinates != null && TryParseCoordinateArrayArray(coordinates, out var co))
         {
             result = new MultiLineString(co.Select(x => new LineString(x)));
             return true;
@@ -260,11 +251,10 @@ public class GeoJsonReader
         return false;
     }
 
-    private bool TryParseMultiPolygon(JsonObject obj, out object result)
+    private bool TryParseMultiPolygon(JsonObject obj, [NotNullWhen(true)] out object? result)
     {
         var coordinates = GetArray(obj, "coordinates");
-        Coordinate[][][] co;
-        if (coordinates != null && TryParseCoordinateArrayArrayArray(coordinates, out co))
+        if (coordinates != null && TryParseCoordinateArrayArrayArray(coordinates, out var co))
         {
             result = new MultiPolygon(
                 co.Select(x => new Polygon(
@@ -279,14 +269,14 @@ public class GeoJsonReader
         return false;
     }
 
-    private bool TryParseGeometryCollection(JsonObject obj, out object result)
+    private bool TryParseGeometryCollection(JsonObject obj, [NotNullWhen(true)] out object? result)
     {
         result = null;
         var geometries = GetArray(obj, "geometries");
 
         if (geometries != null)
         {
-            var temp = new object[geometries.Count];
+            var temp = new object?[geometries.Count];
             for (var index = 0; index < geometries.Count; index++)
             {
                 var geometry = geometries[index];
@@ -301,7 +291,10 @@ public class GeoJsonReader
         return false;
     }
 
-    private bool TryParseCoordinate(JsonArray coordinates, out Coordinate result)
+    private bool TryParseCoordinate(
+        JsonArray? coordinates,
+        [NotNullWhen(true)] out Coordinate? result
+    )
     {
         result = null;
         if (coordinates == null || coordinates.Count < 2)
@@ -332,7 +325,10 @@ public class GeoJsonReader
         return true;
     }
 
-    private bool TryParseCoordinateArray(JsonArray coordinates, out Coordinate[] result)
+    private bool TryParseCoordinateArray(
+        JsonArray? coordinates,
+        [NotNullWhen(true)] out Coordinate[]? result
+    )
     {
         result = null;
         if (coordinates == null)
@@ -344,13 +340,20 @@ public class GeoJsonReader
 
         var tempResult = new Coordinate[coordinates.Count];
         for (var index = 0; index < coordinates.Count; index++)
-            if (!TryParseCoordinate((JsonArray)coordinates[index], out tempResult[index]))
+        {
+            if (!TryParseCoordinate((JsonArray)coordinates[index], out var coordinate))
                 return false;
+            tempResult[index] = coordinate;
+        }
+
         result = tempResult;
         return true;
     }
 
-    private bool TryParseCoordinateArrayArray(JsonArray coordinates, out Coordinate[][] result)
+    private bool TryParseCoordinateArrayArray(
+        JsonArray? coordinates,
+        [NotNullWhen(true)] out Coordinate[][]? result
+    )
     {
         result = null;
         if (coordinates == null)
@@ -362,15 +365,19 @@ public class GeoJsonReader
 
         var tempResult = new Coordinate[coordinates.Count][];
         for (var index = 0; index < coordinates.Count; index++)
-            if (!TryParseCoordinateArray((JsonArray)coordinates[index], out tempResult[index]))
+        {
+            if (!TryParseCoordinateArray((JsonArray)coordinates[index], out var coordinate))
                 return false;
+            tempResult[index] = coordinate;
+        }
+
         result = tempResult;
         return true;
     }
 
     private bool TryParseCoordinateArrayArrayArray(
-        JsonArray coordinates,
-        out Coordinate[][][] result
+        JsonArray? coordinates,
+        [NotNullWhen(true)] out Coordinate[][][]? result
     )
     {
         result = null;
@@ -383,13 +390,17 @@ public class GeoJsonReader
 
         var tempResult = new Coordinate[coordinates.Count][][];
         for (var index = 0; index < coordinates.Count; index++)
-            if (!TryParseCoordinateArrayArray((JsonArray)coordinates[index], out tempResult[index]))
+        {
+            if (!TryParseCoordinateArrayArray((JsonArray)coordinates[index], out var coordinate))
                 return false;
+            tempResult[index] = coordinate;
+        }
+
         result = tempResult;
         return true;
     }
 
-    public object SantizeJsonObjects(object obj)
+    public object? SantizeJsonObjects(object? obj)
     {
         var jsonArray = obj as JsonArray;
         if (jsonArray != null)

--- a/Geo/IO/GeoJson/GeoJsonWriter.cs
+++ b/Geo/IO/GeoJson/GeoJsonWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 using Geo.Abstractions.Interfaces;
@@ -54,7 +55,7 @@ public class GeoJsonWriter
         return SimpleJson.SerializeObject(WriteFeatureCollection(featureCollection));
     }
 
-    private Dictionary<string, object> WriteGeometry(IGeometry geometry)
+    private Dictionary<string, object?> WriteGeometry(IGeometry geometry)
     {
         var point = geometry as Point;
         if (point != null)
@@ -94,36 +95,36 @@ public class GeoJsonWriter
         );
     }
 
-    private Dictionary<string, object> WritePoint(Point point)
+    private Dictionary<string, object?> WritePoint(Point point)
     {
-        return new Dictionary<string, object>
+        return new Dictionary<string, object?>
         {
             { "type", "Point" },
             { "coordinates", WriteCoordinate(point) },
         };
     }
 
-    private Dictionary<string, object> WriteLineString(LineString lineString)
+    private Dictionary<string, object?> WriteLineString(LineString lineString)
     {
-        return new Dictionary<string, object>
+        return new Dictionary<string, object?>
         {
             { "type", "LineString" },
             { "coordinates", WriteCoordinates(lineString.Coordinates) },
         };
     }
 
-    private Dictionary<string, object> WritePolygon(Polygon polygon)
+    private Dictionary<string, object?> WritePolygon(Polygon polygon)
     {
-        return new Dictionary<string, object>
+        return new Dictionary<string, object?>
         {
             { "type", "Polygon" },
             { "coordinates", WriteCoordinates(polygon) },
         };
     }
 
-    private Dictionary<string, object> WriteMultiPoint(MultiPoint multiPoint)
+    private Dictionary<string, object?> WriteMultiPoint(MultiPoint multiPoint)
     {
-        return new Dictionary<string, object>
+        return new Dictionary<string, object?>
         {
             { "type", "MultiPoint" },
             {
@@ -133,9 +134,9 @@ public class GeoJsonWriter
         };
     }
 
-    private Dictionary<string, object> WriteMultiLineString(MultiLineString multiLineString)
+    private Dictionary<string, object?> WriteMultiLineString(MultiLineString multiLineString)
     {
-        return new Dictionary<string, object>
+        return new Dictionary<string, object?>
         {
             { "type", "MultiLineString" },
             {
@@ -148,9 +149,9 @@ public class GeoJsonWriter
         };
     }
 
-    private Dictionary<string, object> WriteMultiPolygon(MultiPolygon multiPolygon)
+    private Dictionary<string, object?> WriteMultiPolygon(MultiPolygon multiPolygon)
     {
-        return new Dictionary<string, object>
+        return new Dictionary<string, object?>
         {
             { "type", "MultiPolygon" },
             {
@@ -160,26 +161,26 @@ public class GeoJsonWriter
         };
     }
 
-    private Dictionary<string, object> WriteGeometryCollection(
+    private Dictionary<string, object?> WriteGeometryCollection(
         GeometryCollection geometryCollection
     )
     {
-        return new Dictionary<string, object>
+        return new Dictionary<string, object?>
         {
             { "type", "GeometryCollection" },
             { "geometries", geometryCollection.Geometries.Select(WriteGeometry).ToArray() },
         };
     }
 
-    private Dictionary<string, object> WriteFeature(Feature feature)
+    private Dictionary<string, object?> WriteFeature(Feature feature)
     {
-        var result = new Dictionary<string, object>
+        var result = new Dictionary<string, object?>
         {
             { "type", "Feature" },
             { "geometry", feature.Geometry == null ? null : WriteGeometry(feature.Geometry) },
         };
 
-        if (feature.Properties != null && feature.Properties.Count > 0)
+        if (feature.Properties.Count > 0)
             result.Add("properties", feature.Properties);
         else
             result.Add("properties", null);
@@ -190,9 +191,9 @@ public class GeoJsonWriter
         return result;
     }
 
-    private Dictionary<string, object> WriteFeatureCollection(FeatureCollection featureCollection)
+    private Dictionary<string, object?> WriteFeatureCollection(FeatureCollection featureCollection)
     {
-        return new Dictionary<string, object>
+        return new Dictionary<string, object?>
         {
             { "type", "FeatureCollection" },
             { "features", featureCollection.Features.Select(WriteFeature).ToArray() },
@@ -225,7 +226,7 @@ public class GeoJsonWriter
 
     private IEnumerable<IEnumerable<double[]>> WriteCoordinates(Polygon polygon)
     {
-        yield return WriteCoordinates(polygon.Shell.Coordinates);
+        yield return WriteCoordinates(polygon.Shell!.Coordinates);
         foreach (var hole in polygon.Holes)
             yield return WriteCoordinates(hole.Coordinates);
     }

--- a/Geo/IO/GeoJson/GeoJsonWriterSettings.cs
+++ b/Geo/IO/GeoJson/GeoJsonWriterSettings.cs
@@ -1,4 +1,5 @@
-﻿namespace Geo;
+﻿#nullable enable
+namespace Geo;
 
 public class GeoJsonWriterSettings
 {

--- a/Geo/IO/Google/GooglePolylineEncoder.cs
+++ b/Geo/IO/Google/GooglePolylineEncoder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Geo.Geometries;

--- a/Geo/IO/Wkb/WkbBinaryReader.cs
+++ b/Geo/IO/Wkb/WkbBinaryReader.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.IO;
 
 namespace Geo.IO.Wkb;
@@ -19,7 +20,7 @@ internal class WkbBinaryReader : IDisposable
 
     public void Dispose()
     {
-        if (_reader != null && !_disposed)
+        if (!_disposed)
         {
             _disposed = true;
             _reader.Dispose();

--- a/Geo/IO/Wkb/WkbBinaryWriter.cs
+++ b/Geo/IO/Wkb/WkbBinaryWriter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.IO;
 
 namespace Geo.IO.Wkb;
@@ -18,7 +19,7 @@ internal class WkbBinaryWriter : IDisposable
 
     public void Dispose()
     {
-        if (_writer != null && !_disposed)
+        if (!_disposed)
         {
             _disposed = true;
             _writer.Dispose();

--- a/Geo/IO/Wkb/WkbReader.cs
+++ b/Geo/IO/Wkb/WkbReader.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,7 +13,7 @@ namespace Geo.IO.Wkb;
 
 public class WkbReader
 {
-    public IGeometry Read(byte[] bytes)
+    public IGeometry? Read(byte[] bytes)
     {
         if (bytes == null)
             throw new ArgumentNullException("bytes");
@@ -26,7 +27,7 @@ public class WkbReader
     // WKB is read incrementally through a BinaryReader, which has no async API, so
     // the source stream is buffered into memory asynchronously up front and the
     // (CPU-bound) decoding then runs against that buffer.
-    public async Task<IGeometry> ReadAsync(
+    public async Task<IGeometry?> ReadAsync(
         Stream stream,
         CancellationToken cancellationToken = default
     )
@@ -42,7 +43,7 @@ public class WkbReader
         }
     }
 
-    public IGeometry Read(Stream stream)
+    public IGeometry? Read(Stream stream)
     {
         if (stream == null)
             throw new ArgumentNullException("stream");

--- a/Geo/IO/Wkb/WkbWriter.cs
+++ b/Geo/IO/Wkb/WkbWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿#nullable enable
+using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
@@ -165,7 +166,7 @@ public class WkbWriter
         {
             WriteEncoding(writer, _settings.Encoding);
             WriteGeometryType(point, WkbGeometryType.Point, writer);
-            WriteCoordinate(point.Coordinate, writer);
+            WriteCoordinate(point.Coordinate!, writer);
         }
     }
 
@@ -199,7 +200,7 @@ public class WkbWriter
         else
         {
             writer.Write((uint)(1 + polygon.Holes.Count));
-            WriteCoordinates(polygon.Shell.Coordinates, writer);
+            WriteCoordinates(polygon.Shell!.Coordinates, writer);
 
             foreach (var hole in polygon.Holes)
                 WriteCoordinates(hole.Coordinates, writer);

--- a/Geo/IO/Wkb/WkbWriterSettings.cs
+++ b/Geo/IO/Wkb/WkbWriterSettings.cs
@@ -1,4 +1,5 @@
-﻿namespace Geo.IO.Wkb;
+﻿#nullable enable
+namespace Geo.IO.Wkb;
 
 public class WkbWriterSettings
 {

--- a/Geo/IO/Wkt/WktReader.cs
+++ b/Geo/IO/Wkt/WktReader.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -15,7 +16,7 @@ public class WktReader
 {
     private readonly WktTokenizer _wktTokenizer = new();
 
-    public IGeometry Read(string wkt)
+    public IGeometry? Read(string wkt)
     {
         if (wkt == null)
             throw new ArgumentNullException("wkt");
@@ -24,7 +25,7 @@ public class WktReader
         return Parse(tokens);
     }
 
-    public IGeometry Read(Stream stream)
+    public IGeometry? Read(Stream stream)
     {
         if (stream == null)
             throw new ArgumentNullException("stream");
@@ -36,7 +37,7 @@ public class WktReader
         }
     }
 
-    public async Task<IGeometry> ReadAsync(
+    public async Task<IGeometry?> ReadAsync(
         Stream stream,
         CancellationToken cancellationToken = default
     )
@@ -52,7 +53,7 @@ public class WktReader
         }
     }
 
-    private IGeometry Parse(WktTokenQueue tokens)
+    private IGeometry? Parse(WktTokenQueue tokens)
     {
         try
         {
@@ -67,7 +68,7 @@ public class WktReader
         }
     }
 
-    private IGeometry ParseGeometry(WktTokenQueue tokens)
+    private IGeometry? ParseGeometry(WktTokenQueue tokens)
     {
         if (tokens.Count == 0)
             return null;
@@ -76,7 +77,7 @@ public class WktReader
 
         if (token.Type == WktTokenType.String)
         {
-            var value = token.Value.ToUpperInvariant();
+            var value = token.Value!.ToUpperInvariant();
             if (value == "POINT")
                 return ParsePoint(tokens);
             if (value == "LINESTRING")
@@ -286,12 +287,12 @@ public class WktReader
         tokens.Dequeue(WktTokenType.LeftParenthesis);
 
         var geometries = new List<IGeometry>();
-        geometries.Add(ParseGeometry(tokens));
+        geometries.Add(ParseGeometry(tokens)!);
 
         while (tokens.NextTokenIs(WktTokenType.Comma))
         {
             tokens.Dequeue();
-            geometries.Add(ParseGeometry(tokens));
+            geometries.Add(ParseGeometry(tokens)!);
         }
 
         tokens.Dequeue(WktTokenType.RightParenthesis);
@@ -302,10 +303,10 @@ public class WktReader
     private Coordinate ParseCoordinate(WktTokenQueue tokens, WktDimensions dimensions)
     {
         var token = tokens.Dequeue(WktTokenType.Number);
-        var x = double.Parse(token.Value, CultureInfo.InvariantCulture);
+        var x = double.Parse(token.Value!, CultureInfo.InvariantCulture);
 
         token = tokens.Dequeue(WktTokenType.Number);
-        var y = double.Parse(token.Value, CultureInfo.InvariantCulture);
+        var y = double.Parse(token.Value!, CultureInfo.InvariantCulture);
 
         var z = double.NaN;
         var m = double.NaN;
@@ -344,7 +345,7 @@ public class WktReader
             if (tokens.NextTokenIs(WktTokenType.Number))
             {
                 var token = tokens.Dequeue(WktTokenType.Number);
-                doubles.Add(double.Parse(token.Value, CultureInfo.InvariantCulture));
+                doubles.Add(double.Parse(token.Value!, CultureInfo.InvariantCulture));
             }
             else if (tokens.NextTokenIs(double.NaN.ToString(CultureInfo.InvariantCulture)))
             {
@@ -360,7 +361,7 @@ public class WktReader
         return doubles;
     }
 
-    private CoordinateSequence ParseCoordinateSequence(
+    private CoordinateSequence? ParseCoordinateSequence(
         WktTokenQueue tokens,
         WktDimensions dimensions
     )
@@ -390,7 +391,7 @@ public class WktReader
         var token = tokens.Peek();
         if (token.Type == WktTokenType.String)
         {
-            var value = token.Value.ToUpperInvariant();
+            var value = token.Value!.ToUpperInvariant();
             if (value == "Z")
             {
                 tokens.Dequeue();

--- a/Geo/IO/Wkt/WktToken.cs
+++ b/Geo/IO/Wkt/WktToken.cs
@@ -1,4 +1,5 @@
-﻿namespace Geo.IO.Wkt;
+﻿#nullable enable
+namespace Geo.IO.Wkt;
 
 internal struct WktToken
 {
@@ -17,5 +18,5 @@ internal struct WktToken
     }
 
     public WktTokenType Type { get; }
-    public string Value { get; }
+    public string? Value { get; }
 }

--- a/Geo/IO/Wkt/WktTokenQueue.cs
+++ b/Geo/IO/Wkt/WktTokenQueue.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -24,7 +25,7 @@ internal class WktTokenQueue : Queue<WktToken>
         if (Count == 0)
             return false;
         var token = Peek();
-        return token.Type == WktTokenType.String && token.Value.ToUpperInvariant() == value;
+        return token.Type == WktTokenType.String && token.Value!.ToUpperInvariant() == value;
     }
 
     public WktToken Dequeue(WktTokenType type)

--- a/Geo/IO/Wkt/WktTokenizer.cs
+++ b/Geo/IO/Wkt/WktTokenizer.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿#nullable enable
+using System.IO;
 using System.Runtime.Serialization;
 using System.Text;
 

--- a/Geo/IO/Wkt/WktWriter.cs
+++ b/Geo/IO/Wkt/WktWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿#nullable enable
+using System.Globalization;
 using System.Runtime.Serialization;
 using System.Text;
 using Geo.Abstractions.Interfaces;
@@ -130,7 +131,7 @@ public class WktWriter
         }
 
         builder.Append("(");
-        AppendCoordinate(builder, point.Coordinate);
+        AppendCoordinate(builder, point.Coordinate!);
         builder.Append(")");
     }
 
@@ -188,7 +189,7 @@ public class WktWriter
         }
 
         builder.Append("(");
-        AppendLineStringInner(builder, polygon.Shell.Coordinates);
+        AppendLineStringInner(builder, polygon.Shell!.Coordinates);
         for (var i = 0; i < polygon.Holes.Count; i++)
         {
             builder.Append(", ");

--- a/Geo/IO/Wkt/WktWriterSettings.cs
+++ b/Geo/IO/Wkt/WktWriterSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿#nullable enable
+using System.Globalization;
 
 namespace Geo.IO.Wkt;
 

--- a/Geo/InternalHelpers.cs
+++ b/Geo/InternalHelpers.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 namespace Geo;
 

--- a/Geo/LineSegment.cs
+++ b/Geo/LineSegment.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using Geo.Abstractions;
 
 namespace Geo;
@@ -26,7 +27,7 @@ public class LineSegment : SpatialObject
 
     #region Equality methods
 
-    public override bool Equals(object obj, SpatialEqualityOptions options)
+    public override bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as LineSegment;
         return !ReferenceEquals(null, other)
@@ -38,12 +39,11 @@ public class LineSegment : SpatialObject
     {
         unchecked
         {
-            return ((Coordinate1 != null ? Coordinate1.GetHashCode(options) : 0) * 397)
-                ^ (Coordinate2 != null ? Coordinate2.GetHashCode(options) : 0);
+            return (Coordinate1.GetHashCode(options) * 397) ^ Coordinate2.GetHashCode(options);
         }
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return base.Equals(obj);
     }
@@ -53,14 +53,14 @@ public class LineSegment : SpatialObject
         return base.GetHashCode();
     }
 
-    public static bool operator ==(LineSegment left, LineSegment right)
+    public static bool operator ==(LineSegment? left, LineSegment? right)
     {
         if (ReferenceEquals(left, null) && ReferenceEquals(right, null))
             return true;
         return !ReferenceEquals(left, null) && !ReferenceEquals(right, null) && left.Equals(right);
     }
 
-    public static bool operator !=(LineSegment left, LineSegment right)
+    public static bool operator !=(LineSegment? left, LineSegment? right)
     {
         return !(left == right);
     }

--- a/Geo/Linq/EnumerableExtensions.cs
+++ b/Geo/Linq/EnumerableExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions.Interfaces;

--- a/Geo/Linq/Spatial2DComparer.cs
+++ b/Geo/Linq/Spatial2DComparer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using Geo.Abstractions;
 using Geo.Abstractions.Interfaces;
 

--- a/Geo/Linq/Spatial3DComparer.cs
+++ b/Geo/Linq/Spatial3DComparer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using Geo.Abstractions;
 using Geo.Abstractions.Interfaces;
 

--- a/Geo/Measure/Area.cs
+++ b/Geo/Measure/Area.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using Geo.Abstractions.Interfaces;
 
@@ -52,7 +53,7 @@ public struct Area : IMeasure, IEquatable<Area>, IComparable<Area>
         return SiValue.Equals(other.SiValue);
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj))
             return false;

--- a/Geo/Measure/AreaUnitExtensions.cs
+++ b/Geo/Measure/AreaUnitExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Geo.Measure;
 
 public static class AreaUnitExtensions

--- a/Geo/Measure/Distance.cs
+++ b/Geo/Measure/Distance.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using Geo.Abstractions.Interfaces;
 
 namespace Geo.Measure;
@@ -52,7 +53,7 @@ public struct Distance : IMeasure, IEquatable<Distance>, IComparable<Distance>
         return SiValue.Equals(other.SiValue);
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj))
             return false;

--- a/Geo/Measure/DistanceUnitExtensions.cs
+++ b/Geo/Measure/DistanceUnitExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Geo.Measure;
 
 public static class DistanceUnitExtensions

--- a/Geo/Measure/Speed.cs
+++ b/Geo/Measure/Speed.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using Geo.Abstractions.Interfaces;
 
 namespace Geo.Measure;
@@ -69,7 +70,7 @@ public struct Speed : IMeasure, IEquatable<Speed>, IComparable<Speed>
         return SiValue.Equals(other.SiValue);
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj))
             return false;

--- a/Geo/Measure/SpeedUnitExtensions.cs
+++ b/Geo/Measure/SpeedUnitExtensions.cs
@@ -1,4 +1,5 @@
-﻿namespace Geo.Measure;
+﻿#nullable enable
+namespace Geo.Measure;
 
 public static class SpeedUnitExtensions
 {

--- a/Geo/Measure/UnitAttribute.cs
+++ b/Geo/Measure/UnitAttribute.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Geo.Measure;

--- a/Geo/Measure/UnitMetadata.cs
+++ b/Geo/Measure/UnitMetadata.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Geo/NullableAttributes.cs
+++ b/Geo/NullableAttributes.cs
@@ -1,0 +1,19 @@
+// Polyfill for the nullable-flow-analysis attributes that live in the BCL from
+// netstandard2.1 / netcoreapp3.0 onwards. The Geo library targets
+// netstandard2.0, so we declare the ones we use here as internal types. When a
+// consuming runtime already provides them, its copies win via type forwarding;
+// these are only compiled into the netstandard2.0 assembly.
+#if NETSTANDARD2_0
+using System;
+
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+[AttributeUsage(AttributeTargets.Parameter)]
+internal sealed class NotNullWhenAttribute : Attribute
+{
+    public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+    public bool ReturnValue { get; }
+}
+#endif

--- a/Geo/SpatialEqualityOptions.cs
+++ b/Geo/SpatialEqualityOptions.cs
@@ -1,4 +1,5 @@
-﻿namespace Geo;
+﻿#nullable enable
+namespace Geo;
 
 public class SpatialEqualityOptions
 {


### PR DESCRIPTION
Rolls out C# nullable reference types (NRT) across the `Geo` library as a series of reviewable, per-subsystem increments. Every hand-written source file is now `#nullable enable`, with the public API surface annotated to reflect the nullability the code already relied on.

## Approach

- **Per-file `#nullable enable`**, subsystem by subsystem, rather than a solution-wide flip — so the diff stays reviewable and each step is independently green.
- **Annotate-only.** No runtime null checks were added or removed, so behaviour is unchanged. Annotations are metadata-only, so this is **binary-compatible** — existing compiled consumers keep working; downstream projects that opt into NRT gain accurate warnings. (One deliberate exception, called out below.)
- No `.csproj` change was needed: `LangVersion` already resolves high enough on netstandard2.0. Where the BCL flow attributes are missing on netstandard2.0 (e.g. `NotNullWhen`), an internal, `#if NETSTANDARD2_0`-guarded polyfill is used.
- Latent throw-on-invalid behaviour at internal dereference sites is preserved via the null-forgiving operator (`!`); a handful of provably-dead null checks were dropped to keep the build warning-clean.

Every increment builds with **0 warnings** and keeps the full suite green (**495 tests**).

## What's covered (in order)

1. **Coordinate family** — `Coordinate`/`Z`/`M`/`ZM`, `CoordinateSequence`. `TryParse` uses `[NotNullWhen(true)] out Coordinate?`; `GetBounds()` returns `Envelope?`.
2. **Geometries** — `Point.Coordinate`, `Circle.Center`, `Polygon.Shell` are nullable for empty instances; `Geometry.GetBounds()` is `Envelope?`.
3. **`GetBounds()` harmonization** *(the one intentional behaviour change)* — `Point`/`Polygon`/`Circle` now return `null` for an empty geometry instead of throwing `NullReferenceException`, matching `LineString`/`GeometryCollection`/`CoordinateSequence`. Covered by new tests.
4. **WKT** serializer (reader/writer/tokenizer).
5. **WKB** serializer (reader/writer).
6. **GeoJSON** + Google polyline + `GeoFormat` — `Feature` modelled honestly (`Geometry` `IGeometry?`, `Id` `object?`, `Properties` `Dictionary<string, object?>`); the `TryParse` surface uses `[NotNullWhen(true)] out T?`.
7. **GPS core model** — `GpsData`, `Route`, `Track`, `TrackSegment`, `Waypoint`, `Metadata`. `Parse` → `GpsData?`; `GetFirst*/GetLast*` → nullable.
8. **GPS deserialization infrastructure** — `IGpsFileDeSerializer` (`DeSerialize` → `GpsData?`), `StreamWrapper`, NMEA/IGC parsers, XML base classes.
9. **Measure & Linq** — `Distance`/`Area`/`Speed` and the spatial comparers.
10. **Geodesy & Geomagnetism** — line calculators return `GeodeticLine?` for coincident points; `GeomagnetismCalculator.TryCalculate` returns `GeomagnetismResult?`.
11. **Core abstractions & root types** — the interface layer (`IGeometry.GetBounds()` → `Envelope?`, `ISpatialEquatable`/`IGeodeticCalculator`), `SpatialObject`, `SpatialReadOnlyCollection`, `Envelope`, `LineSegment`, `GeoContext`.

## Deliberately not annotated

- **GPS XML DTOs** (`Gpx*`/`Garmin*`/`PocketFms*`/`SkyDemon*`, ~68 files) and their 5 coupled flightplan/GPX serializers — a large, mechanical follow-up best done as its own pass.
- **Pure enums** (no reference-type surface), the **generated geomagnetism coefficient tables**, and the **vendored `SimpleJson.cs`**.

## Versioning note

Because increment 3 changes runtime behaviour (empty `GetBounds()` returns null instead of throwing), landing this warrants a **minor version bump** and a release note; the annotation work on its own is non-breaking.