### PR TITLE
Enable nullable reference types on the GPS serialization DTOs and serializers

### DIFF
--- a/Geo/Gps/Serialization/GarminFlightplanDeSerializer.cs
+++ b/Geo/Gps/Serialization/GarminFlightplanDeSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+#nullable enable
+using System.Linq;
 using System.Xml;
 using Geo.Gps.Serialization.Xml;
 using Geo.Gps.Serialization.Xml.Garmin.Flightplan;
@@ -22,13 +23,13 @@ public class GarminFlightplanDeSerializer : GpsXmlDeSerializer<GarminFlightplan>
     protected override GpsData DeSerialize(GarminFlightplan xml)
     {
         var data = new GpsData();
-        foreach (var route in xml.route)
+        foreach (var route in xml.route!)
         {
             var rte = new Route();
             rte.Metadata.Attribute(x => x.Name, route.routename);
-            foreach (var point in route.routepoint)
+            foreach (var point in route.routepoint!)
             {
-                var wp = xml.waypointtable.Single(x => x.identifier == point.waypointidentifier);
+                var wp = xml.waypointtable!.Single(x => x.identifier == point.waypointidentifier);
                 rte.Waypoints.Add(new Waypoint(wp.lat, wp.lon));
             }
 

--- a/Geo/Gps/Serialization/Gpx10Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx10Serializer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -137,7 +138,7 @@ public class Gpx10Serializer : GpsXmlSerializer<GpxFile>
                     foreach (var trksegTrkpt in trkType.trkseg.Where(seg => seg.trkpt != null))
                     {
                         var segment = new TrackSegment();
-                        foreach (var wptType in trksegTrkpt.trkpt)
+                        foreach (var wptType in trksegTrkpt.trkpt!)
                             segment.Waypoints.Add(ConvertWaypoint(wptType));
                         track.Segments.Add(segment);
                     }
@@ -156,7 +157,7 @@ public class Gpx10Serializer : GpsXmlSerializer<GpxFile>
                 route.Metadata.Attribute(x => x.Description, rteType.desc);
                 route.Metadata.Attribute(x => x.Comment, rteType.cmt);
 
-                foreach (var wptType in rteType.rtept)
+                foreach (var wptType in rteType.rtept!)
                     route.Waypoints.Add(ConvertWaypoint(wptType));
                 data.Routes.Add(route);
             }

--- a/Geo/Gps/Serialization/Gpx11Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx11Serializer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -284,7 +285,7 @@ public class Gpx11Serializer : GpsXmlSerializer<GpxFile>
                     foreach (var trksegType in trkType.trkseg.Where(seg => seg.trkpt != null))
                     {
                         var segment = new TrackSegment();
-                        foreach (var wptType in trksegType.trkpt)
+                        foreach (var wptType in trksegType.trkpt!)
                             segment.Waypoints.Add(ConvertWaypoint(wptType));
                         track.Segments.Add(segment);
                     }
@@ -303,7 +304,7 @@ public class Gpx11Serializer : GpsXmlSerializer<GpxFile>
                 route.Metadata.Attribute(x => x.Description, rteType.desc);
                 route.Metadata.Attribute(x => x.Comment, rteType.cmt);
 
-                foreach (var wptType in rteType.rtept)
+                foreach (var wptType in rteType.rtept!)
                     route.Waypoints.Add(ConvertWaypoint(wptType));
                 data.Routes.Add(route);
             }

--- a/Geo/Gps/Serialization/PocketFmsFlightplanDeSerializer.cs
+++ b/Geo/Gps/Serialization/PocketFmsFlightplanDeSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml;
+#nullable enable
+using System.Xml;
 using Geo.Gps.Serialization.Xml;
 using Geo.Gps.Serialization.Xml.PocketFms;
 
@@ -33,19 +34,19 @@ public class PocketFmsFlightplanDeSerializer : GpsXmlDeSerializer<PocketFmsFligh
         var route = new Route();
         route.Waypoints.Add(
             new Waypoint(
-                (double)xml.LIB[0].FromPoint.Latitude,
-                (double)xml.LIB[0].FromPoint.Longitude
+                (double)xml.LIB![0].FromPoint!.Latitude,
+                (double)xml.LIB[0].FromPoint!.Longitude
             )
         );
         foreach (var lib in xml.LIB)
             route.Waypoints.Add(
-                new Waypoint((double)lib.ToPoint.Latitude, (double)lib.ToPoint.Longitude)
+                new Waypoint((double)lib.ToPoint!.Latitude, (double)lib.ToPoint!.Longitude)
             );
 
         var data = new GpsData();
         data.Routes.Add(route);
 
-        data.Metadata.Attribute(x => x.Vehicle.Crew1, xml.META.PilotInCommand);
+        data.Metadata.Attribute(x => x.Vehicle.Crew1, xml.META!.PilotInCommand);
         data.Metadata.Attribute(x => x.Vehicle.Identifier, xml.META.AircraftIdentification);
         data.Metadata.Attribute(x => x.Vehicle.Model, xml.META.AircraftType);
 

--- a/Geo/Gps/Serialization/SkyDemonFlightplanDeSerializer.cs
+++ b/Geo/Gps/Serialization/SkyDemonFlightplanDeSerializer.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -21,9 +22,9 @@ public class SkyDemonFlightplanDeSerializer : GpsXmlDeSerializer<SkyDemonFlightp
     private Route ConvertRoute(SkyDemonRoute route)
     {
         var result = new Route();
-        result.Waypoints.Add(ParseWaypoint(route.Start));
-        foreach (var rhumbLine in route.RhumbLineRoute)
-            result.Waypoints.Add(ParseWaypoint(rhumbLine.To));
+        result.Waypoints.Add(ParseWaypoint(route.Start!));
+        foreach (var rhumbLine in route.RhumbLineRoute!)
+            result.Waypoints.Add(ParseWaypoint(rhumbLine.To!));
         return result;
     }
 
@@ -55,7 +56,7 @@ public class SkyDemonFlightplanDeSerializer : GpsXmlDeSerializer<SkyDemonFlightp
         return xml.Name == "DivelementsFlightPlanner";
     }
 
-    protected override GpsData DeSerialize(SkyDemonFlightplan xml)
+    protected override GpsData? DeSerialize(SkyDemonFlightplan xml)
     {
         if (xml == null)
             return null;

--- a/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminFlightplan.cs
+++ b/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminFlightplan.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Serialization;
+#nullable enable
+using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Garmin.Flightplan;
 
@@ -14,8 +15,8 @@ public class GarminFlightplan
 
     [XmlArray("waypoint-table")]
     [XmlArrayItem("waypoint", typeof(GarminWaypoint), IsNullable = false)]
-    public GarminWaypoint[] waypointtable { get; set; }
+    public GarminWaypoint[]? waypointtable { get; set; }
 
     [XmlElement("route")]
-    public GarminRoute[] route { get; set; }
+    public GarminRoute[]? route { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminRoute.cs
+++ b/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminRoute.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Garmin.Flightplan;
@@ -6,11 +7,11 @@ namespace Geo.Gps.Serialization.Xml.Garmin.Flightplan;
 public class GarminRoute
 {
     [XmlElement("route-name")]
-    public string routename { get; set; }
+    public string? routename { get; set; }
 
     //[XmlElement("flight-plan-index")]
     //public string flightplanindex { get; set; }
 
     [XmlElement("route-point")]
-    public GarminRoutePoint[] routepoint { get; set; }
+    public GarminRoutePoint[]? routepoint { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminRoutePoint.cs
+++ b/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminRoutePoint.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Garmin.Flightplan;
@@ -6,7 +7,7 @@ namespace Geo.Gps.Serialization.Xml.Garmin.Flightplan;
 public class GarminRoutePoint
 {
     [XmlElement("waypoint-identifier")]
-    public string waypointidentifier { get; set; }
+    public string? waypointidentifier { get; set; }
 
     //[XmlElement("waypoint-type")]
     //public string waypointtype { get; set; }

--- a/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminWaypoint.cs
+++ b/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminWaypoint.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Garmin.Flightplan;
@@ -5,7 +6,7 @@ namespace Geo.Gps.Serialization.Xml.Garmin.Flightplan;
 [XmlType(AnonymousType = true, Namespace = "http://www8.garmin.com/xmlschemas/FlightPlan/v1")]
 public class GarminWaypoint
 {
-    public string identifier { get; set; }
+    public string? identifier { get; set; }
 
     //public string type { get; set; }
 

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxBounds.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxBounds.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxFile.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxFile.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;
@@ -11,25 +12,25 @@ public class GpxFile : GpxMetadataBase
         version = "1.0";
     }
 
-    public string author { get; set; }
+    public string? author { get; set; }
 
-    public string email { get; set; }
+    public string? email { get; set; }
 
     [XmlElement(DataType = "anyURI")]
-    public string url { get; set; }
+    public string? url { get; set; }
 
-    public string urlname { get; set; }
+    public string? urlname { get; set; }
 
-    public GpxBounds bounds { get; set; }
+    public GpxBounds? bounds { get; set; }
 
     [XmlElement("wpt")]
-    public GpxPoint[] wpt { get; set; }
+    public GpxPoint[]? wpt { get; set; }
 
     [XmlElement("rte")]
-    public GpxRoute[] rte { get; set; }
+    public GpxRoute[]? rte { get; set; }
 
     [XmlElement("trk")]
-    public GpxTrack[] trk { get; set; }
+    public GpxTrack[]? trk { get; set; }
 
     //[XmlAnyElement]
     //public XmlElement[] Any { get; set; }
@@ -38,5 +39,5 @@ public class GpxFile : GpxMetadataBase
     public string version { get; set; }
 
     [XmlAttribute]
-    public string creator { get; set; }
+    public string? creator { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxPoint.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxPoint.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Serialization;
+#nullable enable
+using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;
 
@@ -6,9 +7,9 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;
 public class GpxPoint : GpxWaypointBase
 {
     [XmlElement(DataType = "anyURI")]
-    public string url { get; set; }
+    public string? url { get; set; }
 
-    public string urlname { get; set; }
+    public string? urlname { get; set; }
 
     public GpxFixType fix { get; set; }
 

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxRoute.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxRoute.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;
@@ -6,13 +7,13 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;
 public class GpxRoute : GpxRteTrkBase
 {
     [XmlElement(DataType = "anyURI")]
-    public string url { get; set; }
+    public string? url { get; set; }
 
-    public string urlname { get; set; }
+    public string? urlname { get; set; }
 
     //[XmlAnyElement]
     //public XmlElement[] Any { get; set; }
 
     [XmlElement("rtept")]
-    public GpxPoint[] rtept { get; set; }
+    public GpxPoint[]? rtept { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxTrack.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxTrack.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;
@@ -6,13 +7,13 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;
 public class GpxTrack : GpxRteTrkBase
 {
     [XmlElement(DataType = "anyURI")]
-    public string url { get; set; }
+    public string? url { get; set; }
 
-    public string urlname { get; set; }
+    public string? urlname { get; set; }
 
     //[XmlAnyElement]
     //public XmlElement[] Any { get; set; }
 
     [XmlElement("trkseg")]
-    public GpxTrackSegment[] trkseg { get; set; }
+    public GpxTrackSegment[]? trkseg { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxTrackPoint.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxTrackPoint.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxTrackSegment.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxTrackSegment.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;
@@ -6,5 +7,5 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;
 public class GpxTrackSegment
 {
     [XmlElement("trkpt")]
-    public GpxTrackPoint[] trkpt { get; set; }
+    public GpxTrackPoint[]? trkpt { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxBounds.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxBounds.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxCopyright.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxCopyright.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Serialization;
+#nullable enable
+using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
 
@@ -6,11 +7,11 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
 public class GpxCopyright
 {
     [XmlElement(DataType = "gYear")]
-    public string year { get; set; }
+    public string? year { get; set; }
 
     [XmlElement(DataType = "anyURI")]
-    public string license { get; set; }
+    public string? license { get; set; }
 
     [XmlAttribute]
-    public string author { get; set; }
+    public string? author { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxEmail.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxEmail.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
@@ -6,8 +7,8 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
 public class GpxEmail
 {
     [XmlAttribute]
-    public string id { get; set; }
+    public string? id { get; set; }
 
     [XmlAttribute]
-    public string domain { get; set; }
+    public string? domain { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxExtensions.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml;
+#nullable enable
+using System.Xml;
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
@@ -7,5 +8,5 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
 public class GpxExtensions
 {
     [XmlAnyElement]
-    public XmlElement[] Any { get; set; }
+    public XmlElement[]? Any { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxFile.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxFile.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
@@ -11,16 +12,16 @@ public class GpxFile
         version = "1.1";
     }
 
-    public GpxMetadata metadata { get; set; }
+    public GpxMetadata? metadata { get; set; }
 
     [XmlElement("wpt")]
-    public GpxWaypoint[] wpt { get; set; }
+    public GpxWaypoint[]? wpt { get; set; }
 
     [XmlElement("rte")]
-    public GpxRoute[] rte { get; set; }
+    public GpxRoute[]? rte { get; set; }
 
     [XmlElement("trk")]
-    public GpxTrack[] trk { get; set; }
+    public GpxTrack[]? trk { get; set; }
 
     //public extensionsType extensions { get; set; }
 
@@ -28,5 +29,5 @@ public class GpxFile
     public string version { get; set; }
 
     [XmlAttribute]
-    public string creator { get; set; }
+    public string? creator { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxLink.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxLink.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
@@ -5,10 +6,10 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
 [XmlType(Namespace = "http://www.topografix.com/GPX/1/1")]
 public class GpxLink
 {
-    public string text { get; set; }
+    public string? text { get; set; }
 
-    public string type { get; set; }
+    public string? type { get; set; }
 
     [XmlAttribute(DataType = "anyURI")]
-    public string href { get; set; }
+    public string? href { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxMetadata.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxMetadata.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
@@ -5,13 +6,13 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
 [XmlType(Namespace = "http://www.topografix.com/GPX/1/1")]
 public class GpxMetadata : GpxMetadataBase
 {
-    public GpxPerson author { get; set; }
-    public GpxCopyright copyright { get; set; }
+    public GpxPerson? author { get; set; }
+    public GpxCopyright? copyright { get; set; }
 
     [XmlElement("link")]
-    public GpxLink[] link { get; set; }
+    public GpxLink[]? link { get; set; }
 
-    public GpxBounds bounds { get; set; }
+    public GpxBounds? bounds { get; set; }
 
     //public extensionsType extensions { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxPerson.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxPerson.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
@@ -5,9 +6,9 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
 [XmlType(Namespace = "http://www.topografix.com/GPX/1/1")]
 public class GpxPerson
 {
-    public string name { get; set; }
+    public string? name { get; set; }
 
-    public GpxEmail email { get; set; }
+    public GpxEmail? email { get; set; }
 
-    public GpxLink link { get; set; }
+    public GpxLink? link { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxRoute.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxRoute.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
@@ -6,12 +7,12 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
 public class GpxRoute : GpxRteTrkBase
 {
     [XmlElement("link")]
-    public GpxLink[] link { get; set; }
+    public GpxLink[]? link { get; set; }
 
-    public string type { get; set; }
+    public string? type { get; set; }
 
     //public extensionsType extensions { get; set; }
 
     [XmlElement("rtept")]
-    public GpxWaypoint[] rtept { get; set; }
+    public GpxWaypoint[]? rtept { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxTrack.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxTrack.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
@@ -6,12 +7,12 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
 public class GpxTrack : GpxRteTrkBase
 {
     [XmlElement("link")]
-    public GpxLink[] link { get; set; }
+    public GpxLink[]? link { get; set; }
 
-    public string type { get; set; }
+    public string? type { get; set; }
 
     //public extensionsType extensions { get; set; }
 
     [XmlElement("trkseg")]
-    public GpxTrackSegment[] trkseg { get; set; }
+    public GpxTrackSegment[]? trkseg { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxTrackSegment.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxTrackSegment.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
@@ -6,7 +7,7 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
 public class GpxTrackSegment
 {
     [XmlElement("trkpt")]
-    public GpxWaypoint[] trkpt { get; set; }
+    public GpxWaypoint[]? trkpt { get; set; }
 
     //public extensionsType extensions { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxWaypoint.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxWaypoint.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
@@ -6,7 +7,7 @@ namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;
 public class GpxWaypoint : GpxWaypointBase
 {
     [XmlElement("link")]
-    public GpxLink[] link { get; set; }
+    public GpxLink[]? link { get; set; }
 
     public GpxFixType fix { get; set; }
     //public extensionsType extensions { get; set; }

--- a/Geo/Gps/Serialization/Xml/Gpx/GpxBoundsBase.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/GpxBoundsBase.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx;

--- a/Geo/Gps/Serialization/Xml/Gpx/GpxMetadataBase.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/GpxMetadataBase.cs
@@ -1,16 +1,17 @@
-﻿using System;
+#nullable enable
+using System;
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx;
 
 public abstract class GpxMetadataBase
 {
-    public string name { get; set; }
-    public string desc { get; set; }
+    public string? name { get; set; }
+    public string? desc { get; set; }
     public DateTime time { get; set; }
 
     [XmlIgnore]
     public bool timeSpecified { get; set; }
 
-    public string keywords { get; set; }
+    public string? keywords { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/GpxRteTrkBase.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/GpxRteTrkBase.cs
@@ -1,14 +1,15 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx;
 
 public abstract class GpxRteTrkBase
 {
-    public string name { get; set; }
-    public string cmt { get; set; }
-    public string desc { get; set; }
-    public string src { get; set; }
+    public string? name { get; set; }
+    public string? cmt { get; set; }
+    public string? desc { get; set; }
+    public string? src { get; set; }
 
     [XmlElement(DataType = "nonNegativeInteger")]
-    public string number { get; set; }
+    public string? number { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/Gpx/GpxWaypointBase.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/GpxWaypointBase.cs
@@ -1,4 +1,5 @@
-﻿using System;
+#nullable enable
+using System;
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx;
@@ -25,23 +26,23 @@ public abstract class GpxWaypointBase
     [XmlIgnore]
     public bool geoidheightSpecified { get; set; }
 
-    public string name { get; set; }
+    public string? name { get; set; }
 
-    public string cmt { get; set; }
+    public string? cmt { get; set; }
 
-    public string desc { get; set; }
+    public string? desc { get; set; }
 
-    public string src { get; set; }
+    public string? src { get; set; }
 
-    public string sym { get; set; }
+    public string? sym { get; set; }
 
-    public string type { get; set; }
+    public string? type { get; set; }
 
     [XmlIgnore]
     public bool fixSpecified { get; set; }
 
     [XmlElement(DataType = "nonNegativeInteger")]
-    public string sat { get; set; }
+    public string? sat { get; set; }
 
     public decimal hdop { get; set; }
 
@@ -64,7 +65,7 @@ public abstract class GpxWaypointBase
     public bool ageofdgpsdataSpecified { get; set; }
 
     [XmlElement(DataType = "integer")]
-    public string dgpsid { get; set; }
+    public string? dgpsid { get; set; }
 
     [XmlAttribute]
     public decimal lat { get; set; }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFMSFlightplanTimeMeasure.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFMSFlightplanTimeMeasure.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Xml.Serialization;
 
@@ -10,5 +11,5 @@ public class PocketFMSFlightplanTimeMeasure
     public DateTime Value { get; set; }
 
     [XmlAttribute]
-    public string Unit { get; set; }
+    public string? Unit { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAircraft.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAircraft.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,47 +8,47 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsAircraft
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AircraftDescription { get; set; }
+    public string? AircraftDescription { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<short> SpeedVx { get; set; }
+    public PocketFmsMeasure<short>? SpeedVx { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<short> SpeedVy { get; set; }
+    public PocketFmsMeasure<short>? SpeedVy { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<short> SpeedCruise { get; set; }
+    public PocketFmsMeasure<short>? SpeedCruise { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<short> SpeedHolding { get; set; }
+    public PocketFmsMeasure<short>? SpeedHolding { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<short> SpeedApproach { get; set; }
+    public PocketFmsMeasure<short>? SpeedApproach { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> FuelConsumptionVx { get; set; }
+    public PocketFmsMeasure<decimal>? FuelConsumptionVx { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> FuelConsumptionVy { get; set; }
+    public PocketFmsMeasure<decimal>? FuelConsumptionVy { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> FuelConsumptionCruise { get; set; }
+    public PocketFmsMeasure<decimal>? FuelConsumptionCruise { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> FuelConsumptionHolding { get; set; }
+    public PocketFmsMeasure<decimal>? FuelConsumptionHolding { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> FuelConsumptionApproach { get; set; }
+    public PocketFmsMeasure<decimal>? FuelConsumptionApproach { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> AvarageRateOfDescend { get; set; }
+    public PocketFmsMeasure<decimal>? AvarageRateOfDescend { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> AvarageRateOfClimb { get; set; }
+    public PocketFmsMeasure<decimal>? AvarageRateOfClimb { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsSuitableDefinitions SuitableDefinitions { get; set; }
+    public PocketFmsSuitableDefinitions? SuitableDefinitions { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsWeightAndBalance WeightAndBalance { get; set; }
+    public PocketFmsWeightAndBalance? WeightAndBalance { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAirportData.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAirportData.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,53 +8,53 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsAirportData
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string Cityname { get; set; }
+    public string? Cityname { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string type { get; set; }
+    public string? type { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string agency { get; set; }
+    public string? agency { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string fuel { get; set; }
+    public string? fuel { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string oil { get; set; }
+    public string? oil { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string HasPrecisionApproachYN { get; set; }
+    public string? HasPrecisionApproachYN { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string HasNonPrecisionApproachYN { get; set; }
+    public string? HasNonPrecisionApproachYN { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string HasVFRReportingPointsYN { get; set; }
+    public string? HasVFRReportingPointsYN { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsValue<short> LongestHardRunway { get; set; }
+    public PocketFmsValue<short>? LongestHardRunway { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsValue<short> LongestSoftRunway { get; set; }
+    public PocketFmsValue<short>? LongestSoftRunway { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string HasWaterRunwayYN { get; set; }
+    public string? HasWaterRunwayYN { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string IsAbandonedYN { get; set; }
+    public string? IsAbandonedYN { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AllowedAircraftTypes { get; set; }
+    public string? AllowedAircraftTypes { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string HasMetarTafYN { get; set; }
+    public string? HasMetarTafYN { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string PPRYN { get; set; }
+    public string? PPRYN { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string EmergencyUseOnlyYN { get; set; }
+    public string? EmergencyUseOnlyYN { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string VisibleButDestroyedYN { get; set; }
+    public string? VisibleButDestroyedYN { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAirspace.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAirspace.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,53 +8,53 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsAirspace
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsAirspaceEntryExitPoint AirspaceEntryPoint { get; set; }
+    public PocketFmsAirspaceEntryExitPoint? AirspaceEntryPoint { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsAirspaceEntryExitPoint AirspaceExitPoint { get; set; }
+    public PocketFmsAirspaceEntryExitPoint? AirspaceExitPoint { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceName { get; set; }
+    public string? AirspaceName { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceType { get; set; }
+    public string? AirspaceType { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceComm1 { get; set; }
+    public string? AirspaceComm1 { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceComm2 { get; set; }
+    public string? AirspaceComm2 { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceCommName { get; set; }
+    public string? AirspaceCommName { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceCommAuth { get; set; }
+    public string? AirspaceCommAuth { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceLowerAltFt { get; set; }
+    public string? AirspaceLowerAltFt { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceUpperAltFt { get; set; }
+    public string? AirspaceUpperAltFt { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceClass { get; set; }
+    public string? AirspaceClass { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceClassRemarks { get; set; }
+    public string? AirspaceClassRemarks { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceSUASIdentifier { get; set; }
+    public string? AirspaceSUASIdentifier { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceRemarks { get; set; }
+    public string? AirspaceRemarks { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceActivity { get; set; }
+    public string? AirspaceActivity { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceActiveFromDateTime { get; set; }
+    public string? AirspaceActiveFromDateTime { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AirspaceActiveUpToDateTime { get; set; }
+    public string? AirspaceActiveUpToDateTime { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAirspaceEntryExitPoint.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAirspaceEntryExitPoint.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Xml.Schema;
 using System.Xml.Serialization;
@@ -14,7 +15,7 @@ public class PocketFmsAirspaceEntryExitPoint
     public decimal Longitude { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFMSFlightplanTimeMeasure ETECUMMULATIVE { get; set; }
+    public PocketFMSFlightplanTimeMeasure? ETECUMMULATIVE { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified, DataType = "time")]
     public DateTime ETAUTC { get; set; }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsCgLimit.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsCgLimit.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,8 +8,8 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsCgLimit
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> YValue_Weight { get; set; }
+    public PocketFmsMeasure<decimal>? YValue_Weight { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> XValue_CG { get; set; }
+    public PocketFmsMeasure<decimal>? XValue_CG { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsComm.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsComm.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;
@@ -6,10 +7,10 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsComm
 {
     [XmlAttribute]
-    public string Sector { get; set; }
+    public string? Sector { get; set; }
 
     [XmlAttribute]
-    public string OprHrs { get; set; }
+    public string? OprHrs { get; set; }
 
     [XmlAttribute]
     public decimal Freq5 { get; set; }
@@ -27,8 +28,8 @@ public class PocketFmsComm
     public decimal Freq1 { get; set; }
 
     [XmlAttribute]
-    public string CommType { get; set; }
+    public string? CommType { get; set; }
 
     [XmlAttribute]
-    public string CommRemarks { get; set; }
+    public string? CommRemarks { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsContingencyFuel.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsContingencyFuel.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsDepartureArrival.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsDepartureArrival.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,7 +8,7 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsDepartureArrival
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string StringIdent { get; set; }
+    public string? StringIdent { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
     public decimal Latitude { get; set; }
@@ -16,20 +17,20 @@ public class PocketFmsDepartureArrival
     public decimal Longitude { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string FriendlyShortname { get; set; }
+    public string? FriendlyShortname { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string Fullname { get; set; }
+    public string? Fullname { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string Elevation { get; set; }
+    public string? Elevation { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsRNav RNAV1 { get; set; }
+    public PocketFmsRNav? RNAV1 { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsRNav RNAV2 { get; set; }
+    public PocketFmsRNav? RNAV2 { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsDetailedObjectInfo DetailedObjectInfo { get; set; }
+    public PocketFmsDetailedObjectInfo? DetailedObjectInfo { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsDetailedObjectInfo.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsDetailedObjectInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Schema;
+#nullable enable
+using System.Xml.Schema;
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;
@@ -7,13 +8,13 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsDetailedObjectInfo
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsAirportData AirportData { get; set; }
+    public PocketFmsAirportData? AirportData { get; set; }
 
     [XmlArray(Form = XmlSchemaForm.Unqualified)]
     [XmlArrayItem("COMM", Form = XmlSchemaForm.Unqualified, IsNullable = false)]
-    public PocketFmsComm[] Communications { get; set; }
+    public PocketFmsComm[]? Communications { get; set; }
 
     [XmlArray(Form = XmlSchemaForm.Unqualified)]
     [XmlArrayItem("Remark", Form = XmlSchemaForm.Unqualified, IsNullable = false)]
-    public PocketFmsRemark[] Remarks { get; set; }
+    public PocketFmsRemark[]? Remarks { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsFlightplan.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsFlightplan.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -8,7 +9,7 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsFlightplan
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeta META { get; set; }
+    public PocketFmsMeta? META { get; set; }
 
     //[XmlElement(Form=XmlSchemaForm.Unqualified)]
     //public PocketFmsFuel FUEL { get; set; }
@@ -17,7 +18,7 @@ public class PocketFmsFlightplan
     //public PocketFmsSupplementaryInformation SUPPLEMENTARYINFORMATION { get; set; }
 
     [XmlElement("LIB", Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsLib[] LIB { get; set; }
+    public PocketFmsLib[]? LIB { get; set; }
 
     //[XmlElement(Form=XmlSchemaForm.Unqualified)]
     //public PocketFmsAircraft AIRCRAFT { get; set; }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsFuel.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsFuel.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,32 +8,32 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsFuel
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasureSpecified<decimal> TotalTripFuel { get; set; }
+    public PocketFmsMeasureSpecified<decimal>? TotalTripFuel { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasureSpecified<decimal> TaxiAndDepartureFuel { get; set; }
+    public PocketFmsMeasureSpecified<decimal>? TaxiAndDepartureFuel { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasureSpecified<decimal> ArrivalAndTaxiFuel { get; set; }
+    public PocketFmsMeasureSpecified<decimal>? ArrivalAndTaxiFuel { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasureSpecified<decimal> AlternateApproachFuel { get; set; }
+    public PocketFmsMeasureSpecified<decimal>? AlternateApproachFuel { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsReserveFuel ReserveFuel { get; set; }
+    public PocketFmsReserveFuel? ReserveFuel { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsContingencyFuel ContingencyFuel { get; set; }
+    public PocketFmsContingencyFuel? ContingencyFuel { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasureSpecified<decimal> LoadedFuel { get; set; }
+    public PocketFmsMeasureSpecified<decimal>? LoadedFuel { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasureSpecified<decimal> TotalFuel { get; set; }
+    public PocketFmsMeasureSpecified<decimal>? TotalFuel { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasureSpecified<decimal> LongestAlternateFuel { get; set; }
+    public PocketFmsMeasureSpecified<decimal>? LongestAlternateFuel { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasureSpecified<decimal> LongestAlternateDistance { get; set; }
+    public PocketFmsMeasureSpecified<decimal>? LongestAlternateDistance { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsLib.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsLib.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,10 +8,10 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsLib
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsPoint FromPoint { get; set; }
+    public PocketFmsPoint? FromPoint { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsPoint ToPoint { get; set; }
+    public PocketFmsPoint? ToPoint { get; set; }
 
     //[XmlElement(Form = XmlSchemaForm.Unqualified, DataType = "time")]
     //public System.DateTime ETAUTC { get; set; }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMeasure.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMeasure.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;
@@ -6,5 +7,5 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsMeasure<T> : PocketFmsValue<T>
 {
     [XmlAttribute]
-    public string Unit { get; set; }
+    public string? Unit { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMeasureSpecified.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMeasureSpecified.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMeta.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMeta.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -31,7 +32,7 @@ public class PocketFmsMeta
     //public PocketFmsDepartureArrival Arrival { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AircraftIdentification { get; set; }
+    public string? AircraftIdentification { get; set; }
 
     //[XmlElement(Form=XmlSchemaForm.Unqualified)]
     //public string RoutingString { get; set; }
@@ -43,7 +44,7 @@ public class PocketFmsMeta
     //public string FlightType { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string AircraftType { get; set; }
+    public string? AircraftType { get; set; }
 
     //[XmlElement(Form=XmlSchemaForm.Unqualified)]
     //public string WakeTurbulence { get; set; }
@@ -58,7 +59,7 @@ public class PocketFmsMeta
     //public string AircraftColorAndMarkings { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string PilotInCommand { get; set; }
+    public string? PilotInCommand { get; set; }
 
     //[XmlElement(Form=XmlSchemaForm.Unqualified)]
     //public string PilotInCommandCompany { get; set; }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMomentLimit.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMomentLimit.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,8 +8,8 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsMomentLimit
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> YValue_Weight { get; set; }
+    public PocketFmsMeasure<decimal>? YValue_Weight { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> XValue_Moment { get; set; }
+    public PocketFmsMeasure<decimal>? XValue_Moment { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsPoint.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsPoint.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsRNav.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsRNav.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;
@@ -9,7 +10,7 @@ public class PocketFmsRNav
     public decimal BEACONRADIAL { get; set; }
 
     [XmlAttribute]
-    public string BEACONIDENT { get; set; }
+    public string? BEACONIDENT { get; set; }
 
     [XmlAttribute]
     public decimal BEACONFREQUENCY { get; set; }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsRemark.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsRemark.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;
@@ -6,8 +7,8 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsRemark
 {
     [XmlAttribute]
-    public string RemarkType { get; set; }
+    public string? RemarkType { get; set; }
 
     [XmlAttribute]
-    public string RemarkText { get; set; }
+    public string? RemarkText { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsReserveFuel.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsReserveFuel.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;
@@ -6,7 +7,7 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsReserveFuel : PocketFmsMeasureSpecified<decimal>
 {
     [XmlAttribute]
-    public string DurationUnit { get; set; }
+    public string? DurationUnit { get; set; }
 
     [XmlAttribute]
     public short Duration { get; set; }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsSuitableDefinitions.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsSuitableDefinitions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -34,14 +35,14 @@ public class PocketFmsSuitableDefinitions
     public sbyte MusthaveNonPrecisionApproach { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> MinimumHardRunwayLength { get; set; }
+    public PocketFmsMeasure<decimal>? MinimumHardRunwayLength { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> MinimumSoftRunwayLength { get; set; }
+    public PocketFmsMeasure<decimal>? MinimumSoftRunwayLength { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> MinimumCloudbase { get; set; }
+    public PocketFmsMeasure<decimal>? MinimumCloudbase { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> MaximumCrosswind { get; set; }
+    public PocketFmsMeasure<decimal>? MaximumCrosswind { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsSupplementaryInformation.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsSupplementaryInformation.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,7 +8,7 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsSupplementaryInformation
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<string> Endurance { get; set; }
+    public PocketFmsMeasure<string>? Endurance { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
     public sbyte POB { get; set; }
@@ -58,14 +59,14 @@ public class PocketFmsSupplementaryInformation
     public sbyte bDinghies { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string DinghiesNumber { get; set; }
+    public string? DinghiesNumber { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string DinghiesCapacity { get; set; }
+    public string? DinghiesCapacity { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
     public sbyte bDinghiesCover { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public string DinghiesCoverColor { get; set; }
+    public string? DinghiesCoverColor { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsValue.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsValue.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;
@@ -6,5 +7,5 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsValue<T>
 {
     [XmlAttribute]
-    public T Value { get; set; }
+    public T? Value { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsWeightAndBalance.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsWeightAndBalance.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,13 +8,13 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsWeightAndBalance
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsWeightAndBalanceData WBData { get; set; }
+    public PocketFmsWeightAndBalanceData? WBData { get; set; }
 
     [XmlArray(Form = XmlSchemaForm.Unqualified)]
     [XmlArrayItem("WBMomentLimitPoint", Form = XmlSchemaForm.Unqualified, IsNullable = false)]
-    public PocketFmsMomentLimit[] WBMomentLimits { get; set; }
+    public PocketFmsMomentLimit[]? WBMomentLimits { get; set; }
 
     [XmlArray(Form = XmlSchemaForm.Unqualified)]
     [XmlArrayItem("WBMomentLimitPoint", Form = XmlSchemaForm.Unqualified, IsNullable = false)]
-    public PocketFmsCgLimit[] WBCGLimits { get; set; }
+    public PocketFmsCgLimit[]? WBCGLimits { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsWeightAndBalanceData.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsWeightAndBalanceData.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,14 +8,14 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsWeightAndBalanceData
 {
     [XmlElement("WBDataRecord", Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsWeightAndBalanceDataRecord[] WBDataRecord { get; set; }
+    public PocketFmsWeightAndBalanceDataRecord[]? WBDataRecord { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> PlaneTotalWeight { get; set; }
+    public PocketFmsMeasure<decimal>? PlaneTotalWeight { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> PlaneTotalArm { get; set; }
+    public PocketFmsMeasure<decimal>? PlaneTotalArm { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> PlaneTotalMoment { get; set; }
+    public PocketFmsMeasure<decimal>? PlaneTotalMoment { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsWeightAndBalanceDataRecord.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsWeightAndBalanceDataRecord.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,14 +8,14 @@ namespace Geo.Gps.Serialization.Xml.PocketFms;
 public class PocketFmsWeightAndBalanceDataRecord
 {
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> Weight { get; set; }
+    public PocketFmsMeasure<decimal>? Weight { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> Arm { get; set; }
+    public PocketFmsMeasure<decimal>? Arm { get; set; }
 
     [XmlElement(Form = XmlSchemaForm.Unqualified)]
-    public PocketFmsMeasure<decimal> Moment { get; set; }
+    public PocketFmsMeasure<decimal>? Moment { get; set; }
 
     [XmlAttribute]
-    public string WBDescription { get; set; }
+    public string? WBDescription { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonAircraft.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonAircraft.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;
@@ -22,7 +23,7 @@ public class SkyDemonAircraft
     //public string Name { get; set; }
 
     [XmlAttribute]
-    public string Registration { get; set; }
+    public string? Registration { get; set; }
 
     //[XmlAttribute]
     //public string FuelType { get; set; }
@@ -55,7 +56,7 @@ public class SkyDemonAircraft
     //public string EmptyArmLat { get; set; }
 
     [XmlAttribute]
-    public string Type { get; set; }
+    public string? Type { get; set; }
 
     //[XmlAttribute]
     //public string ColourMarkings { get; set; }

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonClimbProfile.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonClimbProfile.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;
@@ -6,17 +7,17 @@ namespace Geo.Gps.Serialization.Xml.SkyDemon;
 public class SkyDemonClimbProfile
 {
     [XmlAttribute]
-    public string FpmSL { get; set; }
+    public string? FpmSL { get; set; }
 
     [XmlAttribute]
-    public string FpmSC { get; set; }
+    public string? FpmSC { get; set; }
 
     [XmlAttribute]
-    public string IndicatedAirspeed { get; set; }
+    public string? IndicatedAirspeed { get; set; }
 
     [XmlAttribute]
-    public string FuelBurnSL { get; set; }
+    public string? FuelBurnSL { get; set; }
 
     [XmlAttribute]
-    public string FuelBurnSC { get; set; }
+    public string? FuelBurnSC { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonCruiseProfile.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonCruiseProfile.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;
@@ -6,17 +7,17 @@ namespace Geo.Gps.Serialization.Xml.SkyDemon;
 public class SkyDemonCruiseProfile
 {
     [XmlAttribute]
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     [XmlAttribute]
-    public string FuelBurn { get; set; }
+    public string? FuelBurn { get; set; }
 
     [XmlAttribute]
-    public string IndicatedAirspeed { get; set; }
+    public string? IndicatedAirspeed { get; set; }
 
     [XmlAttribute]
-    public string Airspeed { get; set; }
+    public string? Airspeed { get; set; }
 
     [XmlAttribute]
-    public string AirspeedType { get; set; }
+    public string? AirspeedType { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonDescentProfile.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonDescentProfile.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;
@@ -6,11 +7,11 @@ namespace Geo.Gps.Serialization.Xml.SkyDemon;
 public class SkyDemonDescentProfile
 {
     [XmlAttribute]
-    public string Fpm { get; set; }
+    public string? Fpm { get; set; }
 
     [XmlAttribute]
-    public string IndicatedAirspeed { get; set; }
+    public string? IndicatedAirspeed { get; set; }
 
     [XmlAttribute]
-    public string FuelBurn { get; set; }
+    public string? FuelBurn { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonFlightplan.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonFlightplan.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Schema;
+#nullable enable
+using System.Xml.Schema;
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;
@@ -8,15 +9,15 @@ namespace Geo.Gps.Serialization.Xml.SkyDemon;
 public class SkyDemonFlightplan
 {
     [XmlElement("Aircraft", typeof(SkyDemonAircraft), Form = XmlSchemaForm.Unqualified)]
-    public SkyDemonAircraft[] Aircraft { get; set; }
+    public SkyDemonAircraft[]? Aircraft { get; set; }
 
     //[XmlElement("LoadingPoint", typeof(SkyDemonLoadingPoint))]
     //public SkyDemonLoadingPoint[] LoadingPoint { get; set; }
     [XmlElement("PrimaryRoute", typeof(SkyDemonRoute), Form = XmlSchemaForm.Unqualified)]
-    public SkyDemonRoute PrimaryRoute { get; set; }
+    public SkyDemonRoute? PrimaryRoute { get; set; }
 
     [XmlElement("Route", typeof(SkyDemonRoute), Form = XmlSchemaForm.Unqualified)]
-    public SkyDemonRoute[] Routes { get; set; }
+    public SkyDemonRoute[]? Routes { get; set; }
     //[XmlElement("WaypointNameHints", typeof (SkyDemonWaypointNameHints), Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
     //public SkyDemonWaypointNameHints WaypointNameHints { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonFuelLoadingPoint.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonFuelLoadingPoint.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;
@@ -6,17 +7,17 @@ namespace Geo.Gps.Serialization.Xml.SkyDemon;
 public class SkyDemonFuelLoadingPoint
 {
     [XmlAttribute]
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     [XmlAttribute]
-    public string LeverArm { get; set; }
+    public string? LeverArm { get; set; }
 
     [XmlAttribute]
-    public string LeverArmLat { get; set; }
+    public string? LeverArmLat { get; set; }
 
     [XmlAttribute]
-    public string DefaultValue { get; set; }
+    public string? DefaultValue { get; set; }
 
     [XmlAttribute]
-    public string Capacity { get; set; }
+    public string? Capacity { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonLoadingPoint.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonLoadingPoint.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;
@@ -7,17 +8,17 @@ namespace Geo.Gps.Serialization.Xml.SkyDemon;
 public class SkyDemonLoadingPoint
 {
     [XmlAttribute]
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     [XmlAttribute]
-    public string LeverArm { get; set; }
+    public string? LeverArm { get; set; }
 
     [XmlAttribute]
-    public string LeverArmLat { get; set; }
+    public string? LeverArmLat { get; set; }
 
     [XmlAttribute]
-    public string DefaultValue { get; set; }
+    public string? DefaultValue { get; set; }
 
     [XmlAttribute]
-    public string Weight { get; set; }
+    public string? Weight { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonLoadingPoints.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonLoadingPoints.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,8 +8,8 @@ namespace Geo.Gps.Serialization.Xml.SkyDemon;
 public class SkyDemonLoadingPoints
 {
     [XmlElement("FuelLoadingPoint", Form = XmlSchemaForm.Unqualified)]
-    public SkyDemonFuelLoadingPoint[] FuelLoadingPoint { get; set; }
+    public SkyDemonFuelLoadingPoint[]? FuelLoadingPoint { get; set; }
 
     [XmlElement("LoadingPoint")]
-    public SkyDemonLoadingPoint[] LoadingPoint { get; set; }
+    public SkyDemonLoadingPoint[]? LoadingPoint { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonRhumbLine.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonRhumbLine.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;
@@ -6,11 +7,11 @@ namespace Geo.Gps.Serialization.Xml.SkyDemon;
 public class SkyDemonRhumbLine
 {
     [XmlAttribute]
-    public string To { get; set; }
+    public string? To { get; set; }
 
     [XmlAttribute]
-    public string Level { get; set; }
+    public string? Level { get; set; }
 
     [XmlAttribute]
-    public string LevelChange { get; set; }
+    public string? LevelChange { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonRoute.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonRoute.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,7 +8,7 @@ namespace Geo.Gps.Serialization.Xml.SkyDemon;
 public class SkyDemonRoute
 {
     [XmlElement("RhumbLineRoute", Form = XmlSchemaForm.Unqualified)]
-    public SkyDemonRhumbLine[] RhumbLineRoute { get; set; }
+    public SkyDemonRhumbLine[]? RhumbLineRoute { get; set; }
 
     //[XmlElement("Alternate", Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
     //public SkyDemonRhumbLine[] Alternate { get; set; }
@@ -17,10 +18,10 @@ public class SkyDemonRoute
     //public SkyDemonLoadingPoint[][] WeightBalance { get; set; }
 
     [XmlAttribute]
-    public string Start { get; set; }
+    public string? Start { get; set; }
 
     [XmlAttribute]
-    public string Level { get; set; }
+    public string? Level { get; set; }
 
     //[XmlAttribute]
     //public string CruiseProfile { get; set; }

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonWaypointNameHint.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonWaypointNameHint.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;
@@ -6,8 +7,8 @@ namespace Geo.Gps.Serialization.Xml.SkyDemon;
 public class SkyDemonWaypointNameHint
 {
     [XmlAttribute]
-    public string Location { get; set; }
+    public string? Location { get; set; }
 
     [XmlAttribute]
-    public string Name { get; set; }
+    public string? Name { get; set; }
 }

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonWaypointNameHints.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonWaypointNameHints.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
@@ -7,5 +8,5 @@ namespace Geo.Gps.Serialization.Xml.SkyDemon;
 public class SkyDemonWaypointNameHints
 {
     [XmlElement("Hint", Form = XmlSchemaForm.Unqualified)]
-    public SkyDemonWaypointNameHint[] Hint { get; set; }
+    public SkyDemonWaypointNameHint[]? Hint { get; set; }
 }


### PR DESCRIPTION
Completes the library-wide nullable-reference-types migration begun in #93 by covering the last hand-written code that was deferred there: the GPS XML model classes and the five serializers coupled to them.

## What's included

**GPS XML DTOs (66 files)** — `#nullable enable` across all the `Gpx*`/`Garmin*`/`PocketFms*`/`SkyDemon*` model classes under `Gps/Serialization/Xml`. These are pure XML-mapped property bags populated by `XmlSerializer` via reflection, where any element or attribute may be absent, so every reference-type property (strings, arrays, nested DTOs) is annotated nullable. Value-type properties and their `*Specified` companions are unchanged; the one initialised property (`GpxFile.version`) stays non-null. (The two `GpxFixType` enums have no reference-type surface and are left untouched.)

**GPS format serializers (5 files)** — `#nullable enable` for the GPX 1.0/1.1 serializers and the Garmin/PocketFMS/SkyDemon flightplan deserializers, now that their DTOs are annotated:
- `SkyDemonFlightplanDeSerializer.DeSerialize` returns `GpsData?` (it returns null for a null document), matching the `GpsXmlDeSerializer<T>` base contract.
- The read paths dereference XML elements that may be absent (route/waypoint collections, coordinate points, metadata); they already threw a `NullReferenceException` on malformed input, and that behaviour is preserved via the null-forgiving operator rather than adding new guards.
- The write paths needed no changes — the compiler's flow analysis tracks the existing lazy-initialisation null checks.

## Notes

- **Annotate-only and binary-compatible** — no runtime null checks were added or removed; the annotations are metadata-only.
- With this change, every hand-written source file in the library is nullable-annotated. The only remaining files without `#nullable enable` are pure enums, the generated geomagnetism coefficient tables, and the vendored `SimpleJson.cs` — all by design.
- Builds with 0 warnings; the full test suite (495 tests) stays green.

This is a follow-up to the merged #93, not a continuation of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYc6qCcDnL5BZ5c3Bm7yAp)_