### PR TITLE
Switch to project-wide nullable reference types

### DIFF
--- a/Geo/Abstractions/Interfaces/IGeoJsonObject.cs
+++ b/Geo/Abstractions/Interfaces/IGeoJsonObject.cs
@@ -1,4 +1,3 @@
-#nullable enable
 namespace Geo.Abstractions.Interfaces;
 
 public interface IGeoJsonObject

--- a/Geo/Abstractions/Interfaces/IGeodeticCalculator.cs
+++ b/Geo/Abstractions/Interfaces/IGeodeticCalculator.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Geo.Geodesy;
 using Geo.Geometries;
 using Geo.Measure;

--- a/Geo/Abstractions/Interfaces/IMeasure.cs
+++ b/Geo/Abstractions/Interfaces/IMeasure.cs
@@ -1,4 +1,3 @@
-#nullable enable
 namespace Geo.Abstractions.Interfaces;
 
 public interface IMeasure

--- a/Geo/Abstractions/Interfaces/IPosition.cs
+++ b/Geo/Abstractions/Interfaces/IPosition.cs
@@ -1,4 +1,3 @@
-#nullable enable
 namespace Geo.Abstractions.Interfaces;
 
 public interface IPosition

--- a/Geo/Geo.csproj
+++ b/Geo/Geo.csproj
@@ -15,6 +15,7 @@
     <DefineConstants>SIMPLE_JSON_TYPEINFO</DefineConstants>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>default</LangVersion>
+    <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Geo/Geodesy/SphereCalculator.cs
+++ b/Geo/Geodesy/SphereCalculator.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using Geo.Abstractions.Interfaces;
 using Geo.Geometries;

--- a/Geo/Geodesy/SpheroidCalculator.cs
+++ b/Geo/Geodesy/SpheroidCalculator.cs
@@ -2,7 +2,6 @@
 // http://williams.best.vwh.net/
 // https://github.com/geotools/geotools/blob/master/modules/library/referencing/src/main/java/org/geotools/referencing/datum/DefaultEllipsoid.java
 
-#nullable enable
 using System;
 using Geo.Abstractions.Interfaces;
 using Geo.Geometries;

--- a/Geo/Geomagnetism/Models/IgrfModelFactory.cs
+++ b/Geo/Geomagnetism/Models/IgrfModelFactory.cs
@@ -5922,9 +5922,9 @@ public class IgrfModelFactory
     {
         public DateTime ValidFrom { get; set; }
         public DateTime ValidTo { get; set; }
-        public double[,] MainCoefficientsG { get; set; }
-        public double[,] MainCoefficientsH { get; set; }
-        public double[,] SecularCoefficientsG { get; set; }
-        public double[,] SecularCoefficientsH { get; set; }
+        public double[,] MainCoefficientsG { get; set; } = null!;
+        public double[,] MainCoefficientsH { get; set; } = null!;
+        public double[,] SecularCoefficientsG { get; set; } = null!;
+        public double[,] SecularCoefficientsH { get; set; } = null!;
     }
 }

--- a/Geo/Geometries/MultiLineString.cs
+++ b/Geo/Geometries/MultiLineString.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions.Interfaces;

--- a/Geo/Geometries/MultiPoint.cs
+++ b/Geo/Geometries/MultiPoint.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions.Interfaces;

--- a/Geo/Geometries/MultiPolygon.cs
+++ b/Geo/Geometries/MultiPolygon.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions.Interfaces;

--- a/Geo/Gps/GpsData.cs
+++ b/Geo/Gps/GpsData.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/Geo/Gps/GpsFeaturesExtensions.cs
+++ b/Geo/Gps/GpsFeaturesExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 namespace Geo.Gps;
 
 public static class GpsFeaturesExtensions

--- a/Geo/Gps/Metadata/GpsMetadata.cs
+++ b/Geo/Gps/Metadata/GpsMetadata.cs
@@ -1,4 +1,3 @@
-#nullable enable
 namespace Geo.Gps.Metadata;
 
 public class GpsMetadata : Metadata<GpsMetadata.MetadataKeys>

--- a/Geo/Gps/Metadata/Metadata.cs
+++ b/Geo/Gps/Metadata/Metadata.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 

--- a/Geo/Gps/Metadata/RouteMetadata.cs
+++ b/Geo/Gps/Metadata/RouteMetadata.cs
@@ -1,4 +1,3 @@
-#nullable enable
 namespace Geo.Gps.Metadata;
 
 public class RouteMetadata : Metadata<RouteMetadata.MetadataKeys>

--- a/Geo/Gps/Metadata/TrackMetadata.cs
+++ b/Geo/Gps/Metadata/TrackMetadata.cs
@@ -1,4 +1,3 @@
-#nullable enable
 namespace Geo.Gps.Metadata;
 
 public class TrackMetadata : Metadata<TrackMetadata.MetadataKeys>

--- a/Geo/Gps/Route.cs
+++ b/Geo/Gps/Route.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions.Interfaces;

--- a/Geo/Gps/Serialization/GarminFlightplanDeSerializer.cs
+++ b/Geo/Gps/Serialization/GarminFlightplanDeSerializer.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Linq;
 using System.Xml;
 using Geo.Gps.Serialization.Xml;

--- a/Geo/Gps/Serialization/Gpx10Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx10Serializer.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Geo/Gps/Serialization/Gpx11Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx11Serializer.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Geo/Gps/Serialization/IGpsFileDeSerializer.cs
+++ b/Geo/Gps/Serialization/IGpsFileDeSerializer.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Geo/Gps/Serialization/PocketFmsFlightplanDeSerializer.cs
+++ b/Geo/Gps/Serialization/PocketFmsFlightplanDeSerializer.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml;
 using Geo.Gps.Serialization.Xml;
 using Geo.Gps.Serialization.Xml.PocketFms;

--- a/Geo/Gps/Serialization/SkyDemonFlightplanDeSerializer.cs
+++ b/Geo/Gps/Serialization/SkyDemonFlightplanDeSerializer.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Xml;

--- a/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminFlightplan.cs
+++ b/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminFlightplan.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Garmin.Flightplan;

--- a/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminRoute.cs
+++ b/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminRoute.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Garmin.Flightplan;

--- a/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminRoutePoint.cs
+++ b/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminRoutePoint.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Garmin.Flightplan;

--- a/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminWaypoint.cs
+++ b/Geo/Gps/Serialization/Xml/Garmin/Flightplan/GarminWaypoint.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Garmin.Flightplan;

--- a/Geo/Gps/Serialization/Xml/GpsXmlDeSerializer.cs
+++ b/Geo/Gps/Serialization/Xml/GpsXmlDeSerializer.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Xml;
 using System.Xml.Serialization;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxBounds.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxBounds.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxFile.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxFile.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxPoint.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxPoint.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxRoute.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxRoute.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxTrack.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxTrack.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxTrackPoint.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxTrackPoint.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxTrackSegment.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx10/GpxTrackSegment.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx10;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxBounds.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxBounds.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxCopyright.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxCopyright.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxEmail.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxEmail.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxExtensions.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxFile.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxFile.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxLink.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxLink.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxMetadata.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxMetadata.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxPerson.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxPerson.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxRoute.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxRoute.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxTrack.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxTrack.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxTrackSegment.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxTrackSegment.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;

--- a/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxWaypoint.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/Gpx11/GpxWaypoint.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx.Gpx11;

--- a/Geo/Gps/Serialization/Xml/Gpx/GpxBoundsBase.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/GpxBoundsBase.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx;

--- a/Geo/Gps/Serialization/Xml/Gpx/GpxMetadataBase.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/GpxMetadataBase.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/Gpx/GpxRteTrkBase.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/GpxRteTrkBase.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.Gpx;

--- a/Geo/Gps/Serialization/Xml/Gpx/GpxWaypointBase.cs
+++ b/Geo/Gps/Serialization/Xml/Gpx/GpxWaypointBase.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/NamespaceCoercingXmlReader.cs
+++ b/Geo/Gps/Serialization/Xml/NamespaceCoercingXmlReader.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml;
 
 namespace Geo.Gps.Serialization.Xml;

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFMSFlightplanTimeMeasure.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFMSFlightplanTimeMeasure.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAircraft.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAircraft.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAirportData.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAirportData.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAirspace.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAirspace.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAirspaceEntryExitPoint.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsAirspaceEntryExitPoint.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Xml.Schema;
 using System.Xml.Serialization;

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsCgLimit.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsCgLimit.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsComm.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsComm.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsContingencyFuel.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsContingencyFuel.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsDepartureArrival.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsDepartureArrival.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsDetailedObjectInfo.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsDetailedObjectInfo.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsFlightplan.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsFlightplan.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsFuel.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsFuel.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsLib.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsLib.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMeasure.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMeasure.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMeasureSpecified.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMeasureSpecified.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMeta.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMeta.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMomentLimit.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsMomentLimit.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsPoint.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsPoint.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsRNav.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsRNav.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsRemark.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsRemark.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsReserveFuel.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsReserveFuel.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsSuitableDefinitions.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsSuitableDefinitions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsSupplementaryInformation.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsSupplementaryInformation.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsValue.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsValue.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.PocketFms;

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsWeightAndBalance.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsWeightAndBalance.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsWeightAndBalanceData.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsWeightAndBalanceData.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsWeightAndBalanceDataRecord.cs
+++ b/Geo/Gps/Serialization/Xml/PocketFms/PocketFmsWeightAndBalanceDataRecord.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonAircraft.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonAircraft.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonClimbProfile.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonClimbProfile.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonCruiseProfile.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonCruiseProfile.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonDescentProfile.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonDescentProfile.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonFlightplan.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonFlightplan.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonFuelLoadingPoint.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonFuelLoadingPoint.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonLoadingPoint.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonLoadingPoint.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonLoadingPoints.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonLoadingPoints.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonRhumbLine.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonRhumbLine.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonRoute.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonRoute.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonWaypointNameHint.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonWaypointNameHint.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Serialization;
 
 namespace Geo.Gps.Serialization.Xml.SkyDemon;

--- a/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonWaypointNameHints.cs
+++ b/Geo/Gps/Serialization/Xml/SkyDemon/SkyDemonWaypointNameHints.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Xml.Schema;
 using System.Xml.Serialization;
 

--- a/Geo/Gps/Track.cs
+++ b/Geo/Gps/Track.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Geo/Gps/TrackSegment.cs
+++ b/Geo/Gps/TrackSegment.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Geo/IO/GeoFormat.cs
+++ b/Geo/IO/GeoFormat.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Geo.IO.GeoJson;

--- a/Geo/IO/GeoJson/GeoJsonReader.cs
+++ b/Geo/IO/GeoJson/GeoJsonReader.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/Geo/Measure/Area.cs
+++ b/Geo/Measure/Area.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using Geo.Abstractions.Interfaces;
 

--- a/Geo/Measure/AreaUnitExtensions.cs
+++ b/Geo/Measure/AreaUnitExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 namespace Geo.Measure;
 
 public static class AreaUnitExtensions

--- a/Geo/Measure/DistanceUnitExtensions.cs
+++ b/Geo/Measure/DistanceUnitExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 namespace Geo.Measure;
 
 public static class DistanceUnitExtensions

--- a/Geo/Measure/UnitAttribute.cs
+++ b/Geo/Measure/UnitAttribute.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 
 namespace Geo.Measure;

--- a/Geo/SimpleJson.cs
+++ b/Geo/SimpleJson.cs
@@ -1,3 +1,6 @@
+// Vendored third-party JSON parser; opted out of nullable analysis to keep it
+// in sync with upstream rather than annotating it.
+#nullable disable
 //-----------------------------------------------------------------------
 // <copyright file="SimpleJson.cs" company="The Outercurve Foundation">
 //    Copyright (c) 2011, The Outercurve Foundation.


### PR DESCRIPTION
The library-wide nullable-reference-types migration (#93, #94) annotated every hand-written file with per-file `#nullable enable` pragmas. This promotes it to a single project-level setting.

## What's included

- **`<Nullable>enable</Nullable>` in `Geo.csproj`** — nullable is on by default for the whole library.
- **`SimpleJson.cs` opted out** with `#nullable disable`. Annotating this vendored parser's ~84 warnings would be real work *and* would fork it from upstream, making future syncs painful; opting it out keeps it in step with upstream.
- **`IgrfModelFactory`** — the four coefficient arrays on its private model type get a `= null!` default. They're always populated via object initializer and implement the non-null `IGeomagneticModel` members, so `= null!` (the standard object-initialiser idiom) is more accurate than making them nullable, and keeps that ~6000-line generated data file participating in nullable analysis.
- **Removed the now-redundant per-file `#nullable enable` pragmas** from all 98 files that carried them — the project-level setting supersedes them, so nullability is governed in one place with no pragma noise.

## Notes

- **No behaviour change and no new annotations** — this only changes *how* nullable is switched on. The measured surface when flipping the flag was exactly two files (SimpleJson and IgrfModelFactory); everything else was already clean.
- The only file now opted out of nullable analysis is the vendored `SimpleJson.cs`.
- Builds with 0 warnings; the full test suite (495 tests) stays green; the CSharpier formatting gate passes.

This is a follow-up to the merged #93/#94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYc6qCcDnL5BZ5c3Bm7yAp)_