### PR TITLE
Add coordinate ordering and winding-order helpers (issue #54)

### DIFF
--- a/Geo.Tests/Linq/EnumerableExtensionsTests.cs
+++ b/Geo.Tests/Linq/EnumerableExtensionsTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Geo.Geometries;
 using Geo.Linq;
 using Geo.Measure;
 using Xunit;
@@ -72,5 +74,119 @@ public class EnumerableExtensionsTests
 
         Assert.Equal(250, areas.Max(x => x).SiValue);
         Assert.Equal(50, areas.Min(x => x).SiValue);
+    }
+
+    [Fact]
+    public void OrderCounterClockwise_orders_shuffled_box_corners_into_a_ring()
+    {
+        // The four corners of a box, deliberately out of order.
+        var bottomLeft = new Coordinate(0, 0);
+        var bottomRight = new Coordinate(0, 10);
+        var topRight = new Coordinate(10, 10);
+        var topLeft = new Coordinate(10, 0);
+
+        var shuffled = new List<Coordinate> { topRight, bottomLeft, topLeft, bottomRight };
+
+        var ordered = shuffled.OrderCounterClockwise();
+
+        // Same four corners, now walking counter-clockwise, so the ring is valid.
+        Assert.Equal(4, ordered.Count);
+        Assert.Equal(WindingOrder.CounterClockwise, ordered.GetWindingOrder());
+    }
+
+    [Fact]
+    public void OrderClockwise_and_OrderCounterClockwise_produce_opposite_windings()
+    {
+        var corners = new List<Coordinate> { new(10, 10), new(0, 0), new(10, 0), new(0, 10) };
+
+        Assert.Equal(WindingOrder.Clockwise, corners.OrderClockwise().GetWindingOrder());
+        Assert.Equal(
+            WindingOrder.CounterClockwise,
+            corners.OrderCounterClockwise().GetWindingOrder()
+        );
+    }
+
+    [Fact]
+    public void OrderCounterClockwise_closes_into_a_usable_linear_ring()
+    {
+        var shuffled = new List<Coordinate> { new(10, 10), new(0, 0), new(10, 0), new(0, 10) };
+
+        var ordered = shuffled.OrderCounterClockwise().ToList();
+        ordered.Add(ordered[0]); // close the ring
+
+        var ring = new LinearRing(ordered);
+
+        Assert.True(ring.IsClosed);
+    }
+
+    [Fact]
+    public void OrderClockwise_is_a_permutation_of_the_input()
+    {
+        var corners = new List<Coordinate> { new(10, 10), new(0, 0), new(10, 0), new(0, 10) };
+
+        var ordered = corners.OrderClockwise();
+
+        Assert.Equal(corners.Count, ordered.Count);
+        foreach (var corner in corners)
+            Assert.Contains(corner, ordered);
+    }
+
+    [Fact]
+    public void Ordering_fewer_than_three_coordinates_returns_them_unchanged()
+    {
+        var coordinates = new List<Coordinate> { new(1, 1), new(2, 2) };
+
+        Assert.Equal(coordinates, coordinates.OrderClockwise());
+        Assert.Equal(coordinates, coordinates.OrderCounterClockwise());
+    }
+
+    [Fact]
+    public void Ordering_preserves_the_coordinate_subtype()
+    {
+        var coordinates = new List<Coordinate>
+        {
+            new CoordinateZ(10, 10, 5),
+            new CoordinateZ(0, 0, 5),
+            new CoordinateZ(10, 0, 5),
+            new CoordinateZ(0, 10, 5),
+        };
+
+        Assert.All(coordinates.OrderCounterClockwise(), x => Assert.True(x.Is3D));
+    }
+
+    [Fact]
+    public void GetWindingOrder_returns_null_for_degenerate_rings()
+    {
+        Assert.Null(new List<Coordinate> { new(0, 0), new(0, 10) }.GetWindingOrder());
+
+        // Three colinear points enclose no area.
+        var colinear = new List<Coordinate> { new(0, 0), new(0, 5), new(0, 10) };
+        Assert.Null(colinear.GetWindingOrder());
+    }
+
+    [Fact]
+    public void GetWindingOrder_ignores_a_repeated_closing_coordinate()
+    {
+        // With longitude as x and latitude as y, this ring sweeps counter-clockwise.
+        var closed = new List<Coordinate>
+        {
+            new(0, 0),
+            new(0, 10),
+            new(10, 10),
+            new(10, 0),
+            new(0, 0),
+        };
+
+        Assert.Equal(WindingOrder.CounterClockwise, closed.GetWindingOrder());
+    }
+
+    [Fact]
+    public void Ordering_and_winding_order_reject_null()
+    {
+        IEnumerable<Coordinate> coordinates = null!;
+
+        Assert.Throws<ArgumentNullException>(() => coordinates.OrderClockwise());
+        Assert.Throws<ArgumentNullException>(() => coordinates.OrderCounterClockwise());
+        Assert.Throws<ArgumentNullException>(() => coordinates.GetWindingOrder());
     }
 }

--- a/Geo/Geometries/WindingOrder.cs
+++ b/Geo/Geometries/WindingOrder.cs
@@ -1,0 +1,16 @@
+#nullable enable
+namespace Geo.Geometries;
+
+/// <summary>
+/// The direction in which the vertices of a ring are ordered. By convention a
+/// polygon's exterior ring (shell) is <see cref="CounterClockwise" /> and its interior
+/// rings (holes) are <see cref="Clockwise" />.
+/// </summary>
+public enum WindingOrder
+{
+    /// <summary>The vertices are ordered clockwise.</summary>
+    Clockwise,
+
+    /// <summary>The vertices are ordered counter-clockwise.</summary>
+    CounterClockwise,
+}

--- a/Geo/Linq/EnumerableExtensions.cs
+++ b/Geo/Linq/EnumerableExtensions.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Geo.Abstractions.Interfaces;
+using Geo.Geometries;
 using Geo.Measure;
 
 namespace Geo.Linq;
@@ -58,5 +59,112 @@ public static class EnumerableExtensions
     )
     {
         return new Distance(source.Select(selector).Min(x => x.SiValue));
+    }
+
+    /// <summary>
+    /// Orders an unsorted set of coordinates clockwise around their centroid, so they
+    /// trace the boundary of a simple polygon that can be closed into a ring.
+    /// </summary>
+    /// <remarks>
+    /// The coordinates are sorted by their bearing from the average of all the vertices,
+    /// treating longitude as the x-axis and latitude as the y-axis. This reliably recovers
+    /// the boundary order of a <em>convex</em> set of coordinates (for example the corners
+    /// of a bounding box), but a concave set has more than one valid ordering and this
+    /// method may not reproduce the one you had in mind. The result is a permutation of the
+    /// input — it is not closed; append the first coordinate to form a ring.
+    /// </remarks>
+    /// <param name="coordinates">The coordinates to order.</param>
+    /// <returns>The coordinates ordered clockwise.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="coordinates" /> is <c>null</c>.</exception>
+    public static IReadOnlyList<Coordinate> OrderClockwise(this IEnumerable<Coordinate> coordinates)
+    {
+        return OrderRadially(coordinates, WindingOrder.Clockwise);
+    }
+
+    /// <summary>
+    /// Orders an unsorted set of coordinates counter-clockwise around their centroid, so
+    /// they trace the boundary of a simple polygon that can be closed into a ring.
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="OrderClockwise" /> for how the ordering is derived and its limitations
+    /// for concave sets.
+    /// </remarks>
+    /// <param name="coordinates">The coordinates to order.</param>
+    /// <returns>The coordinates ordered counter-clockwise.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="coordinates" /> is <c>null</c>.</exception>
+    public static IReadOnlyList<Coordinate> OrderCounterClockwise(
+        this IEnumerable<Coordinate> coordinates
+    )
+    {
+        return OrderRadially(coordinates, WindingOrder.CounterClockwise);
+    }
+
+    /// <summary>
+    /// Determines whether an ordered ring of coordinates winds clockwise or counter-clockwise,
+    /// using the signed area (shoelace formula). Longitude is treated as the x-axis and latitude
+    /// as the y-axis. The ring may be open or closed; the edge from the last coordinate back to
+    /// the first is always included.
+    /// </summary>
+    /// <param name="coordinates">The ordered ring of coordinates.</param>
+    /// <returns>
+    /// The <see cref="WindingOrder" /> of the ring, or <c>null</c> when it is degenerate (fewer
+    /// than three coordinates, or a zero signed area such as a set of colinear points).
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="coordinates" /> is <c>null</c>.</exception>
+    public static WindingOrder? GetWindingOrder(this IEnumerable<Coordinate> coordinates)
+    {
+        if (coordinates == null)
+            throw new ArgumentNullException(nameof(coordinates));
+
+        var list = coordinates as IReadOnlyList<Coordinate> ?? coordinates.ToList();
+        if (list.Count < 3)
+            return null;
+
+        // Twice the signed area: positive winds counter-clockwise, negative clockwise.
+        var twiceArea = 0d;
+        for (var i = 0; i < list.Count; i++)
+        {
+            var current = list[i];
+            var next = list[(i + 1) % list.Count];
+            twiceArea += current.Longitude * next.Latitude - next.Longitude * current.Latitude;
+        }
+
+        if (twiceArea > 0)
+            return WindingOrder.CounterClockwise;
+        if (twiceArea < 0)
+            return WindingOrder.Clockwise;
+        return null;
+    }
+
+    private static IReadOnlyList<Coordinate> OrderRadially(
+        IEnumerable<Coordinate> coordinates,
+        WindingOrder order
+    )
+    {
+        if (coordinates == null)
+            throw new ArgumentNullException(nameof(coordinates));
+
+        var list = coordinates.ToList();
+        if (list.Count < 3)
+            return list;
+
+        var centerLatitude = list.Average(x => x.Latitude);
+        var centerLongitude = list.Average(x => x.Longitude);
+
+        // Bearing from the centroid; longitude is the x-axis and latitude the y-axis, so an
+        // ascending atan2 sweeps counter-clockwise. Distance keeps colinear points stable.
+        var keyed = list.Select(x =>
+        {
+            var dx = x.Longitude - centerLongitude;
+            var dy = x.Latitude - centerLatitude;
+            return (Coordinate: x, Angle: Math.Atan2(dy, dx), Radius: dx * dx + dy * dy);
+        });
+
+        var sorted =
+            order == WindingOrder.CounterClockwise
+                ? keyed.OrderBy(x => x.Angle).ThenBy(x => x.Radius)
+                : keyed.OrderByDescending(x => x.Angle).ThenByDescending(x => x.Radius);
+
+        return sorted.Select(x => x.Coordinate).ToList();
     }
 }

--- a/docs/geometries.md
+++ b/docs/geometries.md
@@ -67,6 +67,41 @@ var withHole = new Polygon(shell: outerRing, holes: innerRing);
 Though it is not enforced, it is advised that the exterior ring is CCW
 (counter-clockwise) and the interior rings/holes are CW (clockwise).
 
+### Ordering an unsorted set of coordinates into a ring
+
+If you have a bag of coordinates that *should* form a polygon shell but are not in
+boundary order, `OrderClockwise` / `OrderCounterClockwise` (in `Geo.Linq`) sort them
+around their centroid so they trace the boundary:
+
+```csharp
+using Geo.Linq;
+
+var unsorted = new[]
+{
+    new Coordinate(10, 10),
+    new Coordinate(0, 0),
+    new Coordinate(10, 0),
+    new Coordinate(0, 10),
+};
+
+var ordered = unsorted.OrderCounterClockwise().ToList();
+ordered.Add(ordered[0]);            // close the ring (first == last)
+
+var shell = new LinearRing(ordered);
+var poly = new Polygon(shell);
+```
+
+The ordering is derived from each coordinate's bearing from the average of all the
+vertices, so it reliably recovers the boundary of a **convex** set (such as the corners
+of a bounding box); a concave set has more than one valid ordering. `GetWindingOrder`
+reports the winding of an already-ordered ring (or `null` if it encloses no area):
+
+```csharp
+using Geo.Linq;
+
+WindingOrder? winding = polygon.Shell.Coordinates.GetWindingOrder();
+```
+
 ## Triangle
 
 A `Polygon` whose shell is limited to 3 distinct points. Similar to the OGC


### PR DESCRIPTION
Provide a built-in way to turn an unordered bag of coordinates into a
polygon shell, as requested in issue #54.

- OrderClockwise / OrderCounterClockwise (Geo.Linq) sort coordinates by
  their bearing from the centroid, recovering the boundary order of a
  convex set so it can be closed into a ring.
- GetWindingOrder reports the winding of an already-ordered ring via the
  signed area (shoelace), returning null for degenerate rings.
- Add a WindingOrder enum and document the workflow in docs/geometries.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hv21f3vb3eug2cYU1sQTjw