### PR TITLE
test: improve coverage of equality, geometry and measure edge paths

### DIFF
--- a/Geo.Tests/Abstractions/GeometryConvenienceTests.cs
+++ b/Geo.Tests/Abstractions/GeometryConvenienceTests.cs
@@ -1,0 +1,58 @@
+using Geo.Geometries;
+using Geo.IO.Wkb;
+using Geo.IO.Wkt;
+using Xunit;
+
+namespace Geo.Tests.Abstractions;
+
+/// <summary>
+/// The <see cref="Geo.Abstractions.Geometry" /> base class exposes serialization
+/// shortcuts (ToWktString / ToWkbBinary / ToGeoJson) that every geometry inherits.
+/// </summary>
+public class GeometryConvenienceTests
+{
+    private static readonly Point Sample = new(45.89, 23.9);
+
+    [Fact]
+    public void ToWktString_round_trips_through_the_wkt_reader()
+    {
+        var wkt = Sample.ToWktString();
+
+        Assert.StartsWith("POINT", wkt);
+        Assert.Equal(Sample, new WktReader().Read(wkt));
+    }
+
+    [Fact]
+    public void ToWktString_with_settings_round_trips()
+    {
+        var wkt = Sample.ToWktString(new WktWriterSettings());
+
+        Assert.Equal(Sample, new WktReader().Read(wkt));
+    }
+
+    [Fact]
+    public void ToWkbBinary_round_trips_through_the_wkb_reader()
+    {
+        var wkb = Sample.ToWkbBinary();
+
+        Assert.NotEmpty(wkb);
+        Assert.Equal(Sample, new WkbReader().Read(wkb));
+    }
+
+    [Fact]
+    public void ToWkbBinary_with_big_endian_settings_round_trips()
+    {
+        var wkb = Sample.ToWkbBinary(new WkbWriterSettings { Encoding = WkbEncoding.BigEndian });
+
+        Assert.Equal(Sample, new WkbReader().Read(wkb));
+    }
+
+    [Fact]
+    public void ToGeoJson_emits_a_point_document()
+    {
+        var geoJson = Sample.ToGeoJson();
+
+        Assert.Contains("\"Point\"", geoJson);
+        Assert.Contains("23.9", geoJson);
+    }
+}

--- a/Geo.Tests/Geodesy/SpheroidTests.cs
+++ b/Geo.Tests/Geodesy/SpheroidTests.cs
@@ -1,0 +1,68 @@
+using Geo.Geodesy;
+using Xunit;
+
+namespace Geo.Tests.Geodesy;
+
+public class SpheroidTests
+{
+    [Fact]
+    public void Constructor_derives_flattening_axes_and_radius()
+    {
+        var spheroid = new Spheroid("WGS84", 6378137d, 298.257223563d);
+
+        Assert.Equal("WGS84", spheroid.Name);
+        Assert.Equal(6378137d, spheroid.EquatorialAxis);
+        Assert.Equal(298.257223563d, spheroid.InverseFlattening);
+        Assert.Equal(1 / 298.257223563d, spheroid.Flattening, 15);
+        Assert.Equal(6378137d * (1 - 1 / 298.257223563d), spheroid.PolarAxis, 9);
+        Assert.Equal(
+            (2 * spheroid.EquatorialAxis + spheroid.PolarAxis) / 3,
+            spheroid.MeanRadius,
+            9
+        );
+        Assert.False(spheroid.IsSphere);
+    }
+
+    [Fact]
+    public void A_spheroid_with_no_flattening_is_a_sphere()
+    {
+        // A very large inverse flattening makes the polar and equatorial axes coincide.
+        var spheroid = new Spheroid("Sphere", 6371000d, double.PositiveInfinity);
+
+        Assert.True(spheroid.IsSphere);
+        Assert.Equal(spheroid.EquatorialAxis, spheroid.PolarAxis);
+        Assert.Equal(0, spheroid.Flattening);
+    }
+
+    [Theory]
+    [InlineData("WGS84", 6378137d, 298.257223563d)]
+    [InlineData("GRS80", 6378137d, 298.257222101d)]
+    [InlineData("International 1924", 6378388d, 297d)]
+    [InlineData("Clarke 1866", 6378206.4d, 294.9786982d)]
+    public void Named_spheroids_expose_their_defining_parameters(
+        string name,
+        double equatorialAxis,
+        double inverseFlattening
+    )
+    {
+        var spheroid = name switch
+        {
+            "WGS84" => Spheroid.Wgs84,
+            "GRS80" => Spheroid.Grs80,
+            "International 1924" => Spheroid.International1924,
+            _ => Spheroid.Clarke1866,
+        };
+
+        Assert.Equal(name, spheroid.Name);
+        Assert.Equal(equatorialAxis, spheroid.EquatorialAxis);
+        Assert.Equal(inverseFlattening, spheroid.InverseFlattening);
+        Assert.False(spheroid.IsSphere);
+    }
+
+    [Fact]
+    public void Default_spheroid_is_wgs84()
+    {
+        Assert.Equal(Spheroid.Wgs84.Name, Spheroid.Default.Name);
+        Assert.Equal(Spheroid.Wgs84.EquatorialAxis, Spheroid.Default.EquatorialAxis);
+    }
+}

--- a/Geo.Tests/Geomagnetism/GeomagnetismResultTests.cs
+++ b/Geo.Tests/Geomagnetism/GeomagnetismResultTests.cs
@@ -1,0 +1,69 @@
+using System;
+using Geo.Geomagnetism;
+using Xunit;
+
+namespace Geo.Tests.Geomagnetism;
+
+public class GeomagnetismResultTests
+{
+    private static readonly DateTime Date = new(2012, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly CoordinateZ Location = new(51.5, -0.1, 0);
+
+    private static double ToDegrees(double radians) => radians * 180 / Math.PI;
+
+    [Fact]
+    public void Derives_intensities_declination_and_inclination_from_the_field_vector()
+    {
+        const double x = 19000;
+        const double y = -500;
+        const double z = 45000;
+
+        var result = new GeomagnetismResult(Location, Date, x, y, z);
+
+        var expectedH = Math.Sqrt(x * x + y * y);
+        var expectedF = Math.Sqrt(x * x + y * y + z * z);
+
+        Assert.Equal(x, result.X);
+        Assert.Equal(y, result.Y);
+        Assert.Equal(z, result.Z);
+        Assert.Equal(expectedH, result.HorizontalIntensity, 6);
+        Assert.Equal(expectedF, result.TotalIntensity, 6);
+        Assert.Equal(ToDegrees(Math.Atan2(y, x)), result.Declination, 9);
+        Assert.Equal(ToDegrees(Math.Atan2(z, expectedH)), result.Inclination, 9);
+        Assert.Same(Location, result.Coordinate);
+        Assert.Equal(Date, result.Date);
+    }
+
+    [Theory]
+    [InlineData(0, 100)]
+    [InlineData(19000, 0)]
+    public void A_zero_x_or_y_component_leaves_the_derived_field_unset(double x, double y)
+    {
+        var result = new GeomagnetismResult(Location, Date, x, y, 45000);
+
+        // The constructor short-circuits before assigning any component, so every
+        // derived quantity stays at its default of zero, while the location and date
+        // are still recorded.
+        Assert.Equal(0, result.X);
+        Assert.Equal(0, result.Y);
+        Assert.Equal(0, result.Z);
+        Assert.Equal(0, result.HorizontalIntensity);
+        Assert.Equal(0, result.TotalIntensity);
+        Assert.Equal(0, result.Declination);
+        Assert.Equal(0, result.Inclination);
+        Assert.Same(Location, result.Coordinate);
+        Assert.Equal(Date, result.Date);
+    }
+
+    [Fact]
+    public void ToString_reports_every_component()
+    {
+        var text = new GeomagnetismResult(Location, Date, 19000, -500, 45000).ToString();
+
+        Assert.StartsWith("Magnetic Field[", text);
+        Assert.Contains("D=", text);
+        Assert.Contains("I=", text);
+        Assert.Contains("H=", text);
+        Assert.Contains("F=", text);
+    }
+}

--- a/Geo.Tests/Geometries/CircleTests.cs
+++ b/Geo.Tests/Geometries/CircleTests.cs
@@ -121,6 +121,68 @@ public class CircleTests
         Assert.True(new Circle(0, 20, 111000) != new Circle(1, 20, 111000));
     }
 
+    [Fact]
+    public void Equality_via_object_overload_and_hashcode()
+    {
+        var circle = new Circle(0, 20, 111000);
+        var same = new Circle(0, 20, 111000);
+
+        Assert.True(circle.Equals((object)same));
+        Assert.False(circle.Equals((object?)null));
+        Assert.False(circle.Equals((object)"not a circle"));
+        Assert.Equal(circle.GetHashCode(), same.GetHashCode());
+    }
+
+    [Fact]
+    public void Equality_operators_handle_null()
+    {
+        var circle = new Circle(0, 20, 111000);
+
+        Assert.True((Circle)null == (Circle)null);
+        Assert.False(circle == null);
+        Assert.False(null == circle);
+        Assert.True(circle != null);
+    }
+
+    [Fact]
+    public void Center_constructed_with_elevation_is_3d_but_not_measured()
+    {
+        var circle = new Circle(1, 2, 300, 111000);
+
+        Assert.True(circle.Is3D);
+        Assert.False(circle.IsMeasured);
+        Assert.Equal(300, ((CoordinateZ)circle.Center).Elevation);
+        Assert.Equal(111000, circle.Radius);
+    }
+
+    [Fact]
+    public void Center_constructed_with_elevation_and_measure_is_3d_and_measured()
+    {
+        var circle = new Circle(1, 2, 300, 42, 111000);
+
+        Assert.True(circle.Is3D);
+        Assert.True(circle.IsMeasured);
+        var center = (CoordinateZM)circle.Center;
+        Assert.Equal(300, center.Elevation);
+        Assert.Equal(42, center.Measure);
+    }
+
+    [Fact]
+    public void Center_from_coordinate_constructor_reports_dimensions_from_the_centre()
+    {
+        var circle = new Circle(new Coordinate(1, 2), 111000);
+
+        Assert.False(circle.Is3D);
+        Assert.False(circle.IsMeasured);
+    }
+
+    [Fact]
+    public void Empty_circle_is_neither_3d_nor_measured()
+    {
+        Assert.False(new Circle().Is3D);
+        Assert.False(new Circle().IsMeasured);
+    }
+
     public double Distance(double nr1, double nr2)
     {
         return Math.Abs(nr1 - nr2);

--- a/Geo.Tests/Geometries/MultiGeometryTests.cs
+++ b/Geo.Tests/Geometries/MultiGeometryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Geo.Geometries;
 using Xunit;
 
@@ -83,5 +84,53 @@ public class MultiGeometryTests
 
         Assert.True(a.Equals(b));
         Assert.False(a.Equals(c));
+    }
+
+    [Fact]
+    public void GeometryCollection_is_not_equal_to_null_or_a_different_count()
+    {
+        var a = new GeometryCollection(new Point(0, 0), new Point(1, 1));
+        var shorter = new GeometryCollection(new Point(0, 0));
+
+        Assert.False(a.Equals(null));
+        Assert.False(a.Equals("not a collection"));
+        Assert.False(a.Equals(shorter));
+    }
+
+    [Fact]
+    public void GeometryCollection_hashcode_matches_for_equal_collections()
+    {
+        var a = new GeometryCollection(new Point(0, 0), new Point(1, 1));
+        var b = new GeometryCollection(new Point(0, 0), new Point(1, 1));
+
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void LinearRing_must_be_closed()
+    {
+        // A non-empty ring whose last coordinate does not repeat the first is invalid.
+        Assert.Throws<ArgumentException>(() =>
+            new LinearRing(new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(0, 1))
+        );
+    }
+
+    [Fact]
+    public void Triangle_rejects_a_degenerate_shell()
+    {
+        Assert.Throws<ArgumentException>(() => new Triangle(new LinearRing()));
+    }
+
+    [Fact]
+    public void Triangle_from_three_points_closes_the_ring()
+    {
+        var triangle = new Triangle(
+            new Coordinate(0, 0),
+            new Coordinate(1, 0),
+            new Coordinate(0, 1)
+        );
+
+        Assert.True(triangle.Shell.IsClosed);
+        Assert.Equal(4, triangle.Shell.Coordinates.Count);
     }
 }

--- a/Geo.Tests/Gps/WaypointTests.cs
+++ b/Geo.Tests/Gps/WaypointTests.cs
@@ -1,0 +1,87 @@
+using System;
+using Geo.Geometries;
+using Geo.Gps;
+using Xunit;
+
+namespace Geo.Tests.Gps;
+
+public class WaypointTests
+{
+    [Fact]
+    public void Lat_lon_constructor_places_a_2d_point()
+    {
+        var waypoint = new Waypoint(1, 2);
+
+        Assert.Equal(new Coordinate(1, 2), waypoint.Coordinate);
+        Assert.False(waypoint.Point.Is3D);
+        Assert.Null(waypoint.TimeUtc);
+    }
+
+    [Fact]
+    public void Lat_lon_elevation_constructor_places_a_3d_point()
+    {
+        var waypoint = new Waypoint(1, 2, 300);
+
+        Assert.True(waypoint.Point.Is3D);
+        Assert.Equal(new CoordinateZ(1, 2, 300), waypoint.Coordinate);
+    }
+
+    [Fact]
+    public void Lat_lon_elevation_time_constructor_records_the_timestamp()
+    {
+        var time = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var waypoint = new Waypoint(1, 2, 300, time);
+
+        Assert.Equal(new CoordinateZ(1, 2, 300), waypoint.Coordinate);
+        Assert.Equal(time, waypoint.TimeUtc);
+    }
+
+    [Fact]
+    public void Point_and_time_constructor_keeps_the_supplied_point()
+    {
+        var time = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var point = new Point(1, 2, 300);
+        var waypoint = new Waypoint(point, time);
+
+        Assert.Same(point, waypoint.Point);
+        Assert.Equal(time, waypoint.TimeUtc);
+    }
+
+    [Fact]
+    public void Point_with_metadata_constructor_exposes_name_comment_and_description()
+    {
+        var waypoint = new Waypoint(new Point(1, 2), "name", "comment", "description");
+
+        Assert.Equal("name", waypoint.Name);
+        Assert.Equal("comment", waypoint.Comment);
+        Assert.Equal("description", waypoint.Description);
+        Assert.Null(waypoint.TimeUtc);
+    }
+
+    [Fact]
+    public void Full_constructor_captures_time_and_metadata()
+    {
+        var time = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var waypoint = new Waypoint(new Point(1, 2), time, "name", "comment", "description");
+
+        Assert.Equal("name", waypoint.Name);
+        Assert.Equal("comment", waypoint.Comment);
+        Assert.Equal("description", waypoint.Description);
+        Assert.Equal(time, waypoint.TimeUtc);
+    }
+
+    [Fact]
+    public void ToLineString_wraps_the_single_coordinate()
+    {
+        var lineString = new Waypoint(1, 2).ToLineString();
+
+        Assert.Single(lineString.Coordinates);
+        Assert.Equal(new Coordinate(1, 2), lineString.Coordinates[0]);
+    }
+
+    [Fact]
+    public void GetLength_of_a_single_point_is_zero()
+    {
+        Assert.Equal(0, new Waypoint(1, 2).GetLength().SiValue);
+    }
+}

--- a/Geo.Tests/SpatialEqualityTests.cs
+++ b/Geo.Tests/SpatialEqualityTests.cs
@@ -1,0 +1,334 @@
+using Geo.Geometries;
+using Xunit;
+
+namespace Geo.Tests;
+
+/// <summary>
+/// Exercises the <see cref="SpatialEqualityOptions" /> permutations (pole, anti-meridian,
+/// elevation and measure toggles) across the coordinate hierarchy and spatial collections.
+/// These option-driven branches carry the library's subtlest equality logic and are otherwise
+/// thinly covered.
+/// </summary>
+public class SpatialEqualityTests
+{
+    private static readonly SpatialEqualityOptions All = new();
+
+    #region CoordinateZ
+
+    [Fact]
+    public void CoordinateZ_anti_meridian_coordinates_compare_equal_when_enabled()
+    {
+        Assert.True(
+            new CoordinateZ(4, 180, 7).Equals(
+                new CoordinateZ(4, -180, 7),
+                new SpatialEqualityOptions { AntiMeridianCoordinatesAreEqual = true }
+            )
+        );
+        Assert.False(
+            new CoordinateZ(4, 180, 7).Equals(
+                new CoordinateZ(4, -180, 7),
+                new SpatialEqualityOptions { AntiMeridianCoordinatesAreEqual = false }
+            )
+        );
+    }
+
+    [Fact]
+    public void CoordinateZ_pole_coordinates_compare_equal_when_enabled()
+    {
+        Assert.True(
+            new CoordinateZ(-90, 0, 7).Equals(
+                new CoordinateZ(-90, 150, 7),
+                new SpatialEqualityOptions { PoleCoordiantesAreEqual = true }
+            )
+        );
+        Assert.False(
+            new CoordinateZ(-90, 0, 7).Equals(
+                new CoordinateZ(-90, 150, 7),
+                new SpatialEqualityOptions { PoleCoordiantesAreEqual = false }
+            )
+        );
+    }
+
+    [Fact]
+    public void CoordinateZ_is_not_equal_to_null_or_other_dimensions()
+    {
+        var z = new CoordinateZ(1, 2, 3);
+
+        Assert.False(z.Equals(null, All));
+        Assert.False(z.Equals(new Coordinate(1, 2), All));
+        Assert.False(z.Equals(new CoordinateM(1, 2, 3), All));
+    }
+
+    [Fact]
+    public void CoordinateZ_hashcode_honours_pole_anti_meridian_and_elevation()
+    {
+        // Pole longitudes collapse together.
+        Assert.Equal(
+            new CoordinateZ(90, 0, 5).GetHashCode(All),
+            new CoordinateZ(90, 150, 5).GetHashCode(All)
+        );
+
+        // Anti-meridian longitudes hash together.
+        Assert.Equal(
+            new CoordinateZ(4, 180, 5).GetHashCode(All),
+            new CoordinateZ(4, -180, 5).GetHashCode(All)
+        );
+
+        // Elevation participates only when UseElevation is set.
+        var without = new SpatialEqualityOptions { UseElevation = false };
+        Assert.Equal(
+            new CoordinateZ(1, 2, 100).GetHashCode(without),
+            new CoordinateZ(1, 2, 200).GetHashCode(without)
+        );
+        Assert.NotEqual(
+            new CoordinateZ(1, 2, 100).GetHashCode(All),
+            new CoordinateZ(1, 2, 200).GetHashCode(All)
+        );
+    }
+
+    #endregion
+
+    #region CoordinateM
+
+    [Fact]
+    public void CoordinateM_anti_meridian_coordinates_compare_equal_when_enabled()
+    {
+        Assert.True(
+            new CoordinateM(4, -180, 7).Equals(
+                new CoordinateM(4, 180, 7),
+                new SpatialEqualityOptions { AntiMeridianCoordinatesAreEqual = true }
+            )
+        );
+        Assert.False(
+            new CoordinateM(4, -180, 7).Equals(
+                new CoordinateM(4, 180, 7),
+                new SpatialEqualityOptions { AntiMeridianCoordinatesAreEqual = false }
+            )
+        );
+    }
+
+    [Fact]
+    public void CoordinateM_pole_coordinates_compare_equal_when_enabled()
+    {
+        Assert.True(
+            new CoordinateM(90, 0, 7).Equals(
+                new CoordinateM(90, 150, 7),
+                new SpatialEqualityOptions { PoleCoordiantesAreEqual = true }
+            )
+        );
+    }
+
+    [Fact]
+    public void CoordinateM_is_not_equal_to_null_or_other_dimensions()
+    {
+        var m = new CoordinateM(1, 2, 3);
+
+        Assert.False(m.Equals(null, All));
+        Assert.False(m.Equals(new Coordinate(1, 2), All));
+        Assert.False(m.Equals(new CoordinateZ(1, 2, 3), All));
+    }
+
+    [Fact]
+    public void CoordinateM_hashcode_honours_pole_anti_meridian_and_measure()
+    {
+        Assert.Equal(
+            new CoordinateM(90, 0, 5).GetHashCode(All),
+            new CoordinateM(90, 150, 5).GetHashCode(All)
+        );
+        Assert.Equal(
+            new CoordinateM(4, 180, 5).GetHashCode(All),
+            new CoordinateM(4, -180, 5).GetHashCode(All)
+        );
+
+        var without = new SpatialEqualityOptions { UseM = false };
+        Assert.Equal(
+            new CoordinateM(1, 2, 100).GetHashCode(without),
+            new CoordinateM(1, 2, 200).GetHashCode(without)
+        );
+        Assert.NotEqual(
+            new CoordinateM(1, 2, 100).GetHashCode(All),
+            new CoordinateM(1, 2, 200).GetHashCode(All)
+        );
+    }
+
+    #endregion
+
+    #region CoordinateZM
+
+    [Fact]
+    public void CoordinateZM_anti_meridian_coordinates_compare_equal_when_enabled()
+    {
+        Assert.True(
+            new CoordinateZM(4, 180, 5, 7).Equals(
+                new CoordinateZM(4, -180, 5, 7),
+                new SpatialEqualityOptions { AntiMeridianCoordinatesAreEqual = true }
+            )
+        );
+        Assert.False(
+            new CoordinateZM(4, 180, 5, 7).Equals(
+                new CoordinateZM(4, -180, 5, 7),
+                new SpatialEqualityOptions { AntiMeridianCoordinatesAreEqual = false }
+            )
+        );
+    }
+
+    [Fact]
+    public void CoordinateZM_distinguishes_elevation_and_measure_independently()
+    {
+        var origin = new CoordinateZM(1, 2, 5, 7);
+
+        // Elevation differs.
+        Assert.False(origin.Equals(new CoordinateZM(1, 2, 99, 7), All));
+        Assert.True(
+            origin.Equals(
+                new CoordinateZM(1, 2, 99, 7),
+                new SpatialEqualityOptions { UseElevation = false }
+            )
+        );
+
+        // Measure differs.
+        Assert.False(origin.Equals(new CoordinateZM(1, 2, 5, 99), All));
+        Assert.True(
+            origin.Equals(
+                new CoordinateZM(1, 2, 5, 99),
+                new SpatialEqualityOptions { UseM = false }
+            )
+        );
+    }
+
+    [Fact]
+    public void CoordinateZM_is_not_equal_to_null_or_other_dimensions()
+    {
+        var zm = new CoordinateZM(1, 2, 3, 4);
+
+        Assert.False(zm.Equals(null, All));
+        Assert.False(zm.Equals(new Coordinate(1, 2), All));
+        Assert.False(zm.Equals(new CoordinateZ(1, 2, 3), All));
+    }
+
+    [Fact]
+    public void CoordinateZM_hashcode_honours_every_option()
+    {
+        // Pole longitudes collapse together.
+        Assert.Equal(
+            new CoordinateZM(90, 0, 5, 7).GetHashCode(All),
+            new CoordinateZM(90, 150, 5, 7).GetHashCode(All)
+        );
+
+        // Anti-meridian longitudes hash together.
+        Assert.Equal(
+            new CoordinateZM(4, 180, 5, 7).GetHashCode(All),
+            new CoordinateZM(4, -180, 5, 7).GetHashCode(All)
+        );
+
+        // Elevation excluded when UseElevation is false.
+        var withoutElevation = new SpatialEqualityOptions { UseElevation = false };
+        Assert.Equal(
+            new CoordinateZM(1, 2, 100, 7).GetHashCode(withoutElevation),
+            new CoordinateZM(1, 2, 200, 7).GetHashCode(withoutElevation)
+        );
+
+        // Measure excluded when UseM is false.
+        var withoutMeasure = new SpatialEqualityOptions { UseM = false };
+        Assert.Equal(
+            new CoordinateZM(1, 2, 5, 100).GetHashCode(withoutMeasure),
+            new CoordinateZM(1, 2, 5, 200).GetHashCode(withoutMeasure)
+        );
+
+        // Both included by default.
+        Assert.NotEqual(
+            new CoordinateZM(1, 2, 5, 7).GetHashCode(All),
+            new CoordinateZM(1, 2, 6, 7).GetHashCode(All)
+        );
+        Assert.NotEqual(
+            new CoordinateZM(1, 2, 5, 7).GetHashCode(All),
+            new CoordinateZM(1, 2, 5, 8).GetHashCode(All)
+        );
+    }
+
+    #endregion
+
+    #region Spatial collections
+
+    [Fact]
+    public void Collection_2d_equality_ignores_elevation_but_3d_equality_respects_it()
+    {
+        var a = new CoordinateSequence(new CoordinateZ(0, 0, 10), new CoordinateZ(1, 1, 20));
+        var b = new CoordinateSequence(new CoordinateZ(0, 0, 99), new CoordinateZ(1, 1, 88));
+
+        Assert.True(a.Equals2D(b));
+        Assert.False(a.Equals3D(b));
+    }
+
+    [Fact]
+    public void Collection_is_not_equal_to_null_or_different_length()
+    {
+        var a = new CoordinateSequence(new Coordinate(0, 0), new Coordinate(1, 1));
+        var shorter = new CoordinateSequence(new Coordinate(0, 0));
+
+        Assert.False(a.Equals(null, All));
+        Assert.False(a.Equals(shorter, All));
+    }
+
+    [Fact]
+    public void Collection_equality_compares_elements_positionally()
+    {
+        var a = new CoordinateSequence(new Coordinate(0, 0), new Coordinate(1, 1));
+        var same = new CoordinateSequence(new Coordinate(0, 0), new Coordinate(1, 1));
+        var reordered = new CoordinateSequence(new Coordinate(1, 1), new Coordinate(0, 0));
+
+        Assert.True(a.Equals(same, All));
+        Assert.False(a.Equals(reordered, All));
+    }
+
+    [Fact]
+    public void Collection_hashcode_matches_for_equal_sequences()
+    {
+        var a = new CoordinateSequence(new Coordinate(0, 0), new Coordinate(1, 1));
+        var same = new CoordinateSequence(new Coordinate(0, 0), new Coordinate(1, 1));
+
+        Assert.Equal(a.GetHashCode(All), same.GetHashCode(All));
+        Assert.Equal(a.GetHashCode(), same.GetHashCode());
+    }
+
+    [Fact]
+    public void MultiPoint_respects_elevation_only_in_3d_comparison()
+    {
+        var a = new MultiPoint(new Point(0, 0, 10), new Point(1, 1, 20));
+        var b = new MultiPoint(new Point(0, 0, 99), new Point(1, 1, 88));
+
+        Assert.True(a.Equals2D(b));
+        Assert.False(a.Equals3D(b));
+    }
+
+    #endregion
+
+    #region Envelope
+
+    [Fact]
+    public void Envelope_boxed_equality_covers_null_self_and_wrong_type()
+    {
+        var envelope = new Envelope(0, 0, 10, 10);
+
+        Assert.False(envelope.Equals((object?)null));
+        Assert.True(envelope.Equals((object)envelope));
+        Assert.False(envelope.Equals((object)"not an envelope"));
+        Assert.True(envelope.Equals((object)new Envelope(0, 0, 10, 10)));
+        Assert.False(envelope.Equals((object)new Envelope(0, 0, 10, 11)));
+    }
+
+    [Fact]
+    public void Envelope_operators_and_hashcode_agree_with_equality()
+    {
+        var a = new Envelope(1, 2, 3, 4);
+        var b = new Envelope(1, 2, 3, 4);
+        var c = new Envelope(1, 2, 3, 5);
+
+        Assert.True(a == b);
+        Assert.False(a != b);
+        Assert.True(a != c);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Following a test-coverage analysis of the library, this PR closes the highest-risk gaps — primarily the option-driven equality branches and geometry edge cases where branch coverage lagged well behind line coverage. All new tests are additive; no library code changed.

Overall coverage moved from **86.0% → 87.2% line** and **67.6% → 71.1% branch** (504 → 558 tests, all passing).

The work is split into three commits:

### Tier 1 — Spatial equality option permutations
`SpatialEqualityTests` exercises the pole, anti-meridian, elevation and measure branches of `Equals`/`GetHashCode(options)` across `CoordinateZ`/`M`/`ZM`, spatial collections (`CoordinateSequence`, `MultiPoint`) and `Envelope`. These carried the library's subtlest equality logic and were the thinnest-covered branches.

- CoordinateZM 64→95%, CoordinateM 69→94%, CoordinateZ 73→94%, SpatialReadOnlyCollection 34→81%, Envelope 90→100%.

### Tier 2 — Circle dimensions, GeomagnetismResult, Waypoint, Spheroid
- **Circle**: elevation/measure centre constructors, `Is3D`/`IsMeasured`, object-equality overload, hashcode and null-operator handling.
- **GeomagnetismResult**: derivation of H/F/D/I from the field vector, the zero-component short-circuit that leaves the field unset, and `ToString`.
- **Waypoint**: all constructor overloads, metadata accessors and `ToLineString`/`GetLength` (new dedicated test file).
- **Spheroid**: parameter derivation, the sphere special case and the named reference spheroids (new dedicated test file).

- Circle 68→100%, GeomagnetismResult 55→100%, Waypoint 70→100%, Spheroid 70→100%.

### Tier 3 — Geometry serialization shortcuts and validation
- **Geometry base class**: `ToWktString` / `ToWkbBinary` (with and without settings) and `ToGeoJson`, each round-tripped back through its reader.
- **GeometryCollection**: null and count-mismatch inequality plus hashcode agreement.
- **Geometry-layer guards**: `LinearRing` rejects an unclosed sequence, `Triangle` rejects a degenerate shell, and the three-point `Triangle` constructor closes its ring.

- Abstractions/Geometry 20→100%, GeometryCollection 76→100%, Triangle and LinearRing to 100%.

## Testing

- `dotnet test Geo.Tests/Geo.Tests.csproj` — 558 passed, 0 failed.
- `dotnet csharpier check .` — clean (CI formatting gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3Lx7arM7PHVDt2PF4ff7c)_