### PR TITLE
Make coordinate ordering and winding order spherical (issue #54)

### DIFF
--- a/Geo.Tests/Linq/EnumerableExtensionsTests.cs
+++ b/Geo.Tests/Linq/EnumerableExtensionsTests.cs
@@ -189,4 +189,81 @@ public class EnumerableExtensionsTests
         Assert.Throws<ArgumentNullException>(() => coordinates.OrderCounterClockwise());
         Assert.Throws<ArgumentNullException>(() => coordinates.GetWindingOrder());
     }
+
+    [Fact]
+    public void GetWindingOrder_is_correct_across_the_antimeridian()
+    {
+        // A narrow box straddling the 180th meridian (lon 175 .. -175). A planar
+        // shoelace on raw longitudes would span ~350 degrees and get this wrong.
+        var counterClockwise = new List<Coordinate>
+        {
+            new(0, 175),
+            new(0, -175),
+            new(10, -175),
+            new(10, 175),
+        };
+
+        Assert.Equal(WindingOrder.CounterClockwise, counterClockwise.GetWindingOrder());
+
+        counterClockwise.Reverse();
+        Assert.Equal(WindingOrder.Clockwise, counterClockwise.GetWindingOrder());
+    }
+
+    [Fact]
+    public void OrderCounterClockwise_orders_box_corners_across_the_antimeridian()
+    {
+        // The four corners of a box straddling the date line, out of order.
+        var shuffled = new List<Coordinate>
+        {
+            new(10, 175),
+            new(0, -175),
+            new(0, 175),
+            new(10, -175),
+        };
+
+        var ordered = shuffled.OrderCounterClockwise().ToList();
+
+        Assert.Equal(WindingOrder.CounterClockwise, ordered.GetWindingOrder());
+
+        // Consecutive corners of an axis-aligned box share exactly one ordinate; a wrong
+        // ordering would connect diagonal corners (which share neither).
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            var current = ordered[i];
+            var next = ordered[(i + 1) % ordered.Count];
+            var sharesLatitude = current.Latitude.Equals(next.Latitude);
+            var sharesLongitude = current.Longitude.Equals(next.Longitude);
+            Assert.True(sharesLatitude ^ sharesLongitude);
+        }
+    }
+
+    [Fact]
+    public void GetWindingOrder_handles_a_ring_enclosing_the_north_pole()
+    {
+        // A cap around the North Pole, sampled at a constant latitude. A planar shoelace
+        // reads this as zero area (every vertex has the same latitude) and reports null;
+        // measured on the sphere it correctly encloses the pole.
+        var counterClockwise = new List<Coordinate>
+        {
+            new(80, 0),
+            new(80, 90),
+            new(80, 180),
+            new(80, -90),
+        };
+
+        Assert.Equal(WindingOrder.CounterClockwise, counterClockwise.GetWindingOrder());
+
+        counterClockwise.Reverse();
+        Assert.Equal(WindingOrder.Clockwise, counterClockwise.GetWindingOrder());
+    }
+
+    [Fact]
+    public void OrderCounterClockwise_orders_a_cap_around_the_south_pole()
+    {
+        var shuffled = new List<Coordinate> { new(-85, 120), new(-85, -120), new(-85, 0) };
+
+        var ordered = shuffled.OrderCounterClockwise();
+
+        Assert.Equal(WindingOrder.CounterClockwise, ordered.GetWindingOrder());
+    }
 }

--- a/Geo/Linq/EnumerableExtensions.cs
+++ b/Geo/Linq/EnumerableExtensions.cs
@@ -66,12 +66,13 @@ public static class EnumerableExtensions
     /// trace the boundary of a simple polygon that can be closed into a ring.
     /// </summary>
     /// <remarks>
-    /// The coordinates are sorted by their bearing from the average of all the vertices,
-    /// treating longitude as the x-axis and latitude as the y-axis. This reliably recovers
-    /// the boundary order of a <em>convex</em> set of coordinates (for example the corners
-    /// of a bounding box), but a concave set has more than one valid ordering and this
-    /// method may not reproduce the one you had in mind. The result is a permutation of the
-    /// input — it is not closed; append the first coordinate to form a ring.
+    /// The coordinates are projected onto the unit sphere and sorted by their azimuth in
+    /// the tangent plane at the centroid (the normalised sum of the vertices), so the result
+    /// is correct across the antimeridian and around the poles. This reliably recovers the
+    /// boundary order of a <em>convex</em> set of coordinates (for example the corners of a
+    /// bounding box), but a concave set has more than one valid ordering and this method may
+    /// not reproduce the one you had in mind. The result is a permutation of the input — it
+    /// is not closed; append the first coordinate to form a ring.
     /// </remarks>
     /// <param name="coordinates">The coordinates to order.</param>
     /// <returns>The coordinates ordered clockwise.</returns>
@@ -101,14 +102,16 @@ public static class EnumerableExtensions
 
     /// <summary>
     /// Determines whether an ordered ring of coordinates winds clockwise or counter-clockwise,
-    /// using the signed area (shoelace formula). Longitude is treated as the x-axis and latitude
-    /// as the y-axis. The ring may be open or closed; the edge from the last coordinate back to
-    /// the first is always included.
+    /// as seen from outside the sphere. The ring is measured on the unit sphere via its signed
+    /// spherical area, so the antimeridian and the poles (including rings that enclose a pole)
+    /// are handled correctly. The ring may be open or closed; the edge from the last coordinate
+    /// back to the first is always included.
     /// </summary>
     /// <param name="coordinates">The ordered ring of coordinates.</param>
     /// <returns>
     /// The <see cref="WindingOrder" /> of the ring, or <c>null</c> when it is degenerate (fewer
-    /// than three coordinates, or a zero signed area such as a set of colinear points).
+    /// than three coordinates, a ring that encloses no area such as a set of points on a great
+    /// circle, or vertices spread over more than a hemisphere with no well-defined centre).
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="coordinates" /> is <c>null</c>.</exception>
     public static WindingOrder? GetWindingOrder(this IEnumerable<Coordinate> coordinates)
@@ -120,18 +123,24 @@ public static class EnumerableExtensions
         if (list.Count < 3)
             return null;
 
-        // Twice the signed area: positive winds counter-clockwise, negative clockwise.
-        var twiceArea = 0d;
+        var vertices = new Vector3[list.Count];
+        var sum = Vector3.Zero;
         for (var i = 0; i < list.Count; i++)
         {
-            var current = list[i];
-            var next = list[(i + 1) % list.Count];
-            twiceArea += current.Longitude * next.Latitude - next.Longitude * current.Latitude;
+            vertices[i] = Vector3.FromCoordinate(list[i]);
+            sum = sum.Add(vertices[i]);
         }
 
-        if (twiceArea > 0)
+        // No well-defined centre to fan from (e.g. vertices spread over more than a hemisphere).
+        if (sum.Length < Epsilon)
+            return null;
+
+        // Signed spherical area seen from outside the sphere: positive winds counter-clockwise.
+        var signedArea = SignedSphericalArea(vertices, sum.Normalize());
+
+        if (signedArea > Epsilon)
             return WindingOrder.CounterClockwise;
-        if (twiceArea < 0)
+        if (signedArea < -Epsilon)
             return WindingOrder.Clockwise;
         return null;
     }
@@ -148,23 +157,109 @@ public static class EnumerableExtensions
         if (list.Count < 3)
             return list;
 
-        var centerLatitude = list.Average(x => x.Latitude);
-        var centerLongitude = list.Average(x => x.Longitude);
-
-        // Bearing from the centroid; longitude is the x-axis and latitude the y-axis, so an
-        // ascending atan2 sweeps counter-clockwise. Distance keeps colinear points stable.
-        var keyed = list.Select(x =>
+        var vertices = new Vector3[list.Count];
+        var sum = Vector3.Zero;
+        for (var i = 0; i < list.Count; i++)
         {
-            var dx = x.Longitude - centerLongitude;
-            var dy = x.Latitude - centerLatitude;
-            return (Coordinate: x, Angle: Math.Atan2(dy, dx), Radius: dx * dx + dy * dy);
-        });
+            vertices[i] = Vector3.FromCoordinate(list[i]);
+            sum = sum.Add(vertices[i]);
+        }
+
+        // Direction to sort around. If the vertices cancel out (spread over more than a
+        // hemisphere) there is no meaningful centre, so fall back to the first vertex.
+        var center = sum.Length < Epsilon ? vertices[0] : sum.Normalize();
+
+        // A tangent basis (u, v) at the centre. (u, v, center) is right-handed, so an
+        // ascending azimuth sweeps counter-clockwise as seen from outside the sphere.
+        var helper = Math.Abs(center.Z) < 0.9 ? Vector3.UnitZ : Vector3.UnitX;
+        var u = helper.Add(center.Scale(-helper.Dot(center))).Normalize();
+        var v = center.Cross(u);
+
+        var keyed = new (Coordinate Coordinate, double Angle, double Height)[list.Count];
+        for (var i = 0; i < list.Count; i++)
+        {
+            var p = vertices[i];
+            // Azimuth around the centre; height keeps colinear points in a stable order.
+            keyed[i] = (list[i], Math.Atan2(p.Dot(v), p.Dot(u)), p.Dot(center));
+        }
 
         var sorted =
             order == WindingOrder.CounterClockwise
-                ? keyed.OrderBy(x => x.Angle).ThenBy(x => x.Radius)
-                : keyed.OrderByDescending(x => x.Angle).ThenByDescending(x => x.Radius);
+                ? keyed.OrderBy(x => x.Angle).ThenByDescending(x => x.Height)
+                : keyed.OrderByDescending(x => x.Angle).ThenBy(x => x.Height);
 
         return sorted.Select(x => x.Coordinate).ToList();
+    }
+
+    // Below this, values smaller than a rounding error are treated as zero.
+    private const double Epsilon = 1e-12;
+
+    /// <summary>
+    /// The signed area of the spherical polygon <paramref name="vertices" />, as the sum of the
+    /// signed solid angles of the triangles (<paramref name="reference" />, V_i, V_i+1) using the
+    /// Van Oosterom–Strackee formula. Signed areas are additive, so fanning from the reference
+    /// direction gives the whole ring regardless of its shape or whether it encloses a pole.
+    /// Positive is counter-clockwise as seen from outside the sphere.
+    /// </summary>
+    private static double SignedSphericalArea(IReadOnlyList<Vector3> vertices, Vector3 reference)
+    {
+        var total = 0d;
+        for (var i = 0; i < vertices.Count; i++)
+        {
+            var a = vertices[i];
+            var b = vertices[(i + 1) % vertices.Count];
+            var numerator = reference.Dot(a.Cross(b));
+            var denominator = 1 + a.Dot(b) + b.Dot(reference) + reference.Dot(a);
+            total += 2 * Math.Atan2(numerator, denominator);
+        }
+
+        return total;
+    }
+
+    private readonly struct Vector3
+    {
+        public static readonly Vector3 Zero = new(0, 0, 0);
+        public static readonly Vector3 UnitX = new(1, 0, 0);
+        public static readonly Vector3 UnitZ = new(0, 0, 1);
+
+        public Vector3(double x, double y, double z)
+        {
+            X = x;
+            Y = y;
+            Z = z;
+        }
+
+        public double X { get; }
+        public double Y { get; }
+        public double Z { get; }
+
+        public double Length => Math.Sqrt(Dot(this));
+
+        public static Vector3 FromCoordinate(Coordinate coordinate)
+        {
+            var latitude = coordinate.Latitude * Math.PI / 180.0;
+            var longitude = coordinate.Longitude * Math.PI / 180.0;
+            var cosLatitude = Math.Cos(latitude);
+            return new Vector3(
+                cosLatitude * Math.Cos(longitude),
+                cosLatitude * Math.Sin(longitude),
+                Math.Sin(latitude)
+            );
+        }
+
+        public double Dot(Vector3 other) => X * other.X + Y * other.Y + Z * other.Z;
+
+        public Vector3 Cross(Vector3 other) =>
+            new(Y * other.Z - Z * other.Y, Z * other.X - X * other.Z, X * other.Y - Y * other.X);
+
+        public Vector3 Add(Vector3 other) => new(X + other.X, Y + other.Y, Z + other.Z);
+
+        public Vector3 Scale(double scalar) => new(X * scalar, Y * scalar, Z * scalar);
+
+        public Vector3 Normalize()
+        {
+            var length = Length;
+            return length == 0 ? this : new Vector3(X / length, Y / length, Z / length);
+        }
     }
 }

--- a/docs/geometries.md
+++ b/docs/geometries.md
@@ -91,10 +91,17 @@ var shell = new LinearRing(ordered);
 var poly = new Polygon(shell);
 ```
 
-The ordering is derived from each coordinate's bearing from the average of all the
-vertices, so it reliably recovers the boundary of a **convex** set (such as the corners
-of a bounding box); a concave set has more than one valid ordering. `GetWindingOrder`
-reports the winding of an already-ordered ring (or `null` if it encloses no area):
+The ordering is computed on the unit sphere (each coordinate's azimuth around the
+centroid direction), so it is correct **across the antimeridian and around the poles** —
+not just a flat lon/lat approximation. It reliably recovers the boundary of a **convex**
+set (such as the corners of a bounding box); a concave set has more than one valid
+ordering, so the result may not be the one you had in mind.
+
+`GetWindingOrder` reports the winding of an already-ordered ring, viewed from outside the
+sphere. It too is measured spherically (signed spherical area), so a ring that crosses the
+date line or even encloses a pole is handled correctly. It returns `null` for a degenerate
+ring — fewer than three coordinates, one that encloses no area (points on a great circle),
+or vertices spread over more than a hemisphere with no well-defined centre:
 
 ```csharp
 using Geo.Linq;


### PR DESCRIPTION
## Summary

Follow-up to #96, which added `OrderClockwise` / `OrderCounterClockwise` / `GetWindingOrder` (in `Geo.Linq`) for [issue #54](https://github.com/sibartlett/Geo/issues/54).

That first version did **planar math on raw lon/lat degrees**, which breaks in two places:

- **Antimeridian (±180° longitude):** the arithmetic-mean centroid and the shoelace formula both assume longitude is continuous. A polygon straddling the date line gets a centroid on the opposite side of the planet and a signed area spanning ~350° of longitude — so both ordering and winding come out wrong.
- **Poles:** longitude is degenerate at the poles, and a polar-cap ring sampled at constant latitude reads as zero planar area, so `GetWindingOrder` wrongly returned `null`.

This PR reworks both helpers to operate on **unit vectors on the sphere**, so the antimeridian and the poles (including rings that enclose a pole) are handled correctly. The public API and the winding convention are unchanged.

## What changed

- **`OrderClockwise` / `OrderCounterClockwise`** — project each coordinate to a 3D unit vector and sort by azimuth in the tangent plane at the centroid *direction* (normalised sum of the vectors). No longitude wrapping, no pole singularity in the centroid.
- **`GetWindingOrder`** — replaced the planar shoelace with the **signed spherical area**: the sum of signed solid angles of the triangles (centroid, Vᵢ, Vᵢ₊₁) via the Van Oosterom–Strackee formula, fanned from the centroid. Signed areas are additive, so this works for any ring shape, across the date line, and for rings that enclose a pole. Positive area = counter-clockwise as seen from outside the sphere (matching the previous convention for ordinary polygons).
- All the math is a small private `Vector3` helper — netstandard2.0-compatible, no new dependencies.

## Tests

Added coverage for the previously-broken cases (all pass, 636 total):

- A box straddling the 180th meridian (lon 175 → −175) now orders into a valid ring and winds correctly.
- A cap around the North Pole (constant latitude) now reports `CounterClockwise` instead of `null`.
- A cap around the South Pole orders consistently.

The existing convex / degenerate / null-guard / subtype-preservation tests still pass unchanged.

## Notes

- `dotnet csharpier check .` is clean.
- The docs example in `docs/geometries.md` is compiled by `DocumentationExamplesTests`, and the docs text now states the antimeridian/pole behaviour. The one remaining caveat is inherent, not a projection artifact: a *concave* set still has more than one valid ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hv21f3vb3eug2cYU1sQTjw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hv21f3vb3eug2cYU1sQTjw)_