### PR TITLE
Fix inverted spherical polygon area sign in SphereCalculator

### DIFF
--- a/Geo.Tests/Geodesy/SphereCalculatorTests.cs
+++ b/Geo.Tests/Geodesy/SphereCalculatorTests.cs
@@ -97,6 +97,37 @@ public class SphereCalculatorTests
         Assert.Equal(expected, result.SiValue, expected * 1e-9);
     }
 
+    [Fact]
+    public void Ring_area_is_a_positive_magnitude_regardless_of_winding_order()
+    {
+        var calculator = new SphereCalculator(Radius);
+
+        // Same square traversed counter-clockwise (the GeoJSON/OGC exterior-ring
+        // convention) and clockwise. Area is a magnitude, so both must be positive
+        // and equal.
+        var counterClockwise = new CoordinateSequence(
+            new Coordinate(0, 0),
+            new Coordinate(0, 10),
+            new Coordinate(10, 10),
+            new Coordinate(10, 0),
+            new Coordinate(0, 0)
+        );
+        var clockwise = new CoordinateSequence(
+            new Coordinate(0, 0),
+            new Coordinate(10, 0),
+            new Coordinate(10, 10),
+            new Coordinate(0, 10),
+            new Coordinate(0, 0)
+        );
+
+        var ccw = calculator.CalculateArea(counterClockwise).SiValue;
+        var cw = calculator.CalculateArea(clockwise).SiValue;
+
+        Assert.True(ccw > 0);
+        Assert.True(cw > 0);
+        Assert.Equal(cw, ccw, ccw * 1e-9);
+    }
+
     [Theory]
     [InlineData(0, 0, 1, 1, 444763.38338824594)]
     [InlineData(0, 0, 10, 10, 4430910.158223232)]

--- a/Geo.Tests/Geometries/PolygonTests.cs
+++ b/Geo.Tests/Geometries/PolygonTests.cs
@@ -58,6 +58,42 @@ public class PolygonTests
         Assert.True(withHole.GetArea().SiValue < withoutHole.GetArea().SiValue);
     }
 
+    // A counter-clockwise ring (the GeoJSON/OGC exterior-ring convention), which is
+    // the opposite winding to Square above.
+    private static LinearRing SquareCounterClockwise(double size)
+    {
+        return new LinearRing(
+            new Coordinate(0, 0),
+            new Coordinate(0, size),
+            new Coordinate(size, size),
+            new Coordinate(size, 0),
+            new Coordinate(0, 0)
+        );
+    }
+
+    [Fact]
+    public void GetArea_is_positive_regardless_of_shell_winding()
+    {
+        // Both windings describe the same square, so the area must be positive
+        // and identical either way.
+        var clockwise = new Polygon(Square(10)).GetArea().SiValue;
+        var counterClockwise = new Polygon(SquareCounterClockwise(10)).GetArea().SiValue;
+
+        Assert.True(counterClockwise > 0);
+        Assert.Equal(clockwise, counterClockwise, clockwise * 1e-9);
+    }
+
+    [Fact]
+    public void A_hole_reduces_the_area_of_a_standards_wound_polygon()
+    {
+        // GeoJSON/OGC winding: counter-clockwise shell, clockwise hole.
+        var withoutHole = new Polygon(SquareCounterClockwise(10));
+        var withHole = new Polygon(SquareCounterClockwise(10), Square(5));
+
+        Assert.True(withHole.GetArea().SiValue > 0);
+        Assert.True(withHole.GetArea().SiValue < withoutHole.GetArea().SiValue);
+    }
+
     [Fact]
     public void Empty_polygons_are_equal()
     {

--- a/Geo/Geodesy/SphereCalculator.cs
+++ b/Geo/Geodesy/SphereCalculator.cs
@@ -80,7 +80,10 @@ public class SphereCalculator : IGeodeticCalculator
             area = area * Radius * Radius / 2.0;
         }
 
-        return new Area(area);
+        // The formula yields a signed area whose sign depends on the ring's winding
+        // order. Callers (e.g. Polygon.GetArea, which subtracts hole areas from the
+        // shell area) expect a non-negative magnitude, so return the absolute value.
+        return new Area(Math.Abs(area));
     }
 
     public Area CalculateArea(Circle circle)


### PR DESCRIPTION
SphereCalculator.CalculateArea(CoordinateSequence) returned a *signed*
area whose sign is inverted relative to the library's own winding-order
convention (WindingOrder / GetWindingOrder, where a counter-clockwise
exterior ring - the GeoJSON/OGC standard - has positive area).

As a result a standards-wound polygon (CCW shell) produced a negative
area, and because Polygon.GetArea subtracts hole areas from the shell
area, standard winding (CCW shell, CW holes) caused holes to be *added*
in magnitude instead of subtracted. The existing tests only passed
because their "Square" helper is actually wound clockwise despite its
comment.

Since IGeodeticCalculator.CalculateArea returns an Area magnitude and
Polygon.GetArea expects positive ring areas to subtract, return the
absolute area. This makes ring area winding-independent and hole
subtraction correct for any winding.

Add regression tests covering both windings and a standards-wound
polygon with a hole.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H2PtKmAg4L6aBAFembup7Y