### PR TITLE
Align ring and triangle validation with OGC/NTS conventions

### DIFF
--- a/Geo.Tests/Geometries/LineStringTests.cs
+++ b/Geo.Tests/Geometries/LineStringTests.cs
@@ -103,4 +103,22 @@ public class LineStringTests
 
         Assert.True(ring.IsEmpty);
     }
+
+    [Fact]
+    public void LinearRing_requires_at_least_four_coordinates()
+    {
+        // A closed sequence of three coordinates repeats the first point but does not
+        // enclose an area; OGC/NTS require a ring to have zero or at least four points.
+        Assert.Throws<ArgumentException>(() =>
+            new LinearRing(new Coordinate(0, 0), new Coordinate(1, 1), new Coordinate(0, 0))
+        );
+    }
+
+    [Fact]
+    public void A_single_coordinate_line_string_is_not_closed()
+    {
+        var line = new LineString(new Coordinate(0, 0));
+
+        Assert.False(line.IsClosed);
+    }
 }

--- a/Geo.Tests/Geometries/MultiGeometryTests.cs
+++ b/Geo.Tests/Geometries/MultiGeometryTests.cs
@@ -133,4 +133,20 @@ public class MultiGeometryTests
         Assert.True(triangle.Shell.IsClosed);
         Assert.Equal(4, triangle.Shell.Coordinates.Count);
     }
+
+    [Fact]
+    public void Triangle_rejects_a_closed_ring_that_is_not_four_points()
+    {
+        // A closed five-point ring is a valid polygon but not a valid triangle, which
+        // must be a closed ring of exactly four coordinates.
+        var shell = new LinearRing(
+            new Coordinate(0, 0),
+            new Coordinate(1, 0),
+            new Coordinate(1, 1),
+            new Coordinate(0, 1),
+            new Coordinate(0, 0)
+        );
+
+        Assert.Throws<ArgumentException>(() => new Triangle(shell));
+    }
 }

--- a/Geo/CoordinateSequence.cs
+++ b/Geo/CoordinateSequence.cs
@@ -26,7 +26,7 @@ public class CoordinateSequence : SpatialReadOnlyCollection<Coordinate>
         get { return this.Any(x => x.IsMeasured); }
     }
 
-    public bool IsClosed => Count > 2 && this[0].Equals(this[Count - 1]);
+    public bool IsClosed => Count > 1 && this[0].Equals(this[Count - 1]);
 
     public Envelope? GetBounds()
     {

--- a/Geo/Geometries/LineString.cs
+++ b/Geo/Geometries/LineString.cs
@@ -47,7 +47,7 @@ public class LineString : Geometry, ICurve
 
     public override bool IsMeasured => Coordinates.HasM;
 
-    public bool IsClosed => !IsEmpty && Coordinates[0].Equals(Coordinates[Coordinates.Count - 1]);
+    public bool IsClosed => Coordinates.IsClosed;
 
     public Distance GetLength()
     {

--- a/Geo/Geometries/LinearRing.cs
+++ b/Geo/Geometries/LinearRing.cs
@@ -20,9 +20,17 @@ public class LinearRing : LineString
     public LinearRing(CoordinateSequence? coordinates)
         : base(coordinates)
     {
-        if (coordinates != null && !coordinates.IsEmpty && !coordinates.IsClosed)
-            throw new ArgumentException(
-                "The Coordinate Sequence must be closed to form a Linear Ring"
-            );
+        if (coordinates != null && !coordinates.IsEmpty)
+        {
+            if (coordinates.Count < 4)
+                throw new ArgumentException(
+                    "A Linear Ring must have either zero or at least four coordinates"
+                );
+
+            if (!coordinates.IsClosed)
+                throw new ArgumentException(
+                    "The Coordinate Sequence must be closed to form a Linear Ring"
+                );
+        }
     }
 }

--- a/Geo/Geometries/Triangle.cs
+++ b/Geo/Geometries/Triangle.cs
@@ -19,7 +19,7 @@ public class Triangle : Polygon
     public Triangle(LinearRing shell, IEnumerable<LinearRing> holes)
         : base(shell, holes)
     {
-        if (!shell.IsClosed && shell.Coordinates.Count != 4)
+        if (!shell.IsClosed || shell.Coordinates.Count != 4)
             throw new ArgumentException("The Coordinate Sequence is not valid for a triangle.");
     }
 }


### PR DESCRIPTION
Fixes three inconsistencies with OGC Simple Features / NetTopologySuite:

- LinearRing now requires zero or at least four coordinates, matching the
  OGC/NTS rule. Previously a closed three-point sequence such as [A, B, A]
  was accepted even though it encloses no area.
- LineString.IsClosed and CoordinateSequence.IsClosed now share a single
  definition (non-empty, >1 point, coincident endpoints). They previously
  disagreed: CoordinateSequence guarded on Count > 2 while LineString did
  not, so a single-coordinate LineString reported IsClosed == true.
- Triangle construction now rejects any closed ring that is not exactly four
  coordinates. The guard used && instead of ||, so a closed ring with five
  or more points was accepted as a Triangle.

Adds tests for each newly-enforced rule.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WNyvWrWr6ykNRxf8GCp5Y2