### PR TITLE
Encode empty points in WKB as NaN and preserve empties in collections

### DIFF
--- a/Geo.Tests/IO/Wkb/WkbTests.cs
+++ b/Geo.Tests/IO/Wkb/WkbTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using System.Runtime.Serialization;
+using Geo.Geometries;
 using Geo.IO.Wkb;
 using Geo.IO.Wkt;
 using Xunit;
@@ -11,7 +13,7 @@ public class WkbTests
     [Fact]
     public void Point()
     {
-        //Test("POINT EMPTY");
+        Test("POINT EMPTY");
         Test("POINT (45.89 23.9)");
         Test("POINT Z (45.89 23.9 0.45)");
         Test("POINT M (45.89 23.9 34)");
@@ -98,6 +100,48 @@ public class WkbTests
         Test(
             "GEOMETRYCOLLECTION (LINESTRING ZM (45.89 23.9 0.45 34, 0 0 0.45 34), POLYGON ZM ((0 0 2 -1, 1 0 2 -1, 0 1 2 -1, 0 0 2 -1)))"
         );
+    }
+
+    [Fact]
+    public void Empty_point_round_trips_as_a_non_empty_wkb_record()
+    {
+        // WKB has no empty flag for a point, so an empty point is encoded as a 2D point
+        // with NaN ordinates (never zero bytes) and read back as an empty point.
+        var wkb = new WkbWriter().Write(new Point());
+
+        Assert.NotEmpty(wkb);
+
+        var result = new WkbReader().Read(wkb);
+
+        Assert.NotNull(result);
+        Assert.True(result!.IsEmpty);
+        Assert.IsType<Point>(result);
+    }
+
+    [Fact]
+    public void Empty_points_are_preserved_inside_a_multipoint()
+    {
+        var multiPoint = new MultiPoint(new Point(1, 2), new Point(), new Point(3, 4));
+
+        var wkb = new WkbWriter().Write(multiPoint);
+        var result = (MultiPoint)new WkbReader().Read(wkb)!;
+
+        Assert.Equal(3, result.Geometries.Count);
+        Assert.True(result.Geometries.ElementAt(1).IsEmpty);
+        Assert.Equal(multiPoint, result);
+    }
+
+    [Fact]
+    public void Empty_points_are_preserved_inside_a_geometry_collection()
+    {
+        var collection = new GeometryCollection(new Point(), new Point(5, 6));
+
+        var wkb = new WkbWriter().Write(collection);
+        var result = (GeometryCollection)new WkbReader().Read(wkb)!;
+
+        Assert.Equal(2, result.Geometries.Count);
+        Assert.True(result.Geometries.ElementAt(0).IsEmpty);
+        Assert.Equal(collection, result);
     }
 
     [Fact]

--- a/Geo.Tests/IO/Wkt/WktReaderTests.cs
+++ b/Geo.Tests/IO/Wkt/WktReaderTests.cs
@@ -256,6 +256,10 @@ public class WktReaderTests
             points
         );
 
+        var withEmptyMember = reader.Read("GEOMETRYCOLLECTION (POINT EMPTY, POINT (0.0 65.9))");
+        Assert.Equal(new GeometryCollection(new Point(), new Point(65.9, 0)), withEmptyMember);
+        Assert.True(((GeometryCollection)withEmptyMember!).Geometries[0].IsEmpty);
+
         var empty = reader.Read("GEOMETRYCOLLECTION ZM EMPTY");
         Assert.Equal(new GeometryCollection(), empty);
     }

--- a/Geo.Tests/IO/Wkt/WktWriterTests.cs
+++ b/Geo.Tests/IO/Wkt/WktWriterTests.cs
@@ -7,6 +7,26 @@ namespace Geo.Tests.IO.Wkt;
 public class WktWriterTests
 {
     [Fact]
+    public void Empty_point_members_survive_a_write_then_read_round_trip()
+    {
+        var writer = new WktWriter();
+        var reader = new WktReader();
+
+        var multiPoint = new MultiPoint(new Point(), new Point(65.9, 0), new Point());
+        var multiPointResult = (MultiPoint)reader.Read(writer.Write(multiPoint))!;
+        Assert.Equal(3, multiPointResult.Geometries.Count);
+        Assert.True(multiPointResult.Geometries[0].IsEmpty);
+        Assert.True(multiPointResult.Geometries[2].IsEmpty);
+        Assert.Equal(multiPoint, multiPointResult);
+
+        var collection = new GeometryCollection(new Point(), new Point(65.9, 0));
+        var collectionResult = (GeometryCollection)reader.Read(writer.Write(collection))!;
+        Assert.Equal(2, collectionResult.Geometries.Count);
+        Assert.True(collectionResult.Geometries[0].IsEmpty);
+        Assert.Equal(collection, collectionResult);
+    }
+
+    [Fact]
     public void Point()
     {
         var writer = new WktWriter();

--- a/Geo/IO/Wkb/WkbReader.cs
+++ b/Geo/IO/Wkb/WkbReader.cs
@@ -139,7 +139,15 @@ public class WkbReader
 
     private Point ReadPoint(WkbBinaryReader reader, WkbDimensions dimensions)
     {
-        return new Point(ReadCoordinate(reader, dimensions));
+        var coordinate = ReadCoordinate(reader, dimensions);
+
+        // A point whose position ordinates are all NaN encodes POINT EMPTY, matching
+        // NTS/GEOS/PostGIS. Return a fresh empty point rather than the shared singleton,
+        // since Point.Coordinate is mutable.
+        if (double.IsNaN(coordinate.Latitude) && double.IsNaN(coordinate.Longitude))
+            return new Point();
+
+        return new Point(coordinate);
     }
 
     private LineString ReadLineString(WkbBinaryReader reader, WkbDimensions dimensions)

--- a/Geo/IO/Wkb/WkbWriter.cs
+++ b/Geo/IO/Wkb/WkbWriter.cs
@@ -162,10 +162,19 @@ public class WkbWriter
 
     private void WritePoint(Point point, WkbBinaryWriter writer)
     {
-        if (!point.IsEmpty)
+        WriteEncoding(writer, _settings.Encoding);
+        WriteGeometryType(point, WkbGeometryType.Point, writer);
+
+        if (point.IsEmpty)
         {
-            WriteEncoding(writer, _settings.Encoding);
-            WriteGeometryType(point, WkbGeometryType.Point, writer);
+            // WKB has no empty flag for a point, so an empty point is encoded as a 2D
+            // point with NaN ordinates, matching NTS/GEOS/PostGIS. WriteGeometryType has
+            // already written the 2D Point type code for the empty geometry.
+            writer.Write(double.NaN);
+            writer.Write(double.NaN);
+        }
+        else
+        {
             WriteCoordinate(point.Coordinate!, writer);
         }
     }
@@ -211,9 +220,8 @@ public class WkbWriter
     {
         WriteEncoding(writer, _settings.Encoding);
         WriteGeometryType(multipoint, WkbGeometryType.MultiPoint, writer);
-        var points = multipoint.Geometries.Cast<Point>().Where(x => !x.IsEmpty).ToList();
-        writer.Write((uint)points.Count);
-        foreach (var point in points)
+        writer.Write((uint)multipoint.Geometries.Count);
+        foreach (var point in multipoint.Geometries.Cast<Point>())
             Write(point, writer);
     }
 
@@ -239,9 +247,8 @@ public class WkbWriter
     {
         WriteEncoding(writer, _settings.Encoding);
         WriteGeometryType(collection, WkbGeometryType.GeometryCollection, writer);
-        var geometries = collection.Geometries.Where(x => !(x is Point) || !x.IsEmpty).ToList();
-        writer.Write((uint)geometries.Count);
-        foreach (var geometry in geometries)
+        writer.Write((uint)collection.Geometries.Count);
+        foreach (var geometry in collection.Geometries)
             Write(geometry, writer);
     }
 

--- a/docs/well-known-binary.md
+++ b/docs/well-known-binary.md
@@ -54,3 +54,13 @@ There is also a static factory for settings that are compatible with NTS/JTS:
 ```csharp
 var writer = new WkbWriter(WkbWriterSettings.NtsCompatible);
 ```
+
+## Empty geometries
+
+WKB carries no dedicated flag for an empty point, so — following the convention
+used by NTS/JTS, GEOS and PostGIS — an empty `Point` is written as a 2D point
+whose ordinates are both `NaN`, and a point read back with all-`NaN` ordinates
+is returned as an empty `Point`. Empty points are also preserved as members of a
+`MultiPoint` or `GeometryCollection` (they are not dropped), so a collection
+keeps its cardinality across a round trip. All other empty geometries use their
+natural zero-length encoding (an empty ring/coordinate count).


### PR DESCRIPTION
## Summary

Aligns WKB empty-point handling with the OGC / NetTopologySuite (NTS/JTS, also GEOS, PostGIS) convention. Follows on from #105 (ring/triangle validation), addressing the last of the WKB-related inconsistencies found in that audit.

Previously an empty `Point` serialised to **zero bytes** — not a valid WKB record — and round-tripped to `null`. Empty points were also silently **dropped** from `MultiPoint` and `GeometryCollection`, changing a collection's cardinality across a round trip.

## Changes

**WKB (behaviour change)**
- An empty `Point` is now written as a 2D point with `NaN` ordinates (`WkbWriter`), and a point read back with all-`NaN` position ordinates is returned as an empty `Point` (`WkbReader`, a fresh instance rather than the mutable `Point.Empty` singleton).
- Empty points are no longer filtered out of `MultiPoint` and `GeometryCollection`; members are written and read as-is, so a collection keeps its cardinality across a round trip.
- Documented the empty-geometry encoding in `docs/well-known-binary.md`.

**WKT (tests only)**
- Geo's WKT reader and writer already preserve empty members (the writer emits `EMPTY`/`POINT EMPTY` and does not filter; the reader parses them back). Added tests to lock that in — no production change was needed for WKT.

## Behaviour change to be aware of

Callers that previously received a zero-length `byte[]` (and `null` on read) for a standalone empty point now get a valid `NaN` record and an empty `Point`; empty points inside `MultiPoint`/`GeometryCollection` are no longer dropped. Both are intended, and match NTS.

## Tests

- Enabled the previously-disabled `POINT EMPTY` WKB round-trip case.
- Added WKB tests: non-empty encoding of a standalone empty point, and empties preserved inside `MultiPoint` and `GeometryCollection`.
- Added WKT tests: reading a `GEOMETRYCOLLECTION` with a `POINT EMPTY` member, and a write→read round trip for collections containing empty points.
- Full suite: **682 passing**; `csharpier check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNyvWrWr6ykNRxf8GCp5Y2)_