### PR TITLE
Make geometry Empty singletons return fresh instances

### DIFF
--- a/Geo.Tests/Geometries/PointTests.cs
+++ b/Geo.Tests/Geometries/PointTests.cs
@@ -14,6 +14,18 @@ public class PointTests
     }
 
     [Fact]
+    public void Empty_returns_a_fresh_instance_that_cannot_corrupt_the_shared_state()
+    {
+        // Point.Coordinate is mutable, so Empty must hand out a new instance each time;
+        // mutating one must not turn a later Point.Empty into a non-empty point.
+        var first = Point.Empty;
+        first.Coordinate = new Coordinate(1, 2);
+
+        Assert.NotSame(first, Point.Empty);
+        Assert.True(Point.Empty.IsEmpty);
+    }
+
+    [Fact]
     public void Two_argument_constructor_is_neither_3d_nor_measured()
     {
         var point = new Point(1, 2);

--- a/Geo/Geometries/Circle.cs
+++ b/Geo/Geometries/Circle.cs
@@ -9,7 +9,7 @@ namespace Geo.Geometries;
 
 public class Circle : Geometry, ISurface
 {
-    public static readonly Circle Empty = new();
+    public static Circle Empty => new();
 
     public Circle()
     {

--- a/Geo/Geometries/GeometryCollection.cs
+++ b/Geo/Geometries/GeometryCollection.cs
@@ -8,7 +8,7 @@ namespace Geo.Geometries;
 
 public class GeometryCollection : Geometry
 {
-    public static readonly GeometryCollection Empty = new();
+    public static GeometryCollection Empty => new();
 
     public GeometryCollection()
     {

--- a/Geo/Geometries/LineString.cs
+++ b/Geo/Geometries/LineString.cs
@@ -9,7 +9,7 @@ namespace Geo.Geometries;
 
 public class LineString : Geometry, ICurve
 {
-    public static readonly LineString Empty = new();
+    public static LineString Empty => new();
 
     public LineString()
         : this(new CoordinateSequence()) { }

--- a/Geo/Geometries/LinearRing.cs
+++ b/Geo/Geometries/LinearRing.cs
@@ -6,7 +6,7 @@ namespace Geo.Geometries;
 
 public class LinearRing : LineString
 {
-    public static new readonly LinearRing Empty = new();
+    public static new LinearRing Empty => new();
 
     public LinearRing()
         : this(new CoordinateSequence()) { }

--- a/Geo/Geometries/MultiLineString.cs
+++ b/Geo/Geometries/MultiLineString.cs
@@ -8,7 +8,7 @@ namespace Geo.Geometries;
 
 public class MultiLineString : GeometryCollection, IMultiCurve
 {
-    public static new readonly MultiLineString Empty = new();
+    public static new MultiLineString Empty => new();
 
     public MultiLineString() { }
 

--- a/Geo/Geometries/MultiPoint.cs
+++ b/Geo/Geometries/MultiPoint.cs
@@ -6,7 +6,7 @@ namespace Geo.Geometries;
 
 public class MultiPoint : GeometryCollection
 {
-    public static new readonly MultiPoint Empty = new();
+    public static new MultiPoint Empty => new();
 
     public MultiPoint() { }
 

--- a/Geo/Geometries/MultiPolygon.cs
+++ b/Geo/Geometries/MultiPolygon.cs
@@ -8,7 +8,7 @@ namespace Geo.Geometries;
 
 public class MultiPolygon : GeometryCollection, IMultiSurface
 {
-    public static new readonly MultiPolygon Empty = new();
+    public static new MultiPolygon Empty => new();
 
     public MultiPolygon() { }
 

--- a/Geo/Geometries/Point.cs
+++ b/Geo/Geometries/Point.cs
@@ -6,7 +6,7 @@ namespace Geo.Geometries;
 
 public class Point : Geometry, IPosition
 {
-    public static readonly Point Empty = new();
+    public static Point Empty => new();
 
     public Point()
         : this(null) { }

--- a/Geo/Geometries/Polygon.cs
+++ b/Geo/Geometries/Polygon.cs
@@ -9,7 +9,7 @@ namespace Geo.Geometries;
 
 public class Polygon : Geometry, ISurface
 {
-    public static readonly Polygon Empty = new();
+    public static Polygon Empty => new();
 
     public Polygon()
         : this((LinearRing?)null) { }

--- a/Geo/Geometries/Triangle.cs
+++ b/Geo/Geometries/Triangle.cs
@@ -6,7 +6,7 @@ namespace Geo.Geometries;
 
 public class Triangle : Polygon
 {
-    public static new readonly Triangle Empty = new();
+    public static new Triangle Empty => new();
 
     public Triangle() { }
 


### PR DESCRIPTION
## Summary

Each geometry type exposed a shared `static readonly Empty` singleton. `Point` has a mutable `Coordinate` setter, so a caller — or the WKT reader, which returns `Point.Empty` for `POINT EMPTY` — mutating a returned empty point corrupted the shared instance for the whole process. Follows on from the OGC/NTS convention work in #105 and #106.

## Changes

- Convert every geometry `Empty` from a shared `static readonly` field to an expression-bodied static property that returns a new instance:

  ```csharp
  // before
  public static readonly Point Empty = new();
  // after
  public static Point Empty => new();
  ```

  Applied to `Point`, `LineString`, `LinearRing`, `Polygon`, `Triangle`, `Circle`, `MultiPoint`, `MultiLineString`, `MultiPolygon`, and `GeometryCollection`.

## Scope rationale

Only `Point` is actually mutable today (public `Coordinate` setter), so it was the one real corruption vector. The other nine types are immutable through their public surface (`SpatialReadOnlyCollection` is read-only; `Shell`/`Holes`/`Center`/`Geometries` are get-only), so their singletons could not be corrupted — but converting them too keeps the family consistent and removes the latent trap if a setter is ever added later. Nothing relies on `Empty`'s reference identity (tests use `IsEmpty`/`GetBounds`/value-`Equals`), and `Empty` is never on a hot path, so the per-access allocation is negligible.

## Tests

- Added `Empty_returns_a_fresh_instance_that_cannot_corrupt_the_shared_state`: mutates one `Point.Empty` and asserts a later `Point.Empty` is still empty and a distinct instance.
- Full suite: **683 passing**; `csharpier check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNyvWrWr6ykNRxf8GCp5Y2)_