### PR TITLE
Round scaled ordinates when encoding Google polylines

### DIFF
--- a/Geo.Tests/IO/Google/GooglePolylineEncoderTests.cs
+++ b/Geo.Tests/IO/Google/GooglePolylineEncoderTests.cs
@@ -21,6 +21,19 @@ public class GooglePolylineEncoderTests
     }
 
     [Fact]
+    public void Encode_rounds_the_scaled_ordinate_to_the_nearest_unit()
+    {
+        // Regression: the scaled ordinate must be rounded (as the Google polyline
+        // algorithm specifies), not truncated toward zero. 1.234567 * 1e5 = 123456.7,
+        // which rounds to 123457; truncation would give 123456 and produce "_cpF_cpF".
+        var lineString = new LineString(new Coordinate(1.234567, 1.234567));
+
+        var result = new GooglePolylineEncoder().Encode(lineString);
+
+        Assert.Equal("acpFacpF", result);
+    }
+
+    [Fact]
     public void Decode()
     {
         var lineString = new LineString(

--- a/Geo/IO/Google/GooglePolylineEncoder.cs
+++ b/Geo/IO/Google/GooglePolylineEncoder.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -26,8 +27,14 @@ public class GooglePolylineEncoder
 
         foreach (var coordinate in lineString.Coordinates)
         {
-            var late5 = (int)(coordinate.Latitude * CoordinateFactor);
-            var lnge5 = (int)(coordinate.Longitude * CoordinateFactor);
+            // The Google polyline algorithm rounds the scaled ordinate to the nearest
+            // integer; truncating with a plain (int) cast loses the last digit for
+            // common coordinates (e.g. 1.234567) and produces output that disagrees
+            // with Google's reference encoder by one unit in the last place.
+            var late5 = (int)
+                Math.Round(coordinate.Latitude * CoordinateFactor, MidpointRounding.AwayFromZero);
+            var lnge5 = (int)
+                Math.Round(coordinate.Longitude * CoordinateFactor, MidpointRounding.AwayFromZero);
 
             EncodeNumber(builder, late5 - plat);
             EncodeNumber(builder, lnge5 - plng);


### PR DESCRIPTION
GooglePolylineEncoder.Encode cast the scaled ordinate to int, which
truncates toward zero. The Google polyline algorithm rounds to the
nearest unit, so the previous code produced output that disagreed with
Google's reference encoder by one unit in the last place for common
coordinates (e.g. 1.234567 encoded as "_cpF" instead of "acpF").

Round the scaled value (half away from zero) before differencing, and
add a regression test.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0155c5YkLfsx33fD7F3wGRgT