### PR TITLE
Fix GpsFeatures.Contains to require all requested features

### DIFF
--- a/Geo.Tests/Gps/GpsFeaturesExtensionsTests.cs
+++ b/Geo.Tests/Gps/GpsFeaturesExtensionsTests.cs
@@ -13,7 +13,14 @@ public class GpsFeaturesExtensionsTests
     [InlineData(GpsFeatures.RoutesAndTracks, GpsFeatures.Waypoints, false)]
     [InlineData(GpsFeatures.RoutesAndTracks, GpsFeatures.Routes, true)]
     [InlineData(GpsFeatures.TracksAndWaypoints, GpsFeatures.Tracks, true)]
-    public void Contains_reports_whether_any_requested_flag_is_set(
+    // A combined request requires every flag to be present: a format that supports only
+    // one of the requested features must not be reported as containing the whole set.
+    [InlineData(GpsFeatures.TracksAndWaypoints, GpsFeatures.TracksAndWaypoints, true)]
+    [InlineData(GpsFeatures.Tracks, GpsFeatures.TracksAndWaypoints, false)]
+    [InlineData(GpsFeatures.Waypoints, GpsFeatures.TracksAndWaypoints, false)]
+    [InlineData(GpsFeatures.RoutesAndTracks, GpsFeatures.All, false)]
+    [InlineData(GpsFeatures.All, GpsFeatures.All, true)]
+    public void Contains_reports_whether_all_requested_flags_are_set(
         GpsFeatures supported,
         GpsFeatures requested,
         bool expected

--- a/Geo.Tests/Gps/Serialization/GpsDataTests.cs
+++ b/Geo.Tests/Gps/Serialization/GpsDataTests.cs
@@ -170,4 +170,20 @@ public class GpsDataTests : SerializerTestFixtureBase
         Assert.DoesNotContain("IGC", names); // Tracks only
         Assert.DoesNotContain("Garmin Flightplan", names); // Routes only
     }
+
+    [Fact]
+    public void SupportedGpsFileFormats_for_tracks_and_waypoints_excludes_track_only_igc()
+    {
+        // A combined request must only return formats that support every requested feature.
+        // IGC supports tracks but not waypoints, so it cannot store this combination.
+        var names = GpsData
+            .SupportedGpsFileFormats(GpsFeatures.TracksAndWaypoints)
+            .Select(x => x.Name)
+            .ToList();
+
+        Assert.Contains("NMEA", names); // Tracks and Waypoints
+        Assert.Contains("GPX 1.1", names); // Supports every feature
+        Assert.DoesNotContain("IGC", names); // Tracks only
+        Assert.DoesNotContain("Garmin Flightplan", names); // Routes only
+    }
 }

--- a/Geo/Gps/GpsFeaturesExtensions.cs
+++ b/Geo/Gps/GpsFeaturesExtensions.cs
@@ -2,9 +2,16 @@ namespace Geo.Gps;
 
 public static class GpsFeaturesExtensions
 {
+    /// <summary>
+    /// Determines whether <paramref name="supportedFeatures" /> includes <em>all</em> of the
+    /// features in <paramref name="features" />. For a combined request such as
+    /// <see cref="GpsFeatures.TracksAndWaypoints" /> every requested flag must be present, so a
+    /// format that supports only one of them is not a match. This mirrors the semantics of
+    /// <see cref="System.Enum.HasFlag" />.
+    /// </summary>
     public static bool Contains(this GpsFeatures supportedFeatures, GpsFeatures features)
     {
-        return (supportedFeatures & features) != 0;
+        return (supportedFeatures & features) == features;
     }
 
     public static bool Routes(this GpsFeatures supportedFeatures)


### PR DESCRIPTION
## Summary

`GpsFeaturesExtensions.Contains` tested for *any* overlapping flag instead of requiring *every* requested feature to be present:

```csharp
// before
(supportedFeatures & features) != 0   // "shares any flag"
// after
(supportedFeatures & features) == features   // "supports all requested flags" (Enum.HasFlag semantics)
```

The method's name and its only consumer (`GpsData.SupportedGpsFileFormats(features)`) both expect containment — "supports **all** of these features". The intersection test is wrong for any combined request.

## Why it was hidden

Every existing test row and every internal caller passed a **single-flag** request, where "any bit set" and "all bits set" are identical. The defect only manifests on a combined request:

- `GpsFeatures.Tracks.Contains(GpsFeatures.TracksAndWaypoints)` returned `true`, even though a tracks-only format does not support both.
- Through the consumer, `GpsData.SupportedGpsFileFormats(GpsFeatures.TracksAndWaypoints)` wrongly listed **IGC** (tracks-only) as able to store tracks *and* waypoints.

## Changes

- `Contains` now uses `(supported & features) == features`, with an XML doc comment noting the equivalence to `Enum.HasFlag`. Single-flag callers are unaffected.
- Extended the extension theory with the previously-uncovered multi-flag cases (e.g. `Tracks` vs `TracksAndWaypoints → false`).
- Added a consumer regression test asserting `SupportedGpsFileFormats(TracksAndWaypoints)` excludes IGC but includes NMEA/GPX.

## Compatibility note

This is a behavior change to a public extension method. It is a bug fix, but any external caller that (perhaps unknowingly) relied on the old "any-of" behavior for a combined flag request would now see stricter matching. The stricter semantics is the correct and intended one given the method name and its single internal use.

## Testing

- `dotnet test Geo.Tests/Geo.Tests.csproj` — 690/690 passing.
- `dotnet csharpier check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0155c5YkLfsx33fD7F3wGRgT)_