### PR TITLE
Make Area use AreaUnit with squared conversion factors

### DIFF
--- a/Geo.Tests/Measure/AreaTests.cs
+++ b/Geo.Tests/Measure/AreaTests.cs
@@ -58,30 +58,34 @@ public class AreaTests
     [Fact]
     public void Unit_constructor_converts_value_to_si_and_exposes_it_in_unit()
     {
-        var area = new Area(2, DistanceUnit.Km);
+        // 2 km² is 2,000,000 m² — an area unit scales by the square of the linear factor,
+        // not the linear factor itself (which would give 2000).
+        var area = new Area(2, AreaUnit.Km);
 
-        Assert.Equal(2000, area.SiValue);
-        Assert.Equal(DistanceUnit.Km, area.Unit);
+        Assert.Equal(2_000_000, area.SiValue);
+        Assert.Equal(AreaUnit.Km, area.Unit);
         Assert.Equal(2, area.Value, 1e-9);
     }
 
     [Fact]
     public void ConvertTo_expresses_the_value_in_the_requested_unit()
     {
-        var converted = new Area(2000).ConvertTo(DistanceUnit.Km);
+        // 2,000,000 m² is 2 km²; ConvertTo returns another Area, not a Distance.
+        Area converted = new Area(2_000_000).ConvertTo(AreaUnit.Km);
 
         Assert.Equal(2, converted.Value, 1e-9);
-        Assert.Equal(DistanceUnit.Km, converted.Unit);
+        Assert.Equal(AreaUnit.Km, converted.Unit);
     }
 
     [Fact]
     public void ToString_formats_the_value_in_its_unit()
     {
-        Assert.Equal(new Area(2000).ToString(), new Area(2000).ToString(DistanceUnit.M));
+        Assert.Equal(new Area(2000).ToString(), new Area(2000).ToString(AreaUnit.M));
         Assert.Equal(
-            new Area(2000).ConvertTo(DistanceUnit.Km).ToString(),
-            new Area(2000).ToString(DistanceUnit.Km)
+            new Area(2_000_000).ConvertTo(AreaUnit.Km).ToString(),
+            new Area(2_000_000).ToString(AreaUnit.Km)
         );
+        Assert.Equal("1 km²", new Area(1_000_000).ToString(AreaUnit.Km));
     }
 
     [Fact]

--- a/Geo/Measure/Area.cs
+++ b/Geo/Measure/Area.cs
@@ -5,26 +5,26 @@ namespace Geo.Measure;
 
 public struct Area : IMeasure, IEquatable<Area>, IComparable<Area>
 {
-    public Area(double metres)
+    public Area(double squareMetres)
     {
-        SiValue = metres;
-        Unit = DistanceUnit.M;
+        SiValue = squareMetres;
+        Unit = AreaUnit.M;
     }
 
-    public Area(double value, DistanceUnit unit)
+    public Area(double value, AreaUnit unit)
     {
-        SiValue = value.ConvertFrom(unit).To(DistanceUnit.M);
+        SiValue = value.ConvertFrom(unit).To(AreaUnit.M);
         Unit = unit;
     }
 
     public double Value => SiValue.ConvertTo(Unit);
     public double SiValue { get; }
 
-    public DistanceUnit Unit { get; }
+    public AreaUnit Unit { get; }
 
-    public Distance ConvertTo(DistanceUnit unit)
+    public Area ConvertTo(AreaUnit unit)
     {
-        return new Distance(SiValue.ConvertTo(unit), unit);
+        return new Area(SiValue.ConvertTo(unit), unit);
     }
 
     public override string ToString()
@@ -32,7 +32,7 @@ public struct Area : IMeasure, IEquatable<Area>, IComparable<Area>
         return UnitMetadata.For(Unit).Format(Value);
     }
 
-    public string ToString(DistanceUnit unit)
+    public string ToString(AreaUnit unit)
     {
         return ConvertTo(unit).ToString();
     }
@@ -61,29 +61,29 @@ public struct Area : IMeasure, IEquatable<Area>, IComparable<Area>
         return SiValue.GetHashCode();
     }
 
-    public static explicit operator Area(int metersPerSecond)
+    public static explicit operator Area(int squareMetres)
     {
-        return new Area(metersPerSecond);
+        return new Area(squareMetres);
     }
 
-    public static explicit operator Area(long metersPerSecond)
+    public static explicit operator Area(long squareMetres)
     {
-        return new Area(metersPerSecond);
+        return new Area(squareMetres);
     }
 
-    public static explicit operator Area(double metersPerSecond)
+    public static explicit operator Area(double squareMetres)
     {
-        return new Area(metersPerSecond);
+        return new Area(squareMetres);
     }
 
-    public static explicit operator Area(float metersPerSecond)
+    public static explicit operator Area(float squareMetres)
     {
-        return new Area(metersPerSecond);
+        return new Area(squareMetres);
     }
 
-    public static explicit operator Area(decimal metersPerSecond)
+    public static explicit operator Area(decimal squareMetres)
     {
-        return new Area((double)metersPerSecond);
+        return new Area((double)squareMetres);
     }
 
     public static bool operator ==(Area left, Area right)

--- a/Geo/Measure/AreaUnit.cs
+++ b/Geo/Measure/AreaUnit.cs
@@ -2,18 +2,18 @@ namespace Geo.Measure;
 
 public enum AreaUnit
 {
-    [Unit("m�", 1 * 1)]
+    [Unit("m²", 1 * 1)]
     M = 0,
 
-    [Unit("nm�", 1852 * 1852)]
+    [Unit("nm²", 1852 * 1852)]
     Nm = 1,
 
-    [Unit("km�", 1000 * 1000)]
+    [Unit("km²", 1000 * 1000)]
     Km = 2,
 
-    [Unit("mi�", 1609.34 * 1609.34)]
+    [Unit("mi²", 1609.34 * 1609.34)]
     Mile = 3,
 
-    [Unit("ft�", 0.3048 * 0.3048)]
+    [Unit("ft²", 0.3048 * 0.3048)]
     Ft = 4,
 }

--- a/docs/measure.md
+++ b/docs/measure.md
@@ -58,17 +58,35 @@ double mph = average.ConvertTo(SpeedUnit.Mph).Value;
 
 `Area` stores square metres internally (`SiValue`) and is what area calculations
 return (for example `Envelope.GetArea()` and
-`IGeodeticCalculator.CalculateArea`).
+`IGeodeticCalculator.CalculateArea`). It converts to other units with
+`ConvertTo`, using `AreaUnit` (not `DistanceUnit`) so the conversion scales by
+the **square** of the linear factor.
 
 ```csharp
 using Geo.Measure;
 
 Area area = envelope.GetArea();
 double squareMetres = area.SiValue;
+double squareKm = area.ConvertTo(AreaUnit.Km).Value;
+
+// Construct in a specific unit (2 km² = 2,000,000 m²):
+var field = new Area(2, AreaUnit.Km);
+double m2 = field.SiValue;            // 2000000
 ```
 
-> Note: `Area` is currently modelled on `DistanceUnit` and its `SiValue` is in
-> square metres. Prefer working with `SiValue` (m²) directly.
+`AreaUnit` values: `M` (m²), `Nm` (nautical miles²), `Km` (km²), `Mile` (statute
+miles²), `Ft` (ft²).
+
+`ToString()` formats with the measurement's unit; `ToString(unit)` converts
+first:
+
+```csharp
+area.ToString();               // e.g. "1000000 m²"
+area.ToString(AreaUnit.Km);    // e.g. "1 km²"
+```
+
+Like `Distance`, `Area` values support arithmetic (`+`, `-`) and comparison
+operators, all evaluated on the underlying square-metre value.
 
 ## Converting bare doubles
 

--- a/docs/measure.md
+++ b/docs/measure.md
@@ -81,6 +81,7 @@ miles²), `Ft` (ft²).
 first:
 
 ```csharp
+Area area = envelope.GetArea();
 area.ToString();               // e.g. "1000000 m²"
 area.ToString(AreaUnit.Km);    // e.g. "1 km²"
 ```


### PR DESCRIPTION
## Summary

`Area` is an area quantity, but its entire unit-conversion API was expressed in terms of `DistanceUnit` with **linear** conversion factors. An area cannot be meaningfully expressed in a linear unit, and converting one shouldn't return a `Distance`:

| Expression | Before (broken) | After |
|---|---|---|
| `new Area(2, DistanceUnit.Km).SiValue` | `2000` | `2_000_000` (2 km² = 2M m²) |
| `Value` / `ToString` | scaled by linear factor | scaled by squared factor |
| `area.ConvertTo(DistanceUnit.Km)` | returns a **`Distance`** | returns an `Area` |

The correctly-squared `AreaUnit` enum and `AreaUnitExtensions` already existed and were even wired into `UnitMetadata` — clearly built for this — but `Area` never used them.

## Changes

- **`Area`** now uses `AreaUnit` for its unit constructor, `Unit` property, `Value`, `ConvertTo` (which now returns an `Area`), and `ToString(unit)`, so conversions scale by the square of the linear factor.
- **`AreaUnit` symbols repaired**: the `²` in `m²`, `km²`, … had been mangled into the Unicode replacement character (`�`); these now surface via `ToString`, so they are restored.
- Fixed the explicit-cast operator parameter names, which had been copy-pasted from `Speed` (`metersPerSecond` → `squareMetres`).
- Updated the three `AreaTests` that had baked in the linear behavior and added a `ToString` assertion (`"1 km²"`).
- **`docs/measure.md`**: replaced the caveat that documented the old `DistanceUnit` modelling with a proper Area section (mirroring Distance/Speed) covering `ConvertTo`, unit construction, and `ToString`.

## Compatibility note

This is a **breaking change to `Area`'s public unit API** (`DistanceUnit` → `AreaUnit`; `ConvertTo` returns `Area` instead of `Distance`). Because the old behavior returned wrong magnitudes and the wrong type, it is unlikely any consumer relied on it correctly. The square-metre `SiValue`, arithmetic (`+`/`-`), and comparison operators are unchanged, and the geodetic calculators construct `Area` only from square metres via `new Area(double)` — so **all geometry area calculations are unaffected**. Worth a version bump when released.

## Testing

- `dotnet test Geo.Tests/Geo.Tests.csproj` — 690/690 passing.
- `dotnet csharpier check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0155c5YkLfsx33fD7F3wGRgT)_