### PR TITLE
Accept '+' sign in WKT number tokens

### DIFF
--- a/Geo.Tests/IO/Wkt/WktReaderTests.cs
+++ b/Geo.Tests/IO/Wkt/WktReaderTests.cs
@@ -83,6 +83,31 @@ public class WktReaderTests
     }
 
     [Fact]
+    public void Exponential_number_with_positive_exponent_sign()
+    {
+        var reader = new WktReader();
+
+        // Some producers (including .NET's own double.ToString for large magnitudes)
+        // write the exponent with an explicit '+' sign. The tokenizer must accept it.
+        var xy = reader.Read("POINT (1.5E+01 2)");
+        Assert.Equal(new Point(2, 1.5E+01), xy);
+
+        // A large magnitude (which forces the '+' exponent form) round-trips through
+        // an elevation, where no coordinate range limit applies.
+        var z = reader.Read("POINT Z (1 2 1.5E+21)");
+        Assert.Equal(new Point(2, 1, 1.5E+21), z);
+    }
+
+    [Fact]
+    public void Leading_positive_sign()
+    {
+        var reader = new WktReader();
+
+        var point = reader.Read("POINT (+1 +2)");
+        Assert.Equal(new Point(2, 1), point);
+    }
+
+    [Fact]
     public void Point()
     {
         var reader = new WktReader();

--- a/Geo/IO/Wkt/WktTokenizer.cs
+++ b/Geo/IO/Wkt/WktTokenizer.cs
@@ -71,7 +71,7 @@ internal class WktTokenizer
             return WktTokenType.String;
         }
 
-        if (ch == '-' || ch == '.' || (ch >= '0' && ch <= '9'))
+        if (ch == '-' || ch == '+' || ch == '.' || (ch >= '0' && ch <= '9'))
             return WktTokenType.Number;
         if (ch == ',')
             return WktTokenType.Comma;


### PR DESCRIPTION
The WKT tokenizer classified '-', '.' and digits as Number characters but
not '+', so any WKT number carrying an explicit plus sign threw a
SerializationException("Invalid WKT string.") before parsing could begin.

This bites two real cases:
- A positive exponent (e.g. "1.5E+21"), which .NET's own double.ToString
  emits for large-magnitude ordinates such as elevations/measures, so
  values written by WktWriter could fail to read back.
- A leading '+' on an ordinate (e.g. "POINT (+1 +2)"), which is valid WKT.

Treat '+' as a Number character alongside '-'. Adds tests covering a
positive exponent (in-range ordinate and a large elevation) and a leading
positive sign.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0141z1vesfrwRkYvsvnXWSYT