### PR TITLE
Fix Circle.GetBounds longitude extent inverting latitude scaling

### DIFF
--- a/Geo.Tests/Geometries/CircleTests.cs
+++ b/Geo.Tests/Geometries/CircleTests.cs
@@ -46,15 +46,18 @@ public class CircleTests
     }
 
     [Fact]
-    public void An_60Degree_CircleWith_111000M_RadiusShouldBeAboutOneDegreeWide()
+    public void An_60Degree_CircleWith_111000M_RadiusShouldBeAboutFourDegreesWide()
     {
         var circle = new Circle(60, 20, 111000);
         var bounds = circle.GetBounds();
 
-        var minLonError = Distance(19.5, bounds.MinLon);
+        // At 60N a degree of longitude spans only cos(60) = half the metres of a degree
+        // of latitude, so a circle that is ~2 degrees tall is ~4 degrees wide (about two
+        // degrees either side of the centre).
+        var minLonError = Distance(18.002, bounds.MinLon);
         Assert.True(minLonError <= 0.002);
 
-        var maxLonError = Distance(20.5, bounds.MaxLon);
+        var maxLonError = Distance(21.998, bounds.MaxLon);
         Assert.True(maxLonError <= 0.002);
     }
 

--- a/Geo/Geometries/Circle.cs
+++ b/Geo/Geometries/Circle.cs
@@ -57,8 +57,13 @@ public class Circle : Geometry, ISurface
 
         var center = Center;
         var latitudinalRadiusDeg = Radius / (Constants.NauticalMile * 60);
+        // A degree of longitude spans metresPerDegree * cos(latitude) metres, so the
+        // parallels converge towards the poles. Converting a fixed metric radius into
+        // degrees of longitude therefore divides by cos(latitude): the east-west extent
+        // of the box grows with latitude (it equals the latitudinal extent at the
+        // equator and widens beyond it), rather than shrinking.
         var longditudinalRadiusDeg =
-            Radius / (Constants.NauticalMile * 60) * Math.Cos(center.Latitude.ToRadians());
+            Radius / (Constants.NauticalMile * 60) / Math.Cos(center.Latitude.ToRadians());
 
         return new Envelope(
             center.Latitude - latitudinalRadiusDeg,


### PR DESCRIPTION
Circle.GetBounds converted the radius into degrees of longitude by
multiplying by cos(latitude) instead of dividing by it. Because a degree
of longitude spans metresPerDegree * cos(latitude) metres, the parallels
converge towards the poles, so a fixed metric radius must map to *more*
degrees of longitude at higher latitudes, not fewer. The old formula made
the bounding box narrower away from the equator - backwards - and was only
correct at the equator where cos(latitude) == 1.

At 60N a 111 km circle is about 2 degrees tall but ~4 degrees wide; the
previous code (and the test asserting it) reported it as ~1 degree wide.
Divide by cos(latitude) and correct the test expectation.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XX7rsCZWLMWnFzhgW2ddni