### PR TITLE
Fix NullReferenceException comparing an empty polygon to a non-empty one

### DIFF
--- a/Geo.Tests/Geometries/PolygonTests.cs
+++ b/Geo.Tests/Geometries/PolygonTests.cs
@@ -101,6 +101,20 @@ public class PolygonTests
     }
 
     [Fact]
+    public void Empty_polygon_is_not_equal_to_a_non_empty_polygon()
+    {
+        var empty = new Polygon();
+        var nonEmpty = new Polygon(Square(10));
+
+        // The empty side has a null shell; comparing it must return false rather than
+        // throwing, and the result must be symmetric.
+        Assert.False(empty.Equals(nonEmpty));
+        Assert.False(nonEmpty.Equals(empty));
+        Assert.False(empty == nonEmpty);
+        Assert.False(nonEmpty == empty);
+    }
+
+    [Fact]
     public void Equality_compares_shell_and_holes()
     {
         var a = new Polygon(Square(10));

--- a/Geo/Geometries/Polygon.cs
+++ b/Geo/Geometries/Polygon.cs
@@ -72,8 +72,11 @@ public class Polygon : Geometry, ISurface
         if (ReferenceEquals(null, other))
             return false;
 
-        if (IsEmpty && other.IsEmpty)
-            return true;
+        // An empty polygon has a null shell, so guard before dereferencing it: two
+        // empties are equal, an empty and a non-empty never are (and comparing their
+        // shells would throw on the empty side).
+        if (IsEmpty || other.IsEmpty)
+            return IsEmpty && other.IsEmpty;
 
         return Shell!.Equals(other.Shell, options)
             && Holes.Count == other.Holes.Count


### PR DESCRIPTION
## Summary

`Polygon.Equals` throws a `NullReferenceException` when an empty polygon is compared to a non-empty one, and the comparison is asymmetric.

An empty polygon has a **null** `Shell`. The method only returned early when *both* operands were empty, then dereferenced `this.Shell` via the null-forgiving operator:

```csharp
if (IsEmpty && other.IsEmpty)
    return true;
return Shell!.Equals(other.Shell, options) && ...   // Shell is null when `this` is empty
```

So:

- `emptyPolygon.Equals(nonEmpty)` → **throws `NullReferenceException`**
- `nonEmpty.Equals(emptyPolygon)` → returns `false`

This both crashes and violates the symmetry contract of `Equals`. It also affects `Triangle` (a `Polygon` subclass) and the `==` / `!=` operators, so any code that puts polygons in a `HashSet`/`Dictionary` or calls `.Contains` / `.Distinct` where an empty polygon meets a non-empty one can hit it.

## Fix

Guard when *either* side is empty: two empties are equal, an empty and a non-empty never are, and only two non-empty polygons reach the shell comparison.

```csharp
if (IsEmpty || other.IsEmpty)
    return IsEmpty && other.IsEmpty;
```

## Testing

- Added `Empty_polygon_is_not_equal_to_a_non_empty_polygon`, covering both directions plus the `==` operator.
- Full suite: 693 passed / 0 failed.
- `dotnet csharpier check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XX7rsCZWLMWnFzhgW2ddni)_