### PR TITLE
Fix five bugs: empty polygon area, WKB stream reads, culture, GPX extension

### DIFF
--- a/Geo.Tests/CoordinateTests.cs
+++ b/Geo.Tests/CoordinateTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Xunit;
 
 namespace Geo.Tests;
@@ -370,5 +371,58 @@ public class CoordinateTests
     public void GetBounds_is_a_degenerate_envelope_at_the_coordinate()
     {
         Assert.Equal(new Envelope(12, 34, 12, 34), new Coordinate(12, 34).GetBounds());
+    }
+
+    [Theory]
+    [InlineData("de-DE")]
+    [InlineData("fr-FR")]
+    [InlineData("en-US")]
+    [InlineData("")]
+    public void Parse_is_independent_of_the_current_culture(string culture)
+    {
+        // Cultures that swap the roles of '.' and ',' must not change how the degrees,
+        // minutes and seconds of a coordinate are read.
+        using (new CultureScope(culture))
+        {
+            var result = Coordinate.Parse("12 34.56'N 123 45.55'E");
+
+            Assert.Equal(12.576, result.Latitude);
+            Assert.Equal(123.75916666666667, result.Longitude);
+        }
+    }
+
+    [Theory]
+    [InlineData("de-DE")]
+    [InlineData("fr-FR")]
+    [InlineData("en-US")]
+    [InlineData("")]
+    public void ToString_round_trips_through_Parse_in_any_culture(string culture)
+    {
+        // A culture that writes the decimal separator as a comma would otherwise collide
+        // with the comma separating the two ordinates.
+        using (new CultureScope(culture))
+        {
+            var coordinate = new Coordinate(51.5, -0.12);
+
+            var result = Coordinate.Parse(coordinate.ToString());
+
+            Assert.Equal(coordinate.Latitude, result.Latitude);
+            Assert.Equal(coordinate.Longitude, result.Longitude);
+        }
+    }
+
+    private sealed class CultureScope : IDisposable
+    {
+        private readonly CultureInfo _original = CultureInfo.CurrentCulture;
+
+        public CultureScope(string culture)
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+        }
+
+        public void Dispose()
+        {
+            CultureInfo.CurrentCulture = _original;
+        }
     }
 }

--- a/Geo.Tests/Geometries/PolygonTests.cs
+++ b/Geo.Tests/Geometries/PolygonTests.cs
@@ -145,4 +145,22 @@ public class PolygonTests
         Assert.True(new Triangle().IsEmpty);
         Assert.True(Triangle.Empty.IsEmpty);
     }
+
+    [Fact]
+    public void Empty_polygon_has_zero_area()
+    {
+        // An empty polygon has a null shell; asking for its area must report that it
+        // encloses nothing rather than dereferencing the missing shell.
+        Assert.Equal(0d, new Polygon().GetArea().SiValue);
+        Assert.Equal(0d, Polygon.Empty.GetArea().SiValue);
+        Assert.Equal(0d, new Triangle().GetArea().SiValue);
+    }
+
+    [Fact]
+    public void MultiPolygon_area_skips_empty_members()
+    {
+        var multiPolygon = new MultiPolygon(new Polygon(Square(10)), Polygon.Empty);
+
+        Assert.Equal(new Polygon(Square(10)).GetArea().SiValue, multiPolygon.GetArea().SiValue);
+    }
 }

--- a/Geo.Tests/Gps/Serialization/GpsDataTests.cs
+++ b/Geo.Tests/Gps/Serialization/GpsDataTests.cs
@@ -186,4 +186,17 @@ public class GpsDataTests : SerializerTestFixtureBase
         Assert.DoesNotContain("IGC", names); // Tracks only
         Assert.DoesNotContain("Garmin Flightplan", names); // Routes only
     }
+
+    [Fact]
+    public void SupportedGpsFileFormats_report_the_gpx_extension_for_gpx()
+    {
+        var extensions = GpsData
+            .SupportedGpsFileFormats()
+            .Where(x => x.Name.StartsWith("GPX"))
+            .Select(x => x.Extension)
+            .ToList();
+
+        Assert.NotEmpty(extensions);
+        Assert.All(extensions, x => Assert.Equal("gpx", x));
+    }
 }

--- a/Geo.Tests/IO/Wkb/WkbTests.cs
+++ b/Geo.Tests/IO/Wkb/WkbTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using Geo.Geometries;
@@ -198,5 +199,75 @@ public class WkbTests
             var geometry2 = wkbReader.Read(wkb);
             Assert.Equal(geometry, geometry2);
         }
+    }
+
+    [Fact]
+    public void Read_from_a_non_seekable_stream()
+    {
+        // A network, pipe or compression stream cannot seek. Reading WKB from one must
+        // return the geometry, not silently decide the stream holds no data.
+        var expected = new Point(23.9, 45.89);
+        var bytes = new WkbWriter().Write(expected);
+
+        var geometry = new WkbReader().Read(new NonSeekableStream(bytes));
+
+        Assert.Equal(expected, geometry);
+    }
+
+    [Fact]
+    public void Read_from_an_empty_non_seekable_stream_returns_null()
+    {
+        Assert.Null(new WkbReader().Read(new NonSeekableStream(new byte[0])));
+    }
+
+    [Fact]
+    public void Read_from_a_stream_that_returns_short_reads()
+    {
+        // A stream is free to satisfy a read with fewer bytes than were asked for
+        // without being at its end; the reader must keep reading rather than treat the
+        // short read as a truncated geometry.
+        var expected = new Point(23.9, 45.89);
+        var bytes = new WkbWriter().Write(expected);
+
+        var geometry = new WkbReader().Read(new NonSeekableStream(bytes, 3));
+
+        Assert.Equal(expected, geometry);
+    }
+
+    // A read-only stream that reports CanSeek == false, and optionally caps how many
+    // bytes a single read will return.
+    private sealed class NonSeekableStream : Stream
+    {
+        private readonly MemoryStream _inner;
+        private readonly int _maxRead;
+
+        public NonSeekableStream(byte[] data, int maxRead = int.MaxValue)
+        {
+            _inner = new MemoryStream(data);
+            _maxRead = maxRead;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            _inner.Read(buffer, offset, Math.Min(count, _maxRead));
+
+        public override void Flush() { }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
     }
 }

--- a/Geo/Coordinate.cs
+++ b/Geo/Coordinate.cs
@@ -54,7 +54,12 @@ public class Coordinate : SpatialObject, IPosition
 
     public override string ToString()
     {
-        return Latitude + ", " + Longitude;
+        // Invariant culture, so the output stays parseable by Parse/TryParse: a culture
+        // that writes the decimal separator as a comma would otherwise collide with the
+        // comma separating the two ordinates ("51,5, -0,12").
+        return Latitude.ToString(CultureInfo.InvariantCulture)
+            + ", "
+            + Longitude.ToString(CultureInfo.InvariantCulture);
     }
 
     public Envelope GetBounds()
@@ -99,10 +104,10 @@ public class Coordinate : SpatialObject, IPosition
             else
                 dir = 1.0;
 
-            if (double.TryParse(match.Groups["Min1"].Value, out temp))
+            if (TryParseOrdinatePart(match, "Min1", out temp))
                 deg1 += dir * temp / 60;
 
-            if (double.TryParse(match.Groups["Sec1"].Value, out temp))
+            if (TryParseOrdinatePart(match, "Sec1", out temp))
                 deg1 += dir * temp / 3600;
 
             if (deg2 < 0.0)
@@ -110,10 +115,10 @@ public class Coordinate : SpatialObject, IPosition
             else
                 dir = 1.0;
 
-            if (double.TryParse(match.Groups["Min2"].Value, out temp))
+            if (TryParseOrdinatePart(match, "Min2", out temp))
                 deg2 += dir * temp / 60;
 
-            if (double.TryParse(match.Groups["Sec2"].Value, out temp))
+            if (TryParseOrdinatePart(match, "Sec2", out temp))
                 deg2 += dir * temp / 3600;
 
             var dir1 = Regex.IsMatch(match.Groups["Dir1"].Value, "[Ss]") ? -1d : 1d;
@@ -128,6 +133,20 @@ public class Coordinate : SpatialObject, IPosition
 
         result = default;
         return false;
+    }
+
+    // The minutes and seconds groups must be read with the same invariant culture as the
+    // degrees group above. Left to the current culture they would parse a decimal point
+    // as a thousands separator wherever the comma and point are swapped, turning
+    // "51 30.5' N" into 51 degrees 305 minutes — five degrees, or ~550 km, adrift.
+    private static bool TryParseOrdinatePart(Match match, string group, out double value)
+    {
+        return double.TryParse(
+            match.Groups[group].Value,
+            NumberStyles.Float | NumberStyles.AllowThousands,
+            CultureInfo.InvariantCulture,
+            out value
+        );
     }
 
     #region Equality methods

--- a/Geo/Geometries/Polygon.cs
+++ b/Geo/Geometries/Polygon.cs
@@ -45,6 +45,11 @@ public class Polygon : Geometry, ISurface
 
     public Area GetArea()
     {
+        // An empty polygon has a null shell, so guard before dereferencing it: it
+        // encloses nothing, and dereferencing the shell would throw instead.
+        if (IsEmpty)
+            return new Area(0d);
+
         var calculator = GeoContext.Current.GeodeticCalculator;
         var area = calculator.CalculateArea(Shell!.Coordinates);
         return Holes.Aggregate(

--- a/Geo/Gps/Serialization/Gpx10Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx10Serializer.cs
@@ -17,7 +17,7 @@ public class Gpx10Serializer : GpsXmlSerializer<GpxFile>
         {
             return new[]
             {
-                new GpsFileFormat("gps", "GPX 1.0", "http://www.topografix.com/GPX/1/0/gpx.xsd"),
+                new GpsFileFormat("gpx", "GPX 1.0", "http://www.topografix.com/GPX/1/0/gpx.xsd"),
             };
         }
     }

--- a/Geo/Gps/Serialization/Gpx11Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx11Serializer.cs
@@ -17,7 +17,7 @@ public class Gpx11Serializer : GpsXmlSerializer<GpxFile>
         {
             return new[]
             {
-                new GpsFileFormat("gps", "GPX 1.1", "http://www.topografix.com/GPX/1/1/gpx.xsd"),
+                new GpsFileFormat("gpx", "GPX 1.1", "http://www.topografix.com/GPX/1/1/gpx.xsd"),
             };
         }
     }

--- a/Geo/IO/Wkb/WkbBinaryReader.cs
+++ b/Geo/IO/Wkb/WkbBinaryReader.cs
@@ -7,12 +7,19 @@ namespace Geo.IO.Wkb;
 internal class WkbBinaryReader : IDisposable
 {
     private readonly BinaryReader _reader;
+    private int _pushback;
     private bool _disposed;
 
     public WkbBinaryReader(Stream stream)
     {
         _reader = new BinaryReader(stream);
-        HasData = _reader.PeekChar() != -1;
+        // BinaryReader.PeekChar cannot be used to test for data here: it returns -1 for
+        // any stream that cannot seek (a network, pipe or compression stream), which
+        // would silently turn a perfectly good geometry into "no data". It also decodes
+        // bytes as text, which WKB is not. Read the first byte instead and hold it back
+        // for the first subsequent read.
+        _pushback = stream.ReadByte();
+        HasData = _pushback != -1;
     }
 
     public bool HasData { get; }
@@ -29,21 +36,48 @@ internal class WkbBinaryReader : IDisposable
 
     public WkbEncoding ReadAndSetEncoding()
     {
-        Encoding = (WkbEncoding)_reader.ReadByte();
+        Encoding = (WkbEncoding)ReadByte();
         return Encoding;
     }
 
     public byte[] ReadBytes(int count)
     {
-        var bytes = _reader.ReadBytes(count);
-        // BinaryReader.ReadBytes returns a short array at end of stream rather than
-        // throwing; surface that as EndOfStreamException so WkbReader can translate a
+        var bytes = new byte[count];
+        var offset = 0;
+
+        if (_pushback >= 0 && count > 0)
+        {
+            bytes[0] = (byte)_pushback;
+            _pushback = -1;
+            offset = 1;
+        }
+
+        // A single read can return fewer bytes than asked for without being at the end
+        // of the stream (network and compression streams routinely do), so keep reading
+        // until the request is satisfied. A read of zero bytes means the stream really
+        // has ended: surface that as EndOfStreamException so WkbReader can translate a
         // truncated geometry into a SerializationException.
-        if (bytes.Length < count)
-            throw new EndOfStreamException();
+        while (offset < count)
+        {
+            var read = _reader.Read(bytes, offset, count - offset);
+            if (read <= 0)
+                throw new EndOfStreamException();
+            offset += read;
+        }
+
         if (Encoding == WkbEncoding.BigEndian)
             Array.Reverse(bytes);
         return bytes;
+    }
+
+    private byte ReadByte()
+    {
+        if (_pushback < 0)
+            return _reader.ReadByte();
+
+        var value = (byte)_pushback;
+        _pushback = -1;
+        return value;
     }
 
     public double ReadDouble()


### PR DESCRIPTION
Polygon.GetArea dereferenced a null Shell, so Polygon.Empty.GetArea() and
Triangle.Empty.GetArea() threw a NullReferenceException, as did
MultiPolygon.GetArea() over any collection containing an empty member. An
empty polygon encloses nothing, so return zero area, matching GetBounds and
Equals which already guard the null shell.

WkbBinaryReader used BinaryReader.PeekChar to test whether the stream held
any data. PeekChar returns -1 for any stream that cannot seek, so
WkbReader.Read(Stream) silently returned null for a valid geometry arriving
over a network, pipe or compression stream. Read the first byte instead and
push it back for the first subsequent read. ReadBytes now also loops until
the requested count is satisfied, since a single read may legitimately
return fewer bytes than asked for without being at the end of the stream.

Coordinate.TryParse read the degrees group with the invariant culture but
the minutes and seconds groups with the current culture. Under a culture
that swaps '.' and ',', "12 34.56'N" parsed as 12 degrees 3456 minutes,
placing the result tens of degrees away without any error. Coordinate
.ToString had the mirror problem: it formatted the ordinates with the
current culture, so a comma-decimal culture emitted "51,5, -0,12", which
Parse can no longer read back.

Both GPX serializers reported "gps" as their file extension; GPX files use
".gpx", and SupportedGpsFileFormats is public API used to build file
filters.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DZxfL1ENX1Eaw8cxrwtu5a