### PR TITLE
Fix five bugs: GeoJSON empty geometries, GPX routes, TryParse contracts

### DIFF
--- a/Geo.Tests/CoordinateTests.cs
+++ b/Geo.Tests/CoordinateTests.cs
@@ -271,6 +271,17 @@ public class CoordinateTests
         Assert.NotNull(Coordinate.TryParse("1, 2"));
     }
 
+    [Fact]
+    public void TryParse_returns_false_for_null_input()
+    {
+        // TryParse reports failure rather than throwing, unlike Parse.
+        var success = Coordinate.TryParse(null, out var result);
+
+        Assert.False(success);
+        Assert.Null(result);
+        Assert.Null(Coordinate.TryParse(null));
+    }
+
     [Theory]
     [InlineData("91, 0")]
     [InlineData("-91, 0")]

--- a/Geo.Tests/Geometries/CircleTests.cs
+++ b/Geo.Tests/Geometries/CircleTests.cs
@@ -186,6 +186,14 @@ public class CircleTests
         Assert.False(new Circle().IsMeasured);
     }
 
+    [Fact]
+    public void Empty_circle_converts_to_the_empty_polygon()
+    {
+        // An empty circle has no centre to project vertices from; the writers that
+        // convert circles to polygons rely on this rather than faulting.
+        Assert.True(Circle.Empty.ToPolygon().IsEmpty);
+    }
+
     public double Distance(double nr1, double nr2)
     {
         return Math.Abs(nr1 - nr2);

--- a/Geo.Tests/Gps/Serialization/GpxSerializerTests.cs
+++ b/Geo.Tests/Gps/Serialization/GpxSerializerTests.cs
@@ -113,6 +113,42 @@ public class GpxSerializerTests : SerializerTestFixtureBase
         Compare(gpx11, data, gpxData);
     }
 
+    [Fact]
+    public void Gpx11_route_without_route_points_is_parsed()
+    {
+        // <rtept> is optional in the GPX schema, so a route carrying only metadata
+        // is valid and must not fault the parser.
+        var gpx =
+            "<?xml version=\"1.0\"?>"
+            + "<gpx version=\"1.1\" creator=\"Geo.Tests\" xmlns=\"http://www.topografix.com/GPX/1/1\">"
+            + "<rte><name>empty route</name></rte>"
+            + "</gpx>";
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(gpx));
+        var data = new Gpx11Serializer().DeSerialize(new StreamWrapper(stream));
+
+        Assert.NotNull(data);
+        Assert.Equal("empty route", data.Routes.Single().Metadata.Attribute(x => x.Name));
+        Assert.Empty(data.Routes.Single().Waypoints);
+    }
+
+    [Fact]
+    public void Gpx10_route_without_route_points_is_parsed()
+    {
+        var gpx =
+            "<?xml version=\"1.0\"?>"
+            + "<gpx version=\"1.0\" creator=\"Geo.Tests\" xmlns=\"http://www.topografix.com/GPX/1/0\">"
+            + "<rte><name>empty route</name></rte>"
+            + "</gpx>";
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(gpx));
+        var data = new Gpx10Serializer().DeSerialize(new StreamWrapper(stream));
+
+        Assert.NotNull(data);
+        Assert.Equal("empty route", data.Routes.Single().Metadata.Attribute(x => x.Name));
+        Assert.Empty(data.Routes.Single().Waypoints);
+    }
+
     private void Compare(Gpx10Serializer serializer, GpsData data, string gpxData)
     {
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(gpxData));

--- a/Geo.Tests/IO/GeoJson/GeoJsonReaderWriterTests.cs
+++ b/Geo.Tests/IO/GeoJson/GeoJsonReaderWriterTests.cs
@@ -113,6 +113,16 @@ public class GeoJsonReaderWriterTests
     }
 
     [Fact]
+    public void Converts_empty_circle_to_the_empty_polygon()
+    {
+        var writer = new GeoJsonWriter(
+            new GeoJsonWriterSettings { ConvertCirclesToRegularPolygons = true, CircleSides = 4 }
+        );
+
+        Assert.Equal("{\"type\":\"Polygon\",\"coordinates\":[]}", writer.Write(Circle.Empty));
+    }
+
+    [Fact]
     public void Writing_circle_without_conversion_throws_serialization()
     {
         Assert.Throws<SerializationException>(() =>
@@ -199,5 +209,98 @@ public class GeoJsonReaderWriterTests
     public void Nts_compatible_settings_are_available()
     {
         Assert.NotNull(GeoJsonWriterSettings.NtsCompatible);
+    }
+
+    // ---- 8. Empty geometries -----------------------------------------------
+
+    [Fact]
+    public void Writes_and_reads_empty_point()
+    {
+        var writer = new GeoJsonWriter();
+
+        Assert.Equal("{\"type\":\"Point\",\"coordinates\":[]}", writer.Write(Point.Empty));
+        Assert.Equal(Point.Empty, new GeoJsonReader().Read(writer.Write(Point.Empty)));
+    }
+
+    [Fact]
+    public void Writes_and_reads_empty_polygon()
+    {
+        var writer = new GeoJsonWriter();
+
+        Assert.Equal("{\"type\":\"Polygon\",\"coordinates\":[]}", writer.Write(Polygon.Empty));
+        Assert.Equal(Polygon.Empty, new GeoJsonReader().Read(writer.Write(Polygon.Empty)));
+    }
+
+    [Fact]
+    public void Writes_and_reads_multi_point_containing_an_empty_point()
+    {
+        var writer = new GeoJsonWriter();
+        var multiPoint = new MultiPoint(new Point(1, 2), Point.Empty);
+
+        Assert.Equal(
+            "{\"type\":\"MultiPoint\",\"coordinates\":[[2,1],[]]}",
+            writer.Write(multiPoint)
+        );
+        Assert.Equal(multiPoint, new GeoJsonReader().Read(writer.Write(multiPoint)));
+    }
+
+    [Fact]
+    public void Writes_and_reads_multi_polygon_containing_an_empty_polygon()
+    {
+        var writer = new GeoJsonWriter();
+        var multiPolygon = new MultiPolygon(Polygon.Empty);
+
+        Assert.Equal(
+            "{\"type\":\"MultiPolygon\",\"coordinates\":[[]]}",
+            writer.Write(multiPolygon)
+        );
+        Assert.Equal(multiPolygon, new GeoJsonReader().Read(writer.Write(multiPolygon)));
+    }
+
+    [Fact]
+    public void Writes_feature_with_an_empty_geometry()
+    {
+        Assert.Equal(
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[]},\"properties\":null}",
+            new Feature(Polygon.Empty).ToGeoJson()
+        );
+    }
+
+    // ---- 9. Malformed input is reported, not thrown from ---------------------
+
+    [Fact]
+    public void Feature_collection_with_a_non_object_feature_does_not_parse()
+    {
+        Assert.False(
+            new GeoJsonReader().TryRead("{\"type\":\"FeatureCollection\",\"features\":[1]}", out _)
+        );
+    }
+
+    [Fact]
+    public void Geometry_collection_with_a_non_object_geometry_does_not_parse()
+    {
+        Assert.False(
+            new GeoJsonReader().TryRead(
+                "{\"type\":\"GeometryCollection\",\"geometries\":[1]}",
+                out _
+            )
+        );
+    }
+
+    [Fact]
+    public void Feature_with_a_non_object_geometry_does_not_parse()
+    {
+        Assert.False(new GeoJsonReader().TryRead("{\"type\":\"Feature\",\"geometry\":1}", out _));
+    }
+
+    [Fact]
+    public void Feature_with_a_null_geometry_is_unlocated()
+    {
+        var feature = (Feature)
+            new GeoJsonReader().Read(
+                "{\"type\":\"Feature\",\"geometry\":null,\"properties\":null}"
+            );
+
+        Assert.Null(feature.Geometry);
     }
 }

--- a/Geo/Coordinate.cs
+++ b/Geo/Coordinate.cs
@@ -89,6 +89,15 @@ public class Coordinate : SpatialObject, IPosition
 
     public static bool TryParse(string coordinate, [NotNullWhen(true)] out Coordinate? result)
     {
+        // TryParse reports failure rather than throwing, so a null input is just
+        // another value that does not parse. Parse still rejects it up front with
+        // an ArgumentNullException.
+        if (coordinate == null)
+        {
+            result = default;
+            return false;
+        }
+
         var match = Regex.Match(coordinate, CoordinateRegex);
 
         if (match.Success)

--- a/Geo/Geometries/Circle.cs
+++ b/Geo/Geometries/Circle.cs
@@ -94,6 +94,12 @@ public class Circle : Geometry, ISurface
         if (sides < 3)
             throw new ArgumentOutOfRangeException("sides", "Must be greater than 2.");
 
+        // An empty circle has no centre to project the vertices from, so it becomes
+        // the empty polygon rather than dereferencing the centre. This keeps the
+        // WKT/WKB/GeoJSON writers, which convert circles to polygons, from throwing.
+        if (IsEmpty)
+            return Polygon.Empty;
+
         var angle = -360d / sides;
         var coordinates = new List<Coordinate>();
         Coordinate? first = null;

--- a/Geo/Gps/Serialization/Gpx10Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx10Serializer.cs
@@ -156,8 +156,11 @@ public class Gpx10Serializer : GpsXmlSerializer<GpxFile>
                 route.Metadata.Attribute(x => x.Description, rteType.desc);
                 route.Metadata.Attribute(x => x.Comment, rteType.cmt);
 
-                foreach (var wptType in rteType.rtept!)
-                    route.Waypoints.Add(ConvertWaypoint(wptType));
+                // <rtept> is optional in the GPX schema, so a route may carry only
+                // metadata; the element is absent (null) rather than an empty array.
+                if (rteType.rtept != null)
+                    foreach (var wptType in rteType.rtept)
+                        route.Waypoints.Add(ConvertWaypoint(wptType));
                 data.Routes.Add(route);
             }
     }

--- a/Geo/Gps/Serialization/Gpx11Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx11Serializer.cs
@@ -303,8 +303,11 @@ public class Gpx11Serializer : GpsXmlSerializer<GpxFile>
                 route.Metadata.Attribute(x => x.Description, rteType.desc);
                 route.Metadata.Attribute(x => x.Comment, rteType.cmt);
 
-                foreach (var wptType in rteType.rtept!)
-                    route.Waypoints.Add(ConvertWaypoint(wptType));
+                // <rtept> is optional in the GPX schema, so a route may carry only
+                // metadata; the element is absent (null) rather than an empty array.
+                if (rteType.rtept != null)
+                    foreach (var wptType in rteType.rtept)
+                        route.Waypoints.Add(ConvertWaypoint(wptType));
                 data.Routes.Add(route);
             }
     }

--- a/Geo/IO/GeoJson/GeoJsonReader.cs
+++ b/Geo/IO/GeoJson/GeoJsonReader.cs
@@ -92,8 +92,12 @@ public class GeoJsonReader
                 var temp = new object?[features.Count];
                 for (var index = 0; index < features.Count; index++)
                 {
-                    var geometry = features[index];
-                    if (!TryParseFeature((JsonObject)geometry, out temp[index]))
+                    // An element that is not a JSON object is not a feature; fail the
+                    // parse rather than letting the cast throw out of a TryParse.
+                    if (
+                        !(features[index] is JsonObject feature)
+                        || !TryParseFeature(feature, out temp[index])
+                    )
                         return false;
                 }
 
@@ -115,8 +119,20 @@ public class GeoJsonReader
             object? geo = null;
             Dictionary<string, object?>? pr = null;
 
-            if (obj.TryGetValue("geometry", out var geometry))
-                TryParseGeometry((JsonObject)geometry, out geo);
+            // "geometry" may legitimately be null (an unlocated feature). Anything
+            // else that is not a JSON object is malformed: fail the parse rather
+            // than letting the cast throw out of a TryParse, or silently discarding
+            // the value.
+            if (obj.TryGetValue("geometry", out var geometry) && geometry != null)
+            {
+                if (!(geometry is JsonObject geometryObject))
+                {
+                    result = null;
+                    return false;
+                }
+
+                TryParseGeometry(geometryObject, out geo);
+            }
 
             if (obj.TryGetValue("properties", out var prop) && prop is JsonObject)
             {
@@ -178,8 +194,16 @@ public class GeoJsonReader
     {
         result = null;
         var coordinates = GetArray(obj, "coordinates");
-        if (coordinates == null || coordinates.Count < 2)
+        if (coordinates == null)
             return false;
+
+        // An empty coordinates array is the empty point, as written by GeoJsonWriter
+        // (and by NTS/GEOS/PostGIS).
+        if (coordinates.Count == 0)
+        {
+            result = Point.Empty;
+            return true;
+        }
 
         if (TryParseCoordinate(coordinates, out var coordinate))
         {
@@ -207,16 +231,9 @@ public class GeoJsonReader
     {
         var coordinates = GetArray(obj, "coordinates");
 
-        if (
-            coordinates != null
-            && coordinates.Count > 0
-            && TryParseCoordinateArrayArray(coordinates, out var temp)
-        )
+        if (coordinates != null && TryParseCoordinateArrayArray(coordinates, out var temp))
         {
-            result = new Polygon(
-                new LinearRing(temp[0]),
-                temp.Skip(1).Select(x => new LinearRing(x))
-            );
+            result = BuildPolygon(temp);
             return true;
         }
 
@@ -224,17 +241,43 @@ public class GeoJsonReader
         return false;
     }
 
+    // An empty ring array is the empty polygon, as written by GeoJsonWriter (and by
+    // NTS/GEOS/PostGIS); building one would otherwise index past the end of the array.
+    private static Polygon BuildPolygon(Coordinate[][] rings)
+    {
+        if (rings.Length == 0)
+            return Polygon.Empty;
+
+        return new Polygon(new LinearRing(rings[0]), rings.Skip(1).Select(x => new LinearRing(x)));
+    }
+
     private bool TryParseMultiPoint(JsonObject obj, [NotNullWhen(true)] out object? result)
     {
+        result = null;
         var coordinates = GetArray(obj, "coordinates");
-        if (coordinates != null && TryParseCoordinateArray(coordinates, out var co))
+        if (coordinates == null || !coordinates.All(x => x is JsonArray))
+            return false;
+
+        var points = new Point[coordinates.Count];
+        for (var index = 0; index < coordinates.Count; index++)
         {
-            result = new MultiPoint(co.Select(x => new Point(x)));
-            return true;
+            var element = (JsonArray)coordinates[index];
+
+            // An empty coordinates array is the empty point, as written by
+            // GeoJsonWriter for a multi-point containing one.
+            if (element.Count == 0)
+            {
+                points[index] = Point.Empty;
+                continue;
+            }
+
+            if (!TryParseCoordinate(element, out var coordinate))
+                return false;
+            points[index] = new Point(coordinate);
         }
 
-        result = null;
-        return false;
+        result = new MultiPoint(points);
+        return true;
     }
 
     private bool TryParseMultiLineString(JsonObject obj, [NotNullWhen(true)] out object? result)
@@ -255,12 +298,7 @@ public class GeoJsonReader
         var coordinates = GetArray(obj, "coordinates");
         if (coordinates != null && TryParseCoordinateArrayArrayArray(coordinates, out var co))
         {
-            result = new MultiPolygon(
-                co.Select(x => new Polygon(
-                    new LinearRing(x.First()),
-                    x.Skip(1).Select(c => new LinearRing(c))
-                ))
-            );
+            result = new MultiPolygon(co.Select(BuildPolygon));
             return true;
         }
 
@@ -278,8 +316,12 @@ public class GeoJsonReader
             var temp = new object?[geometries.Count];
             for (var index = 0; index < geometries.Count; index++)
             {
-                var geometry = geometries[index];
-                if (!TryParseGeometry((JsonObject)geometry, out temp[index]))
+                // An element that is not a JSON object is not a geometry; fail the
+                // parse rather than letting the cast throw out of a TryParse.
+                if (
+                    !(geometries[index] is JsonObject geometry)
+                    || !TryParseGeometry(geometry, out temp[index])
+                )
                     return false;
             }
 

--- a/Geo/IO/GeoJson/GeoJsonWriter.cs
+++ b/Geo/IO/GeoJson/GeoJsonWriter.cs
@@ -203,6 +203,13 @@ public class GeoJsonWriter
     private double[] WriteCoordinate(IPosition position)
     {
         var coordinate = position.GetCoordinate();
+
+        // An empty point has no coordinate at all. GeoJSON has no explicit empty
+        // marker, so it is written as an empty coordinates array (the convention
+        // used by NTS/GEOS/PostGIS); dereferencing the coordinate would throw.
+        if (coordinate == null)
+            return new double[0];
+
         var pointZM = coordinate as CoordinateZM;
         if (pointZM != null)
             return new[]
@@ -226,6 +233,11 @@ public class GeoJsonWriter
 
     private IEnumerable<IEnumerable<double[]>> WriteCoordinates(Polygon polygon)
     {
+        // An empty polygon has a null shell, so it is written as an empty ring
+        // array rather than dereferencing the shell.
+        if (polygon.IsEmpty)
+            yield break;
+
         yield return WriteCoordinates(polygon.Shell!.Coordinates);
         foreach (var hole in polygon.Holes)
             yield return WriteCoordinates(hole.Coordinates);


### PR DESCRIPTION
GeoJsonWriter threw a NullReferenceException when writing any empty
Point or Polygon, and so for any MultiPoint, MultiPolygon, Feature or
FeatureCollection containing one. An empty geometry is now written as an
empty coordinates array, the convention used by NTS/GEOS/PostGIS, and
GeoJsonReader parses that form back so empties round-trip.

GeoJsonReader threw out of its TryRead/TryParse* methods on malformed
input instead of reporting failure: an InvalidCastException for a
feature, geometry or feature-geometry that is not a JSON object, and an
InvalidOperationException for a MultiPolygon containing an empty ring
array. These now fail the parse (surfacing as a SerializationException
from Read), and an empty ring array is read as the empty polygon.

Both GPX serializers dereferenced rteType.rtept without a null check.
<rtept> is optional in the GPX schema, so a <rte> carrying only metadata
is valid and faulted the parser with a NullReferenceException.

Circle.ToPolygon dereferenced a null centre for an empty circle, which
made the WKT, WKB and GeoJSON writers throw when configured to convert
circles to regular polygons. It now returns the empty polygon.

Coordinate.TryParse threw an ArgumentNullException for a null input
rather than returning false. Parse still rejects null up front.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TG5pKCAek3sVMA4VCrXm4L