### PR TITLE
Fix GooglePolylineEncoder.Decode silently accepting malformed polylines

### DIFF
--- a/Geo.Tests/IO/Google/GooglePolylineEncoderTests.cs
+++ b/Geo.Tests/IO/Google/GooglePolylineEncoderTests.cs
@@ -1,4 +1,6 @@
-﻿using Geo.Geometries;
+﻿using System;
+using System.Runtime.Serialization;
+using Geo.Geometries;
 using Geo.IO.Google;
 using Xunit;
 
@@ -45,5 +47,80 @@ public class GooglePolylineEncoderTests
         var result = new GooglePolylineEncoder().Decode("_p~iF~ps|U_ulLnnqC_mqNvxq`@");
 
         Assert.Equal(lineString, result);
+    }
+
+    [Fact]
+    public void Decode_empty_string_gives_an_empty_linestring()
+    {
+        Assert.True(new GooglePolylineEncoder().Decode("").IsEmpty);
+    }
+
+    [Fact]
+    public void Decode_round_trips_the_largest_possible_deltas()
+    {
+        // Pole to pole and antimeridian to antimeridian is the longest number the
+        // encoder can emit; decoding must not reject it as an overflow.
+        var encoder = new GooglePolylineEncoder();
+        var lineString = new LineString(
+            new Coordinate(-90, -180),
+            new Coordinate(90, 180),
+            new Coordinate(-90, -180)
+        );
+
+        Assert.Equal(lineString, encoder.Decode(encoder.Encode(lineString)));
+    }
+
+    [Theory]
+    // Truncated: the string ends part-way through a number. Decoding used to treat
+    // the end of the string as a final chunk of zero, fabricating a coordinate on
+    // the null meridian instead of reporting the truncation.
+    [InlineData("_p~iF")] // latitude only, longitude missing entirely
+    [InlineData("_p~iF~ps")] // longitude cut mid-number
+    [InlineData("a")] // a lone continuation chunk
+    [InlineData("?")] // a lone terminating chunk
+    public void Decode_truncated_polyline_throws_serialization(string polyline)
+    {
+        Assert.Throws<SerializationException>(() => new GooglePolylineEncoder().Decode(polyline));
+    }
+
+    [Theory]
+    // Characters below the 63 offset are not polyline data. Their low bits used to be
+    // masked into the result, so a stray newline or space silently produced extra,
+    // wrong coordinates rather than an error.
+    [InlineData("_p~iF~ps|U\n")] // trailing newline, as read from a file
+    [InlineData(" _p~iF~ps|U")] // leading space
+    [InlineData("_p~iF~ps|U _p~iF~ps|U")] // two polylines separated by a space
+    [InlineData("_p~iF\u007f~ps|U")] // DEL, above the encodable range
+    public void Decode_invalid_character_throws_serialization(string polyline)
+    {
+        Assert.Throws<SerializationException>(() => new GooglePolylineEncoder().Decode(polyline));
+    }
+
+    [Fact]
+    public void Decode_number_too_large_throws_serialization()
+    {
+        // A runaway run of continuation chunks used to wrap the shift (C# masks it to
+        // 0-31) and fold back over the low bits, decoding to (0, 0) with no error.
+        Assert.Throws<SerializationException>(() =>
+            new GooglePolylineEncoder().Decode("~~~~~~~~~~~~?~~~~~~~~~~~~?")
+        );
+    }
+
+    [Fact]
+    public void Decode_out_of_range_coordinate_throws_serialization()
+    {
+        // A well-formed polyline can still decode to an impossible position; that is a
+        // malformed document, reported like every other decoding failure.
+        var encoder = new GooglePolylineEncoder();
+        var step = encoder.Encode(new LineString(new Coordinate(50, 0)));
+
+        // Two 50-degree steps north run past the pole.
+        Assert.Throws<SerializationException>(() => encoder.Decode(step + step));
+    }
+
+    [Fact]
+    public void Decode_null_throws_argument_null()
+    {
+        Assert.Throws<ArgumentNullException>(() => new GooglePolylineEncoder().Decode(null));
     }
 }

--- a/Geo/IO/Google/GooglePolylineEncoder.cs
+++ b/Geo/IO/Google/GooglePolylineEncoder.cs
@@ -1,7 +1,8 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Globalization;
+using System.Runtime.Serialization;
 using System.Text;
 using Geo.Geometries;
 
@@ -48,19 +49,20 @@ public class GooglePolylineEncoder
 
     public LineString Decode(string polyline)
     {
-        var coordinates = new List<Coordinate>();
-        using (var reader = new StringReader(polyline))
-        {
-            int lat = 0,
-                lng = 0;
-            while (reader.Peek() != -1)
-            {
-                lat += DecodeNumber(reader);
-                lng += DecodeNumber(reader);
+        if (polyline == null)
+            throw new ArgumentNullException("polyline");
 
-                var p = new Coordinate(lat / CoordinateFactor, lng / CoordinateFactor);
-                coordinates.Add(p);
-            }
+        var coordinates = new List<Coordinate>();
+        var index = 0;
+        int lat = 0,
+            lng = 0;
+
+        while (index < polyline.Length)
+        {
+            lat += DecodeNumber(polyline, ref index);
+            lng += DecodeNumber(polyline, ref index);
+
+            coordinates.Add(CreateCoordinate(lat, lng));
         }
 
         return new LineString(coordinates);
@@ -82,18 +84,72 @@ public class GooglePolylineEncoder
         builder.Append((char)(num + MinAscii));
     }
 
-    private static int DecodeNumber(StringReader reader)
+    // Each number is a run of 5-bit chunks, low chunk first, carried in the low six
+    // bits of a printable ASCII character offset by 63; the sixth bit is set on every
+    // chunk but the last. The end of the string, a character outside that range, and a
+    // legitimate final chunk must be told apart: masking the chunk before checking
+    // would turn both malformed cases into data bits and decode them silently.
+    private static int DecodeNumber(string polyline, ref int index)
     {
+        var start = index;
         int b,
             shift = 0,
             result = 0;
+
         do
         {
-            b = reader.Read() - MinAscii;
+            if (index >= polyline.Length)
+                throw new SerializationException(
+                    "Polyline ended part-way through the number starting at offset "
+                        + start.ToString(CultureInfo.InvariantCulture)
+                        + "."
+                );
+
+            var ch = polyline[index++];
+            b = ch - MinAscii;
+
+            if (b < 0 || b > 0x3f)
+                throw new SerializationException(
+                    "Invalid polyline character '"
+                        + ch
+                        + "' at offset "
+                        + (index - 1).ToString(CultureInfo.InvariantCulture)
+                        + "."
+                );
+
+            // The chunks of a single number cannot carry more bits than the int they
+            // accumulate into; without this the shift wraps (C# masks it to 0-31) and
+            // a runaway sequence of chunks silently folds back over the low bits.
+            if (shift >= 32)
+                throw new SerializationException(
+                    "The number starting at offset "
+                        + start.ToString(CultureInfo.InvariantCulture)
+                        + " is too large for a polyline ordinate."
+                );
+
             result |= (b & 0x1f) << shift;
             shift += BinaryChunkSize;
         } while (b >= 0x20);
 
         return (result & 1) != 0 ? ~(result >> 1) : result >> 1;
+    }
+
+    // A polyline that decodes to an impossible position is a malformed document, not a
+    // bad argument from the caller, so it is reported the same way as every other
+    // decoding failure instead of as the ArgumentOutOfRangeException the constructor
+    // would raise (which names 'latitude', a parameter the caller never supplied).
+    private static Coordinate CreateCoordinate(int lat, int lng)
+    {
+        try
+        {
+            return new Coordinate(lat / CoordinateFactor, lng / CoordinateFactor);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            throw new SerializationException(
+                "Polyline decoded to a coordinate outside the valid range.",
+                ex
+            );
+        }
     }
 }


### PR DESCRIPTION
`GooglePolylineEncoder.Decode` accepted malformed input and returned plausible-looking but wrong coordinates instead of reporting a problem.

## Root cause

A number is a run of 5-bit chunks carried in the low six bits of a printable ASCII character offset by 63, with the sixth bit set on every chunk but the last. `DecodeNumber` collapsed three distinct conditions into a single test:

```csharp
b = reader.Read() - MinAscii;      // EOF gives -1 - 63 = -64
result |= (b & 0x1f) << shift;     // masked before it is ever validated
shift += BinaryChunkSize;
} while (b >= 0x20);
```

`StringReader.Read`'s `-1` end-of-string sentinel and any character below `'?'` both become negative and fail the `b >= 0x20` continuation test, so **the end of the string is indistinguishable from a legitimate final chunk** — and the `& 0x1f` mask has already folded the junk into `result` as data bits. Nothing was ever rejected.

## Observed behaviour

| Input | Before |
|---|---|
| `"_p~iF"` (latitude only) | point at **longitude 0**, no error |
| `"_p~iF~ps"` (cut mid-number) | `-0.10528` instead of `-120.2` |
| `"_p~iF~ps\|U\n"` (trailing newline) | **extra fabricated coordinate** (38.49994, -120.2) |
| `" _p~iF~ps\|U"` (leading space) | `ArgumentOutOfRangeException` naming `latitude` |
| long run of continuation chunks | decodes to (0, 0) — `shift` passes 32, C# masks it to 0-31 and the number folds back over its own low bits |

The trailing-newline case is the one that bites in practice, since polylines routinely arrive from a file or a multi-line API response.

## Changes

Each chunk is now validated *before* it is masked, which needs the read position rather than a `StringReader` (whose `-1` is the whole problem), so `DecodeNumber` takes `(string, ref int index)`. Three conditions are now reported as a `SerializationException` naming the offset:

- the string running out part-way through a number;
- a character outside the encodable range;
- a number too large for the `int` it accumulates into.

This matches how `WktReader`, `WkbReader` and `GeoJsonReader` already report a malformed document.

Two related contract fixes:

- a polyline decoding to a position off the globe is likewise a malformed document, so it raises `SerializationException` rather than the `ArgumentOutOfRangeException` the `Coordinate` constructor throws, which names a `latitude` parameter the caller never supplied;
- `Decode(null)` throws `ArgumentNullException` naming `polyline` instead of leaking `StringReader`'s own `s`.

## Compatibility

Valid polylines decode exactly as before. The overflow guard allows seven chunks per number, while the largest delta the encoder can emit — pole to pole, antimeridian to antimeridian — spans six, so it rejects nothing a valid polyline can contain; there is a round-trip test pinning this.

The one behavioural change beyond "was silent, now throws" is the out-of-range exception type, which would affect a caller catching `ArgumentOutOfRangeException` around `Decode`. Happy to drop that part if you would rather keep the change strictly additive.

## Testing

734 tests pass (721 before, 13 added covering truncation, invalid characters, overflow, out-of-range positions, null, the empty string, and the maximum-delta round-trip). `dotnet csharpier check .` is clean.

Note: the build's `CheckForUncommittedChanges` target fails in my container with "Could not find Husky path", which is an environment issue unrelated to this change — I ran the `csharpier check` it wraps directly instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TG5pKCAek3sVMA4VCrXm4L)_