### PR TITLE
Fix writers declaring dimensions their coordinates do not carry, and WKB reader error reporting

### DIFF
--- a/Geo.Tests/Geometries/PolygonTests.cs
+++ b/Geo.Tests/Geometries/PolygonTests.cs
@@ -163,4 +163,49 @@ public class PolygonTests
 
         Assert.Equal(new Polygon(Square(10)).GetArea().SiValue, multiPolygon.GetArea().SiValue);
     }
+
+    [Fact]
+    public void Dimensions_come_from_the_holes_as_well_as_the_shell()
+    {
+        // Regression: consulting the shell alone made a polygon whose elevations or
+        // measures live in a hole describe itself as two-dimensional, which in turn
+        // made the writers declare dimensions their coordinates did not carry.
+        var flat = new LinearRing(
+            new Coordinate(0, 0),
+            new Coordinate(0, 3),
+            new Coordinate(3, 3),
+            new Coordinate(0, 0)
+        );
+        var raised = new LinearRing(
+            new CoordinateZ(1, 1, 7),
+            new CoordinateZ(1, 2, 7),
+            new CoordinateZ(2, 2, 7),
+            new CoordinateZ(1, 1, 7)
+        );
+        var measured = new LinearRing(
+            new CoordinateM(1, 1, 7),
+            new CoordinateM(1, 2, 7),
+            new CoordinateM(2, 2, 7),
+            new CoordinateM(1, 1, 7)
+        );
+
+        Assert.True(new Polygon(flat, raised).Is3D);
+        Assert.True(new Polygon(raised, flat).Is3D);
+        Assert.False(new Polygon(flat, flat).Is3D);
+
+        Assert.True(new Polygon(flat, measured).IsMeasured);
+        Assert.True(new Polygon(measured, flat).IsMeasured);
+        Assert.False(new Polygon(flat, flat).IsMeasured);
+
+        // A collection sees through to them as well, since it reports the dimensions of
+        // any member.
+        Assert.True(new MultiPolygon(new Polygon(flat, raised)).Is3D);
+    }
+
+    [Fact]
+    public void Empty_polygon_has_no_dimensions()
+    {
+        Assert.False(Polygon.Empty.Is3D);
+        Assert.False(Polygon.Empty.IsMeasured);
+    }
 }

--- a/Geo.Tests/IO/Wkb/WkbTests.cs
+++ b/Geo.Tests/IO/Wkb/WkbTests.cs
@@ -179,6 +179,85 @@ public class WkbTests
         Assert.Throws<SerializationException>(() => new WkbReader().Read(bytes));
     }
 
+    [Fact]
+    public void Sequence_mixing_2d_and_3d_coordinates_round_trips()
+    {
+        // Regression: the type code is derived from the geometry (Is3D is an "any
+        // coordinate" test) while the ordinates used to be written per coordinate, so
+        // the 2D coordinate wrote 8 bytes fewer than the Z type code promised and the
+        // reader ran off the end of the geometry.
+        TestRoundTrip(new LineString(new CoordinateZ(0, 0, 10), new Coordinate(1, 1)));
+        TestRoundTrip(new LineString(new Coordinate(0, 0), new CoordinateZ(1, 1, 20)));
+    }
+
+    [Fact]
+    public void Sequence_mixing_measured_and_unmeasured_coordinates_round_trips()
+    {
+        TestRoundTrip(new LineString(new CoordinateM(0, 0, 5), new Coordinate(1, 1)));
+        TestRoundTrip(new LineString(new CoordinateZ(0, 0, 10), new CoordinateM(1, 1, 5)));
+        TestRoundTrip(new LineString(new CoordinateZM(0, 0, 1, 2), new CoordinateZ(1, 1, 3)));
+    }
+
+    [Fact]
+    public void Polygon_takes_its_dimensions_from_its_holes_as_well_as_its_shell()
+    {
+        // Regression: Polygon.Is3D reports only the shell, so a polygon whose
+        // elevations live in a hole declared itself two-dimensional and then wrote
+        // three ordinates per hole coordinate. That misaligns the reader rather than
+        // merely truncating it, because the ring boundaries land in the wrong place.
+        var flat = new LinearRing(
+            new Coordinate(0, 0),
+            new Coordinate(0, 3),
+            new Coordinate(3, 3),
+            new Coordinate(0, 0)
+        );
+        var raised = new LinearRing(
+            new CoordinateZ(1, 1, 7),
+            new CoordinateZ(1, 2, 7),
+            new CoordinateZ(2, 2, 7),
+            new CoordinateZ(1, 1, 7)
+        );
+
+        TestRoundTrip(new Polygon(flat, raised));
+        TestRoundTrip(new Polygon(raised, flat));
+        TestRoundTrip(new MultiPolygon(new Polygon(flat), new Polygon(raised)));
+    }
+
+    [Fact]
+    public void Mixed_dimension_collection_round_trips()
+    {
+        TestRoundTrip(new GeometryCollection(new Point(0, 0, 5), new Point(1, 1)));
+        TestRoundTrip(new MultiPoint(new Point(0, 0, 5), new Point(1, 1)));
+    }
+
+    [Fact]
+    public void Padded_coordinate_declares_the_dimensions_of_its_type_code()
+    {
+        // The geometry must be exactly as long as its type code says: a Z line of two
+        // points is 1 + 4 + 4 + 2 * 24 bytes, whichever coordinates carry elevations.
+        var mixed = new WkbWriter().Write(
+            new LineString(new CoordinateZ(0, 0, 10), new Coordinate(1, 1))
+        );
+        var uniform = new WkbWriter().Write(
+            new LineString(new CoordinateZ(0, 0, 10), new CoordinateZ(1, 1, 20))
+        );
+
+        Assert.Equal(1002u, BitConverter.ToUInt32(mixed, 1));
+        Assert.Equal(57, mixed.Length);
+        Assert.Equal(uniform.Length, mixed.Length);
+    }
+
+    private void TestRoundTrip(Geo.Abstractions.Interfaces.IGeometry geometry)
+    {
+        var wkb = new WkbWriter(new WkbWriterSettings { Triangle = true }).Write(geometry);
+        Assert.Equal(geometry, new WkbReader().Read(wkb));
+
+        var bigEndian = new WkbWriter(
+            new WkbWriterSettings { Encoding = WkbEncoding.BigEndian, Triangle = true }
+        ).Write(geometry);
+        Assert.Equal(geometry, new WkbReader().Read(bigEndian));
+    }
+
     private void Test(string wkt)
     {
         var wktReader = new WktReader();

--- a/Geo.Tests/IO/Wkb/WkbTests.cs
+++ b/Geo.Tests/IO/Wkb/WkbTests.cs
@@ -247,6 +247,63 @@ public class WkbTests
         Assert.Equal(uniform.Length, mixed.Length);
     }
 
+    [Fact]
+    public void Ring_that_cannot_form_a_linear_ring_is_reported_as_serialization()
+    {
+        // A polygon of one ring of three coordinates. The bytes are structurally
+        // complete, so the failure comes from LinearRing rejecting the ring, which used
+        // to surface as an ArgumentException out of a WKB read.
+        var bytes = new byte[] { 1, 3, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0 }
+            .Concat(new byte[3 * 2 * 8])
+            .ToArray();
+
+        var ex = Assert.Throws<SerializationException>(() => new WkbReader().Read(bytes));
+        Assert.IsType<ArgumentException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void Coordinate_outside_the_valid_range_is_reported_as_serialization()
+    {
+        var bytes = new byte[] { 1, 1, 0, 0, 0 }
+            .Concat(BitConverter.GetBytes(0d))
+            .Concat(BitConverter.GetBytes(500d)) // latitude past the pole
+            .ToArray();
+
+        var ex = Assert.Throws<SerializationException>(() => new WkbReader().Read(bytes));
+        Assert.IsType<ArgumentOutOfRangeException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void Trailing_bytes_after_a_geometry_are_reported()
+    {
+        var point = new WkbWriter().Write(new Point(1, 2));
+        var withTrailer = point.Concat(new byte[] { 9, 9, 9 }).ToArray();
+
+        Assert.Throws<SerializationException>(() => new WkbReader().Read(withTrailer));
+
+        // A stream is not held to that: it may carry the geometry alongside whatever
+        // else the caller has put there.
+        Assert.NotNull(new WkbReader().Read(new MemoryStream(withTrailer)));
+    }
+
+    [Fact]
+    public void Overstated_coordinate_count_runs_out_of_stream_rather_than_memory()
+    {
+        // The count is read straight off the input, so it must not be used to size an
+        // allocation: these two ask for 4 billion and 500 million coordinates from a
+        // geometry that carries one.
+        foreach (var count in new[] { uint.MaxValue, 500_000_000u })
+        {
+            var bytes = new byte[] { 1, 2, 0, 0, 0 }
+                .Concat(BitConverter.GetBytes(count))
+                .Concat(BitConverter.GetBytes(0d))
+                .Concat(BitConverter.GetBytes(0d))
+                .ToArray();
+
+            Assert.Throws<SerializationException>(() => new WkbReader().Read(bytes));
+        }
+    }
+
     private void TestRoundTrip(Geo.Abstractions.Interfaces.IGeometry geometry)
     {
         var wkb = new WkbWriter(new WkbWriterSettings { Triangle = true }).Write(geometry);

--- a/Geo.Tests/IO/Wkt/WktWriterTests.cs
+++ b/Geo.Tests/IO/Wkt/WktWriterTests.cs
@@ -291,4 +291,101 @@ public class WktWriterTests
         var empty = writer.Write(new MultiPolygon());
         Assert.Equal("MULTIPOLYGON EMPTY", empty);
     }
+
+    // ---- Mixed dimensionality ----------------------------------------------
+
+    [Fact]
+    public void Coordinates_are_padded_to_the_declared_dimensions()
+    {
+        // Regression: the dimension tag comes from the geometry (Is3D is an "any
+        // coordinate" test) while the ordinates used to be written per coordinate, so
+        // the tag and the points disagreed and the WKT was invalid.
+        var writer = new WktWriter();
+
+        Assert.Equal(
+            "LINESTRING Z (0 0 10, 1 1 NaN)",
+            writer.Write(new LineString(new CoordinateZ(0, 0, 10), new Coordinate(1, 1)))
+        );
+        Assert.Equal(
+            "LINESTRING ZM (0 0 10 NaN, 1 1 NaN 5)",
+            writer.Write(new LineString(new CoordinateZ(0, 0, 10), new CoordinateM(1, 1, 5)))
+        );
+    }
+
+    [Fact]
+    public void Polygon_tag_covers_its_holes_as_well_as_its_shell()
+    {
+        // Polygon.Is3D reports only the shell, so a polygon whose elevations live in a
+        // hole used to be tagged two-dimensional while writing three ordinates for
+        // every hole coordinate.
+        var flat = new LinearRing(
+            new Coordinate(0, 0),
+            new Coordinate(0, 3),
+            new Coordinate(3, 3),
+            new Coordinate(0, 0)
+        );
+        var raised = new LinearRing(
+            new CoordinateZ(1, 1, 7),
+            new CoordinateZ(1, 2, 7),
+            new CoordinateZ(2, 2, 7),
+            new CoordinateZ(1, 1, 7)
+        );
+
+        Assert.Equal(
+            "POLYGON Z ((0 0 NaN, 3 0 NaN, 3 3 NaN, 0 0 NaN), (1 1 7, 2 1 7, 2 2 7, 1 1 7))",
+            new WktWriter().Write(new Polygon(flat, raised))
+        );
+    }
+
+    [Fact]
+    public void Multi_geometry_tag_covers_every_member()
+    {
+        // One tag covers all the members, so they must all write its ordinates.
+        var writer = new WktWriter();
+
+        Assert.Equal(
+            "MULTIPOINT Z ((0 0 5), (1 1 NaN))",
+            writer.Write(new MultiPoint(new Point(0, 0, 5), new Point(1, 1)))
+        );
+        Assert.Equal(
+            "MULTILINESTRING Z ((0 0 5, 1 1 5), (2 2 NaN, 3 3 NaN))",
+            writer.Write(
+                new MultiLineString(
+                    new LineString(new CoordinateZ(0, 0, 5), new CoordinateZ(1, 1, 5)),
+                    new LineString(new Coordinate(2, 2), new Coordinate(3, 3))
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void Mixed_dimension_geometries_round_trip()
+    {
+        var reader = new WktReader();
+        var writer = new WktWriter();
+        var ntsWriter = new WktWriter(WktWriterSettings.NtsCompatible);
+
+        var geometries = new Geo.Abstractions.Interfaces.IGeometry[]
+        {
+            new LineString(new CoordinateZ(0, 0, 10), new Coordinate(1, 1)),
+            new LineString(new CoordinateM(0, 0, 5), new Coordinate(1, 1)),
+            new LineString(new CoordinateZM(0, 0, 1, 2), new CoordinateZ(1, 1, 3)),
+        };
+
+        foreach (var geometry in geometries)
+        {
+            Assert.Equal(geometry, reader.Read(writer.Write(geometry)));
+            Assert.Equal(geometry, reader.Read(ntsWriter.Write(geometry)));
+        }
+    }
+
+    [Fact]
+    public void Measured_geometry_beyond_max_dimensions_writes_no_tag()
+    {
+        // MaxDimesions = 3 drops the measure, so there is no dimension left to tag and
+        // no separator to write for it either.
+        var writer = new WktWriter(new WktWriterSettings { MaxDimesions = 3 });
+
+        Assert.Equal("POINT (0 65.9)", writer.Write(new Point(new CoordinateM(65.9, 0, 5))));
+    }
 }

--- a/Geo/Geometries/Polygon.cs
+++ b/Geo/Geometries/Polygon.cs
@@ -34,9 +34,14 @@ public class Polygon : Geometry, ISurface
 
     public override bool IsEmpty => Shell == null || Shell.IsEmpty;
 
-    public override bool Is3D => !IsEmpty && Shell!.Is3D;
+    // A polygon's holes are as much a part of it as its shell, so - like every other
+    // geometry here - it reports the dimensions of any coordinate it holds, not just
+    // those of the first sequence. Consulting the shell alone made a polygon whose
+    // elevations live in a hole describe itself as two-dimensional.
+    public override bool Is3D => !IsEmpty && (Shell!.Is3D || Holes.Any(x => x.Is3D));
 
-    public override bool IsMeasured => !IsEmpty && Shell!.IsMeasured;
+    public override bool IsMeasured =>
+        !IsEmpty && (Shell!.IsMeasured || Holes.Any(x => x.IsMeasured));
 
     public override Envelope? GetBounds()
     {

--- a/Geo/IO/GeometryDimensions.cs
+++ b/Geo/IO/GeometryDimensions.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using Geo.Abstractions.Interfaces;
-using Geo.Geometries;
 
 namespace Geo.IO;
 
@@ -9,19 +8,16 @@ namespace Geo.IO;
 /// writer will visit.
 /// </summary>
 /// <remarks>
-/// A geometry's own <see cref="IGeometry.Is3D" /> is not enough on its own. It is an
-/// "any coordinate" test, so a sequence holding both 2D and 3D coordinates reports
-/// itself as three-dimensional, and <see cref="Polygon" /> consults only its shell, so
-/// a polygon whose elevations live in a hole reports itself as two-dimensional (and a
-/// collection containing one inherits that blind spot). Writers that declare the
-/// dimensions once for a whole geometry — a WKB type code, a WKT dimension tag — must
-/// agree with the ordinates they then write for every coordinate, or they produce
-/// output that cannot be read back.
+/// <see cref="IGeometry.Is3D" /> and <see cref="IGeometry.IsMeasured" /> are "any
+/// coordinate" tests, so a geometry holding both 2D and 3D coordinates reports itself
+/// as three-dimensional. A writer that declares the dimensions once for a whole
+/// geometry — a WKB type code, a WKT dimension tag — has to write those same ordinates
+/// for every coordinate it then emits, or it produces output that cannot be read back.
+/// Carrying the two together in one value is what keeps the declaration and the
+/// coordinates from drifting apart.
 /// </remarks>
 internal readonly struct GeometryDimensions
 {
-    public static readonly GeometryDimensions None = new(false, false);
-
     private GeometryDimensions(bool has3D, bool hasMeasure)
     {
         Has3D = has3D;
@@ -33,27 +29,6 @@ internal readonly struct GeometryDimensions
 
     public static GeometryDimensions For(IGeometry geometry)
     {
-        // A polygon's holes are written alongside its shell, so they count towards the
-        // dimensions even though Polygon.Is3D/IsMeasured ignore them.
-        if (geometry is Polygon polygon)
-        {
-            if (polygon.IsEmpty)
-                return None;
-
-            var dimensions = For(polygon.Shell!);
-            foreach (var hole in polygon.Holes)
-                dimensions = dimensions.Union(For(hole));
-            return dimensions;
-        }
-
-        if (geometry is GeometryCollection collection)
-        {
-            var dimensions = None;
-            foreach (var member in collection.Geometries)
-                dimensions = dimensions.Union(For(member));
-            return dimensions;
-        }
-
         return new GeometryDimensions(geometry.Is3D, geometry.IsMeasured);
     }
 
@@ -63,10 +38,5 @@ internal readonly struct GeometryDimensions
     public GeometryDimensions Limit(int maxDimensions)
     {
         return new GeometryDimensions(Has3D && maxDimensions > 2, HasMeasure && maxDimensions > 3);
-    }
-
-    private GeometryDimensions Union(GeometryDimensions other)
-    {
-        return new GeometryDimensions(Has3D || other.Has3D, HasMeasure || other.HasMeasure);
     }
 }

--- a/Geo/IO/GeometryDimensions.cs
+++ b/Geo/IO/GeometryDimensions.cs
@@ -1,0 +1,72 @@
+#nullable enable
+using Geo.Abstractions.Interfaces;
+using Geo.Geometries;
+
+namespace Geo.IO;
+
+/// <summary>
+/// The ordinates a geometry has to be written with, taken across every coordinate the
+/// writer will visit.
+/// </summary>
+/// <remarks>
+/// A geometry's own <see cref="IGeometry.Is3D" /> is not enough on its own. It is an
+/// "any coordinate" test, so a sequence holding both 2D and 3D coordinates reports
+/// itself as three-dimensional, and <see cref="Polygon" /> consults only its shell, so
+/// a polygon whose elevations live in a hole reports itself as two-dimensional (and a
+/// collection containing one inherits that blind spot). Writers that declare the
+/// dimensions once for a whole geometry — a WKB type code, a WKT dimension tag — must
+/// agree with the ordinates they then write for every coordinate, or they produce
+/// output that cannot be read back.
+/// </remarks>
+internal readonly struct GeometryDimensions
+{
+    public static readonly GeometryDimensions None = new(false, false);
+
+    private GeometryDimensions(bool has3D, bool hasMeasure)
+    {
+        Has3D = has3D;
+        HasMeasure = hasMeasure;
+    }
+
+    public bool Has3D { get; }
+    public bool HasMeasure { get; }
+
+    public static GeometryDimensions For(IGeometry geometry)
+    {
+        // A polygon's holes are written alongside its shell, so they count towards the
+        // dimensions even though Polygon.Is3D/IsMeasured ignore them.
+        if (geometry is Polygon polygon)
+        {
+            if (polygon.IsEmpty)
+                return None;
+
+            var dimensions = For(polygon.Shell!);
+            foreach (var hole in polygon.Holes)
+                dimensions = dimensions.Union(For(hole));
+            return dimensions;
+        }
+
+        if (geometry is GeometryCollection collection)
+        {
+            var dimensions = None;
+            foreach (var member in collection.Geometries)
+                dimensions = dimensions.Union(For(member));
+            return dimensions;
+        }
+
+        return new GeometryDimensions(geometry.Is3D, geometry.IsMeasured);
+    }
+
+    /// <summary>
+    /// Drops the ordinates a writer has been configured not to emit.
+    /// </summary>
+    public GeometryDimensions Limit(int maxDimensions)
+    {
+        return new GeometryDimensions(Has3D && maxDimensions > 2, HasMeasure && maxDimensions > 3);
+    }
+
+    private GeometryDimensions Union(GeometryDimensions other)
+    {
+        return new GeometryDimensions(Has3D || other.Has3D, HasMeasure || other.HasMeasure);
+    }
+}

--- a/Geo/IO/Wkb/WkbBinaryReader.cs
+++ b/Geo/IO/Wkb/WkbBinaryReader.cs
@@ -25,6 +25,13 @@ internal class WkbBinaryReader : IDisposable
     public bool HasData { get; }
     public WkbEncoding Encoding { get; private set; }
 
+    /// <summary>
+    /// How many bytes the geometry read so far has consumed. The stream itself cannot
+    /// be asked once reading is done, because it has been closed by then, and it may
+    /// not be seekable in the first place.
+    /// </summary>
+    public long BytesRead { get; private set; }
+
     public void Dispose()
     {
         if (!_disposed)
@@ -50,6 +57,7 @@ internal class WkbBinaryReader : IDisposable
             bytes[0] = (byte)_pushback;
             _pushback = -1;
             offset = 1;
+            BytesRead++;
         }
 
         // A single read can return fewer bytes than asked for without being at the end
@@ -63,6 +71,7 @@ internal class WkbBinaryReader : IDisposable
             if (read <= 0)
                 throw new EndOfStreamException();
             offset += read;
+            BytesRead += read;
         }
 
         if (Encoding == WkbEncoding.BigEndian)
@@ -72,6 +81,8 @@ internal class WkbBinaryReader : IDisposable
 
     private byte ReadByte()
     {
+        BytesRead++;
+
         if (_pushback < 0)
             return _reader.ReadByte();
 

--- a/Geo/IO/Wkb/WkbReader.cs
+++ b/Geo/IO/Wkb/WkbReader.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -20,7 +21,19 @@ public class WkbReader
 
         using (var stream = new MemoryStream(bytes))
         {
-            return Read(stream);
+            var geometry = Read(stream, out var bytesRead);
+
+            // A byte array holds the geometry and nothing else, so anything left over
+            // means it does not contain what it claims to. A stream is deliberately not
+            // held to this standard: a caller may hand over one that carries the
+            // geometry alongside whatever else it is already carrying.
+            if (geometry != null && bytesRead != bytes.Length)
+                throw new SerializationException(
+                    (bytes.Length - bytesRead).ToString(CultureInfo.InvariantCulture)
+                        + " bytes remain after the end of the WKB geometry."
+                );
+
+            return geometry;
         }
     }
 
@@ -45,8 +58,15 @@ public class WkbReader
 
     public IGeometry? Read(Stream stream)
     {
+        return Read(stream, out _);
+    }
+
+    private IGeometry? Read(Stream stream, out long bytesRead)
+    {
         if (stream == null)
             throw new ArgumentNullException("stream");
+
+        bytesRead = 0;
 
         using (var reader = new WkbBinaryReader(stream))
         {
@@ -55,13 +75,25 @@ public class WkbReader
 
             try
             {
-                return ReadGeometry(reader);
+                var geometry = ReadGeometry(reader);
+                bytesRead = reader.BytesRead;
+                return geometry;
             }
             catch (EndOfStreamException)
             {
                 throw new SerializationException(
                     "End of stream reached before end of valid WKB geometry."
                 );
+            }
+            // Malformed bytes reach the geometry and coordinate constructors as
+            // impossible values - a latitude past the pole, a ring that does not close -
+            // which reject them as bad arguments. The argument actually at fault is the
+            // WKB, so these are reported like every other decoding failure rather than
+            // surfacing as an argument exception naming a parameter the caller never
+            // supplied.
+            catch (ArgumentException ex)
+            {
+                throw new SerializationException("Invalid WKB geometry.", ex);
             }
         }
     }
@@ -88,12 +120,20 @@ public class WkbReader
         return new Coordinate(y, x);
     }
 
+    // Counts are read straight off the input, so they cannot be trusted to size a list:
+    // a four-byte header would otherwise be able to demand an arbitrarily large
+    // allocation before a single coordinate had been read, and a count above
+    // int.MaxValue turns negative on the way to a capacity or a loop bound. Counts are
+    // kept unsigned and the list grows into whatever actually arrives, so an
+    // overstated count runs out of stream rather than out of memory.
+    private const int MaxPreallocatedCount = 1024;
+
     private CoordinateSequence ReadCoordinates(WkbBinaryReader reader, WkbDimensions dimensions)
     {
-        var pointCount = (int)reader.ReadUInt32();
+        var pointCount = reader.ReadUInt32();
 
-        var result = new List<Coordinate>(pointCount);
-        for (var i = 0; i < pointCount; i++)
+        var result = new List<Coordinate>((int)Math.Min(pointCount, MaxPreallocatedCount));
+        for (var i = 0u; i < pointCount; i++)
             result.Add(ReadCoordinate(reader, dimensions));
 
         return new CoordinateSequence(result);
@@ -174,17 +214,17 @@ public class WkbReader
     private List<LinearRing> ReadPolygonInner(WkbBinaryReader reader, WkbDimensions dimensions)
     {
         var result = new List<LinearRing>();
-        var ringsCount = (int)reader.ReadUInt32();
-        for (var i = 0; i < ringsCount; i++)
+        var ringsCount = reader.ReadUInt32();
+        for (var i = 0u; i < ringsCount; i++)
             result.Add(new LinearRing(ReadCoordinates(reader, dimensions)));
         return result;
     }
 
     private MultiPoint ReadMultiPoint(WkbBinaryReader reader, WkbDimensions dimensions)
     {
-        var pointsCount = (int)reader.ReadUInt32();
+        var pointsCount = reader.ReadUInt32();
         var points = new List<Point>();
-        for (var i = 0; i < pointsCount; i++)
+        for (var i = 0u; i < pointsCount; i++)
         {
             var point = ReadGeometry(reader) as Point;
             if (point != null)
@@ -198,9 +238,9 @@ public class WkbReader
 
     private MultiLineString ReadMultiLineString(WkbBinaryReader reader, WkbDimensions dimensions)
     {
-        var pointsCount = (int)reader.ReadUInt32();
+        var pointsCount = reader.ReadUInt32();
         var lineStrings = new List<LineString>();
-        for (var i = 0; i < pointsCount; i++)
+        for (var i = 0u; i < pointsCount; i++)
         {
             var lineString = ReadGeometry(reader) as LineString;
             if (lineString != null)
@@ -214,9 +254,9 @@ public class WkbReader
 
     private MultiPolygon ReadMultiPolygon(WkbBinaryReader reader, WkbDimensions dimensions)
     {
-        var pointsCount = (int)reader.ReadUInt32();
+        var pointsCount = reader.ReadUInt32();
         var polygons = new List<Polygon>();
-        for (var i = 0; i < pointsCount; i++)
+        for (var i = 0u; i < pointsCount; i++)
         {
             var polygon = ReadGeometry(reader) as Polygon;
             if (polygon != null)
@@ -230,9 +270,9 @@ public class WkbReader
 
     private GeometryCollection ReadGeometryCollection(WkbBinaryReader reader)
     {
-        var pointsCount = (int)reader.ReadUInt32();
+        var pointsCount = reader.ReadUInt32();
         var geometries = new List<IGeometry>();
-        for (var i = 0; i < pointsCount; i++)
+        for (var i = 0u; i < pointsCount; i++)
             geometries.Add(ReadGeometry(reader));
         return new GeometryCollection(geometries);
     }

--- a/Geo/IO/Wkb/WkbWriter.cs
+++ b/Geo/IO/Wkb/WkbWriter.cs
@@ -140,30 +140,46 @@ public class WkbWriter
         );
     }
 
-    private void WriteCoordinate(Coordinate coordinate, WkbBinaryWriter writer)
+    // Every coordinate writes exactly the ordinates the type code declared, whether or
+    // not it carries them. A coordinate that lacks one is padded with NaN, which is how
+    // an absent ordinate is already spelled in this format (see WritePoint) and what
+    // WkbReader reads back as "not 3D"/"not measured", so a sequence mixing 2D and 3D
+    // coordinates survives the round-trip unchanged. Writing each coordinate's own
+    // ordinates instead would leave the geometry shorter than its type code promises,
+    // and the reader would run off the end of it or mistake the following bytes for
+    // the rest of the coordinate.
+    private void WriteCoordinate(
+        Coordinate coordinate,
+        GeometryDimensions dimensions,
+        WkbBinaryWriter writer
+    )
     {
         writer.Write(coordinate.Longitude);
         writer.Write(coordinate.Latitude);
 
-        if (coordinate.Is3D && _settings.MaxDimesions > 2)
-            writer.Write(((Is3D)coordinate).Elevation);
+        if (dimensions.Has3D)
+            writer.Write(coordinate is Is3D elevation ? elevation.Elevation : double.NaN);
 
-        if (coordinate.IsMeasured && _settings.MaxDimesions > 3)
-            writer.Write(((IsMeasured)coordinate).Measure);
+        if (dimensions.HasMeasure)
+            writer.Write(coordinate is IsMeasured measure ? measure.Measure : double.NaN);
     }
 
-    private void WriteCoordinates(CoordinateSequence coordinates, WkbBinaryWriter writer)
+    private void WriteCoordinates(
+        CoordinateSequence coordinates,
+        GeometryDimensions dimensions,
+        WkbBinaryWriter writer
+    )
     {
         writer.Write((uint)coordinates.Count);
 
         foreach (var coordinate in coordinates)
-            WriteCoordinate(coordinate, writer);
+            WriteCoordinate(coordinate, dimensions, writer);
     }
 
     private void WritePoint(Point point, WkbBinaryWriter writer)
     {
         WriteEncoding(writer, _settings.Encoding);
-        WriteGeometryType(point, WkbGeometryType.Point, writer);
+        var dimensions = WriteGeometryType(point, WkbGeometryType.Point, writer);
 
         if (point.IsEmpty)
         {
@@ -175,32 +191,36 @@ public class WkbWriter
         }
         else
         {
-            WriteCoordinate(point.Coordinate!, writer);
+            WriteCoordinate(point.Coordinate!, dimensions, writer);
         }
     }
 
     private void WriteLineString(LineString lineString, WkbBinaryWriter writer)
     {
         WriteEncoding(writer, _settings.Encoding);
-        WriteGeometryType(lineString, WkbGeometryType.LineString, writer);
-        WriteCoordinates(lineString.Coordinates, writer);
+        var dimensions = WriteGeometryType(lineString, WkbGeometryType.LineString, writer);
+        WriteCoordinates(lineString.Coordinates, dimensions, writer);
     }
 
     private void WritePolygon(Polygon polygon, WkbBinaryWriter writer)
     {
         WriteEncoding(writer, _settings.Encoding);
-        WriteGeometryType(polygon, WkbGeometryType.Polygon, writer);
-        WritePolygonInner(polygon, writer);
+        var dimensions = WriteGeometryType(polygon, WkbGeometryType.Polygon, writer);
+        WritePolygonInner(polygon, dimensions, writer);
     }
 
     private void WriteTriangle(Triangle triangle, WkbBinaryWriter writer)
     {
         WriteEncoding(writer, _settings.Encoding);
-        WriteGeometryType(triangle, WkbGeometryType.Triangle, writer);
-        WritePolygonInner(triangle, writer);
+        var dimensions = WriteGeometryType(triangle, WkbGeometryType.Triangle, writer);
+        WritePolygonInner(triangle, dimensions, writer);
     }
 
-    private void WritePolygonInner(Polygon polygon, WkbBinaryWriter writer)
+    private void WritePolygonInner(
+        Polygon polygon,
+        GeometryDimensions dimensions,
+        WkbBinaryWriter writer
+    )
     {
         if (polygon.IsEmpty)
         {
@@ -209,10 +229,10 @@ public class WkbWriter
         else
         {
             writer.Write((uint)(1 + polygon.Holes.Count));
-            WriteCoordinates(polygon.Shell!.Coordinates, writer);
+            WriteCoordinates(polygon.Shell!.Coordinates, dimensions, writer);
 
             foreach (var hole in polygon.Holes)
-                WriteCoordinates(hole.Coordinates, writer);
+                WriteCoordinates(hole.Coordinates, dimensions, writer);
         }
     }
 
@@ -252,27 +272,24 @@ public class WkbWriter
             Write(geometry, writer);
     }
 
-    private void WriteGeometryType(
+    // Returns the dimensions the type code just declared, so that the coordinates
+    // written after it are guaranteed to carry the same ordinates.
+    private GeometryDimensions WriteGeometryType(
         IGeometry geometry,
         WkbGeometryType baseType,
         WkbBinaryWriter writer
     )
     {
-        if (geometry.IsEmpty)
-        {
-            writer.Write((uint)baseType);
-        }
-        else
-        {
-            var typeCode = (uint)baseType;
+        var dimensions = GeometryDimensions.For(geometry).Limit(_settings.MaxDimesions);
+        var typeCode = (uint)baseType;
 
-            if (geometry.Is3D && _settings.MaxDimesions > 2)
-                typeCode += 1000;
+        if (dimensions.Has3D)
+            typeCode += 1000;
 
-            if (geometry.IsMeasured && _settings.MaxDimesions > 3)
-                typeCode += 2000;
+        if (dimensions.HasMeasure)
+            typeCode += 2000;
 
-            writer.Write(typeCode);
-        }
+        writer.Write(typeCode);
+        return dimensions;
     }
 }

--- a/Geo/IO/Wkt/WktWriter.cs
+++ b/Geo/IO/Wkt/WktWriter.cs
@@ -116,13 +116,11 @@ public class WktWriter
 
     private void AppendPoint(StringBuilder builder, Point point)
     {
-        builder.Append("POINT");
-        AppendDimensions(builder, point);
-        builder.Append(" ");
-        AppendPointInner(builder, point);
+        var dimensions = AppendTypeAndDimensions(builder, "POINT", point);
+        AppendPointInner(builder, point, dimensions);
     }
 
-    private void AppendPointInner(StringBuilder builder, Point point)
+    private void AppendPointInner(StringBuilder builder, Point point, GeometryDimensions dimensions)
     {
         if (point.IsEmpty)
         {
@@ -131,27 +129,27 @@ public class WktWriter
         }
 
         builder.Append("(");
-        AppendCoordinate(builder, point.Coordinate!);
+        AppendCoordinate(builder, point.Coordinate!, dimensions);
         builder.Append(")");
     }
 
     private void AppendLineString(StringBuilder builder, LineString lineString)
     {
-        builder.Append("LINESTRING");
-        AppendDimensions(builder, lineString);
-        builder.Append(" ");
-        AppendLineStringInner(builder, lineString.Coordinates);
+        var dimensions = AppendTypeAndDimensions(builder, "LINESTRING", lineString);
+        AppendLineStringInner(builder, lineString.Coordinates, dimensions);
     }
 
     private void AppendLinearRing(StringBuilder builder, LinearRing linearRing)
     {
-        builder.Append("LINEARRING");
-        AppendDimensions(builder, linearRing);
-        builder.Append(" ");
-        AppendLineStringInner(builder, linearRing.Coordinates);
+        var dimensions = AppendTypeAndDimensions(builder, "LINEARRING", linearRing);
+        AppendLineStringInner(builder, linearRing.Coordinates, dimensions);
     }
 
-    private void AppendLineStringInner(StringBuilder builder, CoordinateSequence lineString)
+    private void AppendLineStringInner(
+        StringBuilder builder,
+        CoordinateSequence lineString,
+        GeometryDimensions dimensions
+    )
     {
         if (lineString.IsEmpty)
         {
@@ -160,27 +158,27 @@ public class WktWriter
         }
 
         builder.Append("(");
-        AppendCoordinates(builder, lineString);
+        AppendCoordinates(builder, lineString, dimensions);
         builder.Append(")");
     }
 
     private void AppendPolygon(StringBuilder builder, Polygon polygon)
     {
-        builder.Append("POLYGON");
-        AppendDimensions(builder, polygon);
-        builder.Append(" ");
-        AppendPolygonInner(builder, polygon);
+        var dimensions = AppendTypeAndDimensions(builder, "POLYGON", polygon);
+        AppendPolygonInner(builder, polygon, dimensions);
     }
 
     private void AppendTriangle(StringBuilder builder, Triangle polygon)
     {
-        builder.Append("TRIANGLE");
-        AppendDimensions(builder, polygon);
-        builder.Append(" ");
-        AppendPolygonInner(builder, polygon);
+        var dimensions = AppendTypeAndDimensions(builder, "TRIANGLE", polygon);
+        AppendPolygonInner(builder, polygon, dimensions);
     }
 
-    private void AppendPolygonInner(StringBuilder builder, Polygon polygon)
+    private void AppendPolygonInner(
+        StringBuilder builder,
+        Polygon polygon,
+        GeometryDimensions dimensions
+    )
     {
         if (polygon.IsEmpty)
         {
@@ -189,11 +187,11 @@ public class WktWriter
         }
 
         builder.Append("(");
-        AppendLineStringInner(builder, polygon.Shell!.Coordinates);
+        AppendLineStringInner(builder, polygon.Shell!.Coordinates, dimensions);
         for (var i = 0; i < polygon.Holes.Count; i++)
         {
             builder.Append(", ");
-            AppendLineStringInner(builder, polygon.Holes[i].Coordinates);
+            AppendLineStringInner(builder, polygon.Holes[i].Coordinates, dimensions);
         }
 
         builder.Append(")");
@@ -201,20 +199,19 @@ public class WktWriter
 
     private void AppendMultiPoint(StringBuilder builder, MultiPoint multiPoint)
     {
-        builder.Append("MULTIPOINT");
         if (multiPoint.IsEmpty)
         {
-            builder.Append(" EMPTY");
+            builder.Append("MULTIPOINT EMPTY");
             return;
         }
 
-        AppendDimensions(builder, multiPoint);
-        builder.Append(" (");
+        var dimensions = AppendTypeAndDimensions(builder, "MULTIPOINT", multiPoint);
+        builder.Append("(");
         for (var i = 0; i < multiPoint.Geometries.Count; i++)
         {
             if (i > 0)
                 builder.Append(", ");
-            AppendPointInner(builder, (Point)multiPoint.Geometries[i]);
+            AppendPointInner(builder, (Point)multiPoint.Geometries[i], dimensions);
         }
 
         builder.Append(")");
@@ -222,20 +219,23 @@ public class WktWriter
 
     private void AppendMultiLineString(StringBuilder builder, MultiLineString multiLineString)
     {
-        builder.Append("MULTILINESTRING");
         if (multiLineString.IsEmpty)
         {
-            builder.Append(" EMPTY");
+            builder.Append("MULTILINESTRING EMPTY");
             return;
         }
 
-        AppendDimensions(builder, multiLineString);
-        builder.Append(" (");
+        var dimensions = AppendTypeAndDimensions(builder, "MULTILINESTRING", multiLineString);
+        builder.Append("(");
         for (var i = 0; i < multiLineString.Geometries.Count; i++)
         {
             if (i > 0)
                 builder.Append(", ");
-            AppendLineStringInner(builder, ((LineString)multiLineString.Geometries[i]).Coordinates);
+            AppendLineStringInner(
+                builder,
+                ((LineString)multiLineString.Geometries[i]).Coordinates,
+                dimensions
+            );
         }
 
         builder.Append(")");
@@ -243,20 +243,19 @@ public class WktWriter
 
     private void AppendMultiPolygon(StringBuilder builder, MultiPolygon multiPolygon)
     {
-        builder.Append("MULTIPOLYGON");
         if (multiPolygon.IsEmpty)
         {
-            builder.Append(" EMPTY");
+            builder.Append("MULTIPOLYGON EMPTY");
             return;
         }
 
-        AppendDimensions(builder, multiPolygon);
-        builder.Append(" (");
+        var dimensions = AppendTypeAndDimensions(builder, "MULTIPOLYGON", multiPolygon);
+        builder.Append("(");
         for (var i = 0; i < multiPolygon.Geometries.Count; i++)
         {
             if (i > 0)
                 builder.Append(", ");
-            AppendPolygonInner(builder, (Polygon)multiPolygon.Geometries[i]);
+            AppendPolygonInner(builder, (Polygon)multiPolygon.Geometries[i], dimensions);
         }
 
         builder.Append(")");
@@ -267,92 +266,110 @@ public class WktWriter
         GeometryCollection geometryCollection
     )
     {
-        builder.Append("GEOMETRYCOLLECTION");
         if (geometryCollection.IsEmpty)
         {
-            builder.Append(" EMPTY");
+            builder.Append("GEOMETRYCOLLECTION EMPTY");
             return;
         }
 
-        AppendDimensions(builder, geometryCollection);
-        builder.Append(" (");
+        AppendTypeAndDimensions(builder, "GEOMETRYCOLLECTION", geometryCollection);
+        builder.Append("(");
         for (var i = 0; i < geometryCollection.Geometries.Count; i++)
         {
             if (i > 0)
                 builder.Append(", ");
+            // Each member carries its own type and dimension tag, so it declares its
+            // own ordinates rather than inheriting the collection's.
             AppendGeometry(builder, geometryCollection.Geometries[i]);
         }
 
         builder.Append(")");
     }
 
-    private void AppendDimensions(StringBuilder builder, IGeometry geometry)
+    // Writes the geometry type and its dimension tag, and returns the dimensions that
+    // tag declared so every coordinate written afterwards carries the same ordinates.
+    // A single tag covers the whole geometry - including a polygon's holes and the
+    // members of a multi-geometry - so the dimensions have to be taken across all of
+    // their coordinates, not just the first sequence reached.
+    private GeometryDimensions AppendTypeAndDimensions(
+        StringBuilder builder,
+        string type,
+        IGeometry geometry
+    )
     {
-        if (_settings.DimensionFlag && _settings.MaxDimesions > 2)
+        var dimensions = GeometryDimensions.For(geometry).Limit(_settings.MaxDimesions);
+
+        builder.Append(type);
+
+        if (_settings.DimensionFlag)
         {
-            if (geometry.Is3D || geometry.IsMeasured)
+            if (dimensions.Has3D || dimensions.HasMeasure)
                 builder.Append(" ");
 
-            if (geometry.Is3D && _settings.MaxDimesions > 2)
+            if (dimensions.Has3D)
                 builder.Append("Z");
 
-            if (geometry.IsMeasured && _settings.MaxDimesions > 3)
+            if (dimensions.HasMeasure)
                 builder.Append("M");
         }
+
+        builder.Append(" ");
+        return dimensions;
     }
 
-    private void AppendCoordinates(StringBuilder builder, CoordinateSequence coordinates)
+    private void AppendCoordinates(
+        StringBuilder builder,
+        CoordinateSequence coordinates,
+        GeometryDimensions dimensions
+    )
     {
         for (var i = 0; i < coordinates.Count; i++)
         {
             if (i > 0)
                 builder.Append(", ");
-            AppendCoordinate(builder, coordinates[i]);
+            AppendCoordinate(builder, coordinates[i], dimensions);
         }
     }
 
-    private void AppendCoordinate(StringBuilder builder, Coordinate coordinate)
+    // Every coordinate writes the ordinates the dimension tag declared, whether or not
+    // it carries them, so that a sequence mixing 2D and 3D coordinates does not produce
+    // a geometry whose points disagree with its own tag. A coordinate missing an
+    // ordinate gets NullOrdinate ("NaN" by default), which is what the reader takes
+    // back as an absent ordinate.
+    private void AppendCoordinate(
+        StringBuilder builder,
+        Coordinate coordinate,
+        GeometryDimensions dimensions
+    )
     {
         builder.Append(coordinate.Longitude.ToString(CultureInfo.InvariantCulture));
         builder.Append(" ");
         builder.Append(coordinate.Latitude.ToString(CultureInfo.InvariantCulture));
 
-        if (_settings.DimensionFlag)
-        {
-            if (coordinate.Is3D && _settings.MaxDimesions > 2)
-            {
-                builder.Append(" ");
-                builder.Append(((Is3D)coordinate).Elevation.ToString(CultureInfo.InvariantCulture));
-            }
+        // With no dimension tag to say whether a third ordinate is an elevation or a
+        // measure, a measured geometry has to fill the elevation slot as well to keep
+        // the measure in fourth position.
+        var appendElevation =
+            dimensions.Has3D || (!_settings.DimensionFlag && dimensions.HasMeasure);
 
-            if (coordinate.IsMeasured && _settings.MaxDimesions > 3)
-            {
-                builder.Append(" ");
-                builder.Append(
-                    ((IsMeasured)coordinate).Measure.ToString(CultureInfo.InvariantCulture)
-                );
-            }
+        if (appendElevation)
+        {
+            builder.Append(" ");
+            builder.Append(
+                coordinate is Is3D elevation
+                    ? elevation.Elevation.ToString(CultureInfo.InvariantCulture)
+                    : _settings.NullOrdinate
+            );
         }
-        else
-        {
-            if (coordinate.Is3D && _settings.MaxDimesions > 2)
-            {
-                builder.Append(" ");
-                builder.Append(((Is3D)coordinate).Elevation.ToString(CultureInfo.InvariantCulture));
-            }
-            else if (coordinate.IsMeasured && _settings.MaxDimesions > 3)
-            {
-                builder.Append(" ");
-                builder.Append(_settings.NullOrdinate);
-            }
 
-            if (coordinate.IsMeasured && _settings.MaxDimesions > 3)
-            {
-                builder.Append(" ");
-                builder.Append(
-                    ((IsMeasured)coordinate).Measure.ToString(CultureInfo.InvariantCulture)
-                );
-            }
+        if (dimensions.HasMeasure)
+        {
+            builder.Append(" ");
+            builder.Append(
+                coordinate is IsMeasured measure
+                    ? measure.Measure.ToString(CultureInfo.InvariantCulture)
+                    : _settings.NullOrdinate
+            );
         }
     }
 }


### PR DESCRIPTION
The WKB and WKT writers could silently produce output that could not be read back, and the WKB reader reported some malformed input as argument exceptions rather than as a decoding failure.

## 1. Writers declared dimensions their coordinates did not carry

Both writers declare dimensions **once for a whole geometry** — a WKB type code, a WKT dimension tag — but then wrote ordinates according to **each coordinate's own** type. Nothing kept the two in step, so when they disagreed the output was malformed and no error was raised.

They disagree in two independent ways:

**`Is3D`/`IsMeasured` are "any coordinate" tests.** A sequence mixing 2D and 3D coordinates declares itself 3D while its 2D coordinates still write two ordinates.

**`Polygon.Is3D` consulted only the shell.** No mixing required — a polygon whose elevations live in a *hole* declared itself 2D and then wrote three ordinates for every hole coordinate.

| Geometry | Type code | Bytes written | Read back |
|---|---|---|---|
| `LINESTRING [Z, xy]` | 1002 (3D) | 49 (needs 57) | `SerializationException` |
| `LINESTRING [Z, M]` | 3002 (4D) | 57 (needs 73) | `SerializationException` |
| Polygon shell 2D, hole 3D | 3 (2D) | 177 | `ArgumentException`, 32 bytes unread |
| Polygon shell 3D, hole 2D | 1003 (3D) | 177 | `SerializationException` |

The polygon case is worse than truncation: the reader misaligns, so ring boundaries land in the wrong place.

**Neither needs unusual geometry to reach.** `<ele>` is optional *per trackpoint* in GPX, so a device that loses its altitude fix mid-track parses into exactly such a sequence, and `TrackSegment`/`Track`/`Route.ToLineString()` build straight from the waypoint coordinates. Parsing such a file and writing it produced 73 bytes of WKB this library could not read back.

### Fix

`Polygon.Is3D`/`IsMeasured` now count holes — it was the only geometry whose dimensions were not an "any coordinate" test, and a collection built from such a polygon inherited the blind spot. The only consumers outside the geometry classes are the two GPX serializers, which use *coordinate*-level `Is3D` and are unaffected.

A new internal `GeometryDimensions` then carries the dimensions and the writer's `MaxDimesions` limit as one value, threaded from the declaration through to every coordinate written after it, so the two cannot drift apart again.

Coordinates that lack a declared ordinate are padded — NaN in WKB, `NullOrdinate` in WKT. Both are how an absent ordinate is already spelled in each format (`WritePoint` already writes NaN for `POINT EMPTY`), and both readers already take them back as "not 3D"/"not measured", so mixed geometries round-trip to exactly what was written:

```
LINESTRING [Z, xy]         wkb type 1002  57B EQUAL   wkt EQUAL
Polygon shell2D hole3D     wkb type 1003 209B EQUAL   wkt EQUAL
GeomColl w/ hole-3D member wkb type 1007 239B EQUAL   wkt EQUAL
GPX patchy <ele>           wkb type 1002  81B EQUAL   wkt EQUAL

POLYGON Z ((0 0 NaN, 3 0 NaN, 3 3 NaN, 0 0 NaN), (1 1 7, 2 1 7, 2 2 7, 1 1 7))
```

Uniform geometries are byte-for-byte unchanged — every pre-existing test passes untouched.

Incidentally, WKT no longer emits a stray separator when `MaxDimesions` has dropped the only dimension that would have been tagged.

## 2. WkbReader reported malformed input as argument failures

It translated only `EndOfStreamException`, so malformed bytes that were structurally complete escaped as whatever the constructors raised on being handed impossible values:

| Input | Before | After |
|---|---|---|
| polygon ring of 3 coordinates | `ArgumentException` | `SerializationException` |
| latitude 500 | `ArgumentOutOfRangeException` (param `latitude`) | `SerializationException` |
| coordinate count `0xFFFFFFFF` | `ArgumentOutOfRangeException` (param `capacity`) | `SerializationException` |
| valid point + 3 trailing bytes | silently ignored | `SerializationException` |

`ArgumentOutOfRangeException` naming `latitude` was the least helpful of these: the caller passed a byte array, not a latitude. All now report as `SerializationException` with the original kept as `InnerException`.

Two related hardenings. Counts were read off the input and then used to **size a list**, so a four-byte header could demand an arbitrary allocation before a single coordinate had been read, and a count above `int.MaxValue` turned negative on the way to that capacity or to a loop bound — either throwing on the capacity or silently skipping the loop and returning an empty geometry. Counts are now unsigned and the list grows into what actually arrives, so an overstated count runs out of stream rather than out of memory.

`Read(byte[])` now rejects bytes left over after the geometry, which is how the misaligned reads above were passing unnoticed. The stream overloads are deliberately **not** held to that, since a caller may hand over a stream carrying more than the geometry. The reader tracks what it consumed rather than asking the stream, which by then has been closed and may never have been seekable.

## Testing

750 tests pass (734 before, 16 added). All pre-existing tests pass unmodified, which is what confirms uniform geometries are unchanged. `dotnet csharpier check .` is clean.

Note: the build's `CheckForUncommittedChanges` target fails in my container with "Could not find Husky path", an environment issue unrelated to this change — I ran the `csharpier check` it wraps directly instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TG5pKCAek3sVMA4VCrXm4L)_