### PR TITLE
Fix six bugs: circle bounds past the pole, 2D/3D coordinate equality, and more

### DIFF
--- a/Geo.Tests/Geomagnetism/GeomagnetismResultTests.cs
+++ b/Geo.Tests/Geomagnetism/GeomagnetismResultTests.cs
@@ -37,22 +37,34 @@ public class GeomagnetismResultTests
     [Theory]
     [InlineData(0, 100)]
     [InlineData(19000, 0)]
-    public void A_zero_x_or_y_component_leaves_the_derived_field_unset(double x, double y)
+    public void A_zero_x_or_y_component_is_still_a_field(double x, double y)
     {
-        var result = new GeomagnetismResult(Location, Date, x, y, 45000);
+        const double z = 45000;
 
-        // The constructor short-circuits before assigning any component, so every
-        // derived quantity stays at its default of zero, while the location and date
-        // are still recorded.
-        Assert.Equal(0, result.X);
-        Assert.Equal(0, result.Y);
-        Assert.Equal(0, result.Z);
-        Assert.Equal(0, result.HorizontalIntensity);
-        Assert.Equal(0, result.TotalIntensity);
-        Assert.Equal(0, result.Declination);
-        Assert.Equal(0, result.Inclination);
+        var result = new GeomagnetismResult(Location, Date, x, y, z);
+
+        var expectedH = Math.Sqrt(x * x + y * y);
+
+        Assert.Equal(x, result.X);
+        Assert.Equal(y, result.Y);
+        Assert.Equal(z, result.Z);
+        Assert.Equal(expectedH, result.HorizontalIntensity, 6);
+        Assert.Equal(Math.Sqrt(x * x + y * y + z * z), result.TotalIntensity, 6);
+        Assert.Equal(ToDegrees(Math.Atan2(y, x)), result.Declination, 9);
+        Assert.Equal(ToDegrees(Math.Atan2(z, expectedH)), result.Inclination, 9);
         Assert.Same(Location, result.Coordinate);
         Assert.Equal(Date, result.Date);
+    }
+
+    [Fact]
+    public void A_field_pointing_straight_down_keeps_its_vertical_component()
+    {
+        var result = new GeomagnetismResult(Location, Date, 0, 0, 45000);
+
+        Assert.Equal(45000, result.Z);
+        Assert.Equal(45000, result.TotalIntensity, 6);
+        Assert.Equal(0, result.HorizontalIntensity, 6);
+        Assert.Equal(90, result.Inclination, 9);
     }
 
     [Fact]

--- a/Geo.Tests/Geometries/CircleTests.cs
+++ b/Geo.Tests/Geometries/CircleTests.cs
@@ -61,6 +61,81 @@ public class CircleTests
         Assert.True(maxLonError <= 0.002);
     }
 
+    [Theory]
+    [InlineData(89.5, 100000)] // reaches over the north pole
+    [InlineData(-89.5, 100000)] // reaches over the south pole
+    [InlineData(89.9, 100000)] // longitudinal half-span would be several turns
+    [InlineData(0, 40000000)] // larger than the earth
+    public void Bounds_of_a_circle_that_reaches_a_pole_stay_inside_the_valid_range(
+        double latitude,
+        double radius
+    )
+    {
+        var bounds = new Circle(latitude, 0, radius).GetBounds();
+
+        Assert.InRange(bounds.MinLat, -90, 90);
+        Assert.InRange(bounds.MaxLat, -90, 90);
+        Assert.InRange(bounds.MinLon, -180, 180);
+        Assert.InRange(bounds.MaxLon, -180, 180);
+
+        // Every meridian runs through a circle that covers a pole, so its box has to
+        // span the whole longitude range rather than a slice of it.
+        Assert.Equal(-180, bounds.MinLon);
+        Assert.Equal(180, bounds.MaxLon);
+    }
+
+    [Fact]
+    public void Bounds_of_a_circle_crossing_the_anti_meridian_span_every_longitude()
+    {
+        // An envelope runs west to east, so it cannot describe a wrapped box; the whole
+        // range is the smallest one it can express that still contains the circle.
+        var bounds = new Circle(0, 179.9, 100000).GetBounds();
+
+        Assert.Equal(-180, bounds.MinLon);
+        Assert.Equal(180, bounds.MaxLon);
+    }
+
+    [Fact]
+    public void Bounds_widen_towards_the_pole_without_ever_leaving_the_valid_range()
+    {
+        var previousWidth = 0d;
+
+        foreach (var latitude in new[] { 0d, 30d, 45d, 60d, 75d, 80d, 85d, 88d, 89d })
+        {
+            var bounds = new Circle(latitude, 20, 100000).GetBounds();
+
+            Assert.InRange(bounds.MinLat, -90, 90);
+            Assert.InRange(bounds.MaxLat, -90, 90);
+            Assert.InRange(bounds.MinLon, -180, 180);
+            Assert.InRange(bounds.MaxLon, -180, 180);
+
+            // The parallels converge towards the pole, so the same metric radius covers
+            // more of them the further north the circle sits.
+            var width = bounds.MaxLon - bounds.MinLon;
+            Assert.True(width > previousWidth, "width did not grow at " + latitude);
+            previousWidth = width;
+        }
+    }
+
+    [Fact]
+    public void Longitudinal_bounds_reach_the_meridians_tangent_to_the_circle()
+    {
+        // The widest meridians a circle touches are at asin(sin r / cos lat) from its
+        // centre, not the r / cos(lat) small-angle approximation, which understates them.
+        const double latitude = 80;
+        var radiusDeg = 100000 / (1852d * 60);
+        var bounds = new Circle(latitude, 20, 100000).GetBounds();
+
+        var expected =
+            Math.Asin(Math.Sin(radiusDeg * Math.PI / 180) / Math.Cos(latitude * Math.PI / 180))
+            * 180
+            / Math.PI;
+
+        Assert.Equal(20 - expected, bounds.MinLon, 9);
+        Assert.Equal(20 + expected, bounds.MaxLon, 9);
+        Assert.True(expected > radiusDeg / Math.Cos(latitude * Math.PI / 180));
+    }
+
     [Fact]
     public void Empty_circle_has_no_bounds()
     {

--- a/Geo.Tests/Gps/Serialization/GpxSerializerTests.cs
+++ b/Geo.Tests/Gps/Serialization/GpxSerializerTests.cs
@@ -113,6 +113,42 @@ public class GpxSerializerTests : SerializerTestFixtureBase
         Compare(gpx11, data, gpxData);
     }
 
+    [Theory]
+    [InlineData("nobody")] // no '@' to split on
+    [InlineData("@example.com")] // nothing before the '@'
+    [InlineData("ada@")] // nothing after it
+    public void Gpx11_serializes_an_author_email_it_cannot_split(string email)
+    {
+        // GPX 1.1 carries an address as a separate id and domain, so one that cannot be
+        // split into the two is left out - it must not take the whole document with it.
+        var data = new GpsData();
+        data.Metadata.Attribute(x => x.Author.Name, "Ada Lovelace");
+        data.Metadata.Attribute(x => x.Author.Email, email);
+
+        var gpx = new Gpx11Serializer().Serialize(data);
+
+        Assert.Contains("Ada Lovelace", gpx);
+        Assert.DoesNotContain("<email", gpx);
+    }
+
+    [Fact]
+    public void Gpx11_splits_an_author_email_at_its_first_at_sign()
+    {
+        var data = new GpsData();
+        data.Metadata.Attribute(x => x.Author.Email, "ada@example.com");
+
+        var gpx11 = new Gpx11Serializer();
+        var gpx = gpx11.Serialize(data);
+
+        Assert.Contains("id=\"ada\"", gpx);
+        Assert.Contains("domain=\"example.com\"", gpx);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(gpx));
+        var roundTripped = gpx11.DeSerialize(new StreamWrapper(stream));
+
+        Assert.Equal("ada@example.com", roundTripped.Metadata.Attribute(x => x.Author.Email));
+    }
+
     [Fact]
     public void Gpx11_route_without_route_points_is_parsed()
     {

--- a/Geo.Tests/IO/GeoJson/GeoJsonReaderWriterTests.cs
+++ b/Geo.Tests/IO/GeoJson/GeoJsonReaderWriterTests.cs
@@ -303,4 +303,22 @@ public class GeoJsonReaderWriterTests
 
         Assert.Null(feature.Geometry);
     }
+
+    [Theory]
+    // an unknown geometry type
+    [InlineData("{\"type\":\"Feature\",\"geometry\":{\"type\":\"Bogus\",\"coordinates\":[1,2]}}")]
+    // a known type whose coordinates are missing
+    [InlineData("{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\"}}")]
+    // a known type whose coordinates are the wrong shape
+    [InlineData(
+        "{\"type\":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":[1,2]}}"
+    )]
+    public void Feature_with_a_geometry_that_does_not_parse_does_not_parse(string json)
+    {
+        // A feature that carries a geometry it cannot read is malformed. Handing back a
+        // feature with a null geometry would make it indistinguishable from a genuinely
+        // unlocated one, silently losing whatever the document actually said.
+        Assert.False(new GeoJsonReader().TryRead(json, out _));
+        Assert.Throws<SerializationException>(() => new GeoJsonReader().Read(json));
+    }
 }

--- a/Geo.Tests/Measure/DistanceTests.cs
+++ b/Geo.Tests/Measure/DistanceTests.cs
@@ -19,7 +19,7 @@ public class DistanceTests
     [InlineData(1, DistanceUnit.M, 1)]
     [InlineData(1, DistanceUnit.Km, 1000)]
     [InlineData(1, DistanceUnit.Nm, 1852)]
-    [InlineData(1, DistanceUnit.Mile, 1609.34)]
+    [InlineData(1, DistanceUnit.Mile, 1609.344)]
     [InlineData(1, DistanceUnit.Ft, 0.3048)]
     public void Unit_constructor_converts_to_si_metres(
         double value,
@@ -37,7 +37,7 @@ public class DistanceTests
     [Theory]
     [InlineData(1000, DistanceUnit.Km, 1)]
     [InlineData(1852, DistanceUnit.Nm, 1)]
-    [InlineData(1609.34, DistanceUnit.Mile, 1)]
+    [InlineData(1609.344, DistanceUnit.Mile, 1)]
     [InlineData(0.3048, DistanceUnit.Ft, 1)]
     public void ConvertTo_expresses_the_value_in_the_requested_unit(
         double metres,

--- a/Geo.Tests/Measure/SpeedTests.cs
+++ b/Geo.Tests/Measure/SpeedTests.cs
@@ -17,8 +17,8 @@ public class SpeedTests
 
     [Theory]
     [InlineData(1, SpeedUnit.Ms, 1)]
-    [InlineData(1, SpeedUnit.Knots, 0.514444444)]
-    [InlineData(1, SpeedUnit.Kph, 0.277778)]
+    [InlineData(1, SpeedUnit.Knots, 1852d / 3600d)]
+    [InlineData(1, SpeedUnit.Kph, 1000d / 3600d)]
     [InlineData(1, SpeedUnit.Mph, 0.44704)]
     public void Unit_constructor_converts_to_si_metres_per_second(
         double value,
@@ -64,6 +64,22 @@ public class SpeedTests
 
         // 1 m/s is roughly 3.6 km/h.
         Assert.Equal(3.6, converted.Value, 1e-2);
+    }
+
+    [Theory]
+    [InlineData(10, SpeedUnit.Kph, 36)]
+    [InlineData(1, SpeedUnit.Kph, 3.6)]
+    [InlineData(1852d / 3600d, SpeedUnit.Knots, 1)]
+    [InlineData(1609.344 / 3600d, SpeedUnit.Mph, 1)]
+    public void ConvertTo_uses_the_exact_definition_of_the_unit(
+        double metresPerSecond,
+        SpeedUnit unit,
+        double expected
+    )
+    {
+        // The unit factors are exact ratios, not rounded decimals, so a round number of
+        // metres per second converts to a round number in the target unit.
+        Assert.Equal(expected, new Speed(metresPerSecond).ConvertTo(unit).Value, 1e-12);
     }
 
     [Fact]

--- a/Geo.Tests/SpatialEqualityTests.cs
+++ b/Geo.Tests/SpatialEqualityTests.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
 using Geo.Geometries;
+using Geo.Linq;
 using Xunit;
 
 namespace Geo.Tests;
@@ -12,6 +15,8 @@ namespace Geo.Tests;
 public class SpatialEqualityTests
 {
     private static readonly SpatialEqualityOptions All = new();
+    private static readonly SpatialEqualityOptions TwoD = new SpatialEqualityOptions().To2D();
+    private static readonly SpatialEqualityOptions ThreeD = new SpatialEqualityOptions().To3D();
 
     #region CoordinateZ
 
@@ -299,6 +304,86 @@ public class SpatialEqualityTests
 
         Assert.True(a.Equals2D(b));
         Assert.False(a.Equals3D(b));
+    }
+
+    #endregion
+
+    #region Comparisons across the coordinate types
+
+    // An ordinate that the options exclude has to be excluded from the comparison
+    // altogether, not merely from the value check: a 2D comparison that still insists on
+    // matching concrete types can never match a CoordinateZ against a Coordinate, which
+    // is precisely what Distinct2D and Spatial2DComparer exist to do - and their hash
+    // codes have always agreed that the two are the same 2D position.
+
+    public static TheoryData<Coordinate, Coordinate> SamePositionDifferentDimensions =>
+        new()
+        {
+            { new Coordinate(1, 2), new CoordinateZ(1, 2, 100) },
+            { new Coordinate(1, 2), new CoordinateM(1, 2, 7) },
+            { new Coordinate(1, 2), new CoordinateZM(1, 2, 100, 7) },
+            { new CoordinateZ(1, 2, 100), new CoordinateM(1, 2, 7) },
+            { new CoordinateZ(1, 2, 100), new CoordinateZM(1, 2, 500, 7) },
+            { new CoordinateM(1, 2, 7), new CoordinateZM(1, 2, 100, 99) },
+        };
+
+    [Theory]
+    [MemberData(nameof(SamePositionDifferentDimensions))]
+    public void Two_d_equality_ignores_elevation_and_measure_across_the_coordinate_types(
+        Coordinate a,
+        Coordinate b
+    )
+    {
+        Assert.True(a.Equals2D(b));
+        Assert.True(b.Equals2D(a));
+        Assert.Equal(a.GetHashCode(TwoD), b.GetHashCode(TwoD));
+    }
+
+    [Theory]
+    [MemberData(nameof(SamePositionDifferentDimensions))]
+    public void Default_equality_still_distinguishes_the_coordinate_types(
+        Coordinate a,
+        Coordinate b
+    )
+    {
+        Assert.False(a.Equals(b, All));
+        Assert.False(b.Equals(a, All));
+    }
+
+    [Fact]
+    public void Three_d_equality_compares_elevation_and_ignores_measure()
+    {
+        var z = new CoordinateZ(1, 2, 100);
+        var zm = new CoordinateZM(1, 2, 100, 7);
+
+        Assert.True(z.Equals3D(zm));
+        Assert.True(zm.Equals3D(z));
+        Assert.Equal(z.GetHashCode(ThreeD), zm.GetHashCode(ThreeD));
+
+        Assert.False(z.Equals3D(new CoordinateZM(1, 2, 999, 7)));
+        Assert.False(z.Equals3D(new Coordinate(1, 2)));
+    }
+
+    [Fact]
+    public void Distinct2D_collapses_a_coordinate_against_one_carrying_an_elevation()
+    {
+        var coordinates = new List<Coordinate>
+        {
+            new Coordinate(1, 2),
+            new CoordinateZ(1, 2, 100),
+            new CoordinateZM(1, 2, 200, 7),
+            new Coordinate(3, 4),
+        };
+
+        Assert.Equal(2, coordinates.Distinct2D().Count());
+    }
+
+    [Fact]
+    public void Points_of_different_dimensions_match_in_2d()
+    {
+        Assert.True(new Point(1, 2).Equals2D(new Point(1, 2, 100)));
+        Assert.True(new Point(1, 2, 100).Equals2D(new Point(1, 2)));
+        Assert.False(new Point(1, 2).Equals(new Point(1, 2, 100)));
     }
 
     #endregion

--- a/Geo/Coordinate.cs
+++ b/Geo/Coordinate.cs
@@ -47,6 +47,16 @@ public class Coordinate : SpatialObject, IPosition
 
     public virtual bool IsMeasured => false;
 
+    /// <summary>
+    /// The elevation this coordinate carries, or <c>null</c> when it carries none.
+    /// </summary>
+    internal virtual double? ElevationOrNull => null;
+
+    /// <summary>
+    /// The measure this coordinate carries, or <c>null</c> when it carries none.
+    /// </summary>
+    internal virtual double? MeasureOrNull => null;
+
     Coordinate IPosition.GetCoordinate()
     {
         return this;
@@ -160,16 +170,44 @@ public class Coordinate : SpatialObject, IPosition
 
     #region Equality methods
 
+    // Every coordinate type compares the same way, so the comparison lives here rather
+    // than being repeated (and drifting) in CoordinateZ/CoordinateM/CoordinateZM.
     public override bool Equals(object? obj, SpatialEqualityOptions options)
     {
         var other = obj as Coordinate;
 
-        if (ReferenceEquals(null, other))
+        return !ReferenceEquals(null, other)
+            && OrdinatesEqual(other, options)
+            && PositionEquals(other, options);
+    }
+
+    /// <summary>
+    /// Compares the elevation and the measure, each only when <paramref name="options" />
+    /// asks for it.
+    /// </summary>
+    /// <remarks>
+    /// An ordinate that is being compared has to be present on both sides or absent from
+    /// both, so under the default options a <see cref="CoordinateZ" /> is still not the
+    /// same as a plain <see cref="Coordinate" />. An ordinate that is <em>not</em> being
+    /// compared is ignored entirely, which is what lets a 2D comparison match a
+    /// <see cref="CoordinateZ" /> against a <see cref="Coordinate" /> at the same
+    /// position - exactly what <see cref="GetHashCode(SpatialEqualityOptions)" /> has
+    /// always done, and what <see cref="Linq.EnumerableExtensions.Distinct2D" /> and
+    /// <see cref="Linq.Spatial2DComparer{TSource}" /> need in order to work at all.
+    /// </remarks>
+    private bool OrdinatesEqual(Coordinate other, SpatialEqualityOptions options)
+    {
+        if (options.UseElevation && !Nullable.Equals(ElevationOrNull, other.ElevationOrNull))
             return false;
 
-        if (other.Is3D || other.IsMeasured)
+        if (options.UseM && !Nullable.Equals(MeasureOrNull, other.MeasureOrNull))
             return false;
 
+        return true;
+    }
+
+    private bool PositionEquals(Coordinate other, SpatialEqualityOptions options)
+    {
         if (Latitude.Equals(other.Latitude))
         {
             if (options.PoleCoordiantesAreEqual && (Latitude.Equals(90d) || Latitude.Equals(-90d)))

--- a/Geo/CoordinateM.cs
+++ b/Geo/CoordinateM.cs
@@ -19,40 +19,9 @@ public class CoordinateM : Coordinate, IsMeasured
 
     public double Measure { get; }
 
+    internal override double? MeasureOrNull => Measure;
+
     #region Equality methods
-
-    public override bool Equals(object? obj, SpatialEqualityOptions options)
-    {
-        var other = obj as Coordinate;
-
-        if (ReferenceEquals(null, other))
-            return false;
-
-        var other2 = other as CoordinateM;
-        if (ReferenceEquals(null, other2))
-            return false;
-
-        if (options.UseM && !Measure.Equals(other2.Measure))
-            return false;
-
-        if (Latitude.Equals(other.Latitude))
-        {
-            if (options.PoleCoordiantesAreEqual && (Latitude.Equals(90d) || Latitude.Equals(-90d)))
-                return true;
-
-            if (Longitude.Equals(other.Longitude))
-                return true;
-
-            if (options.AntiMeridianCoordinatesAreEqual)
-                if (
-                    (Longitude.Equals(180) && other.Longitude.Equals(-180))
-                    || (Longitude.Equals(-180) && other.Longitude.Equals(180))
-                )
-                    return true;
-        }
-
-        return false;
-    }
 
     public override bool Equals(object? obj)
     {

--- a/Geo/CoordinateZ.cs
+++ b/Geo/CoordinateZ.cs
@@ -19,40 +19,9 @@ public class CoordinateZ : Coordinate, Is3D
 
     public double Elevation { get; }
 
+    internal override double? ElevationOrNull => Elevation;
+
     #region Equality methods
-
-    public override bool Equals(object? obj, SpatialEqualityOptions options)
-    {
-        var other = obj as Coordinate;
-
-        if (ReferenceEquals(null, other))
-            return false;
-
-        var other2 = other as CoordinateZ;
-        if (ReferenceEquals(null, other2))
-            return false;
-
-        if (options.UseElevation && !Elevation.Equals(other2.Elevation))
-            return false;
-
-        if (Latitude.Equals(other.Latitude))
-        {
-            if (options.PoleCoordiantesAreEqual && (Latitude.Equals(90d) || Latitude.Equals(-90d)))
-                return true;
-
-            if (Longitude.Equals(other.Longitude))
-                return true;
-
-            if (options.AntiMeridianCoordinatesAreEqual)
-                if (
-                    (Longitude.Equals(180) && other.Longitude.Equals(-180))
-                    || (Longitude.Equals(-180) && other.Longitude.Equals(180))
-                )
-                    return true;
-        }
-
-        return false;
-    }
 
     public override bool Equals(object? obj)
     {

--- a/Geo/CoordinateZM.cs
+++ b/Geo/CoordinateZM.cs
@@ -26,43 +26,11 @@ public class CoordinateZM : Coordinate, Is3D, IsMeasured
     public double Elevation { get; }
     public double Measure { get; }
 
+    internal override double? ElevationOrNull => Elevation;
+
+    internal override double? MeasureOrNull => Measure;
+
     #region Equality methods
-
-    public override bool Equals(object? obj, SpatialEqualityOptions options)
-    {
-        var other = obj as Coordinate;
-
-        if (ReferenceEquals(null, other))
-            return false;
-
-        var other2 = other as CoordinateZM;
-        if (ReferenceEquals(null, other2))
-            return false;
-
-        if (options.UseElevation && !Elevation.Equals(other2.Elevation))
-            return false;
-
-        if (options.UseM && !Measure.Equals(other2.Measure))
-            return false;
-
-        if (Latitude.Equals(other.Latitude))
-        {
-            if (options.PoleCoordiantesAreEqual && (Latitude.Equals(90d) || Latitude.Equals(-90d)))
-                return true;
-
-            if (Longitude.Equals(other.Longitude))
-                return true;
-
-            if (options.AntiMeridianCoordinatesAreEqual)
-                if (
-                    (Longitude.Equals(180) && other.Longitude.Equals(-180))
-                    || (Longitude.Equals(-180) && other.Longitude.Equals(180))
-                )
-                    return true;
-        }
-
-        return false;
-    }
 
     public override bool Equals(object? obj)
     {

--- a/Geo/Geomagnetism/GeomagnetismResult.cs
+++ b/Geo/Geomagnetism/GeomagnetismResult.cs
@@ -10,9 +10,11 @@ public class GeomagnetismResult
     {
         Date = date;
         Coordinate = coordinate;
-        if (Math.Abs(x - 0.0) < double.Epsilon * 2 || Math.Abs(y - 0.0) < double.Epsilon * 2)
-            return;
 
+        // No guard against a zero component is needed: Math.Atan2 is defined for a zero
+        // argument (and for both being zero), so the angles come out at 0 on their own.
+        // Bailing out instead threw away the components that were fine - a field pointing
+        // straight down, with x and y at zero, reported no field at all.
         X = x;
         Y = y;
         Z = z;

--- a/Geo/Geometries/Circle.cs
+++ b/Geo/Geometries/Circle.cs
@@ -56,21 +56,38 @@ public class Circle : Geometry, ISurface
             return null;
 
         var center = Center;
-        var latitudinalRadiusDeg = Radius / (Constants.NauticalMile * 60);
-        // A degree of longitude spans metresPerDegree * cos(latitude) metres, so the
-        // parallels converge towards the poles. Converting a fixed metric radius into
-        // degrees of longitude therefore divides by cos(latitude): the east-west extent
-        // of the box grows with latitude (it equals the latitudinal extent at the
-        // equator and widens beyond it), rather than shrinking.
-        var longditudinalRadiusDeg =
-            Radius / (Constants.NauticalMile * 60) / Math.Cos(center.Latitude.ToRadians());
+        var latitudinalRadiusDeg = Math.Abs(Radius) / (Constants.NauticalMile * 60);
 
-        return new Envelope(
-            center.Latitude - latitudinalRadiusDeg,
-            center.Longitude - longditudinalRadiusDeg,
-            center.Latitude + latitudinalRadiusDeg,
-            center.Longitude + longditudinalRadiusDeg
-        );
+        var minLat = center.Latitude - latitudinalRadiusDeg;
+        var maxLat = center.Latitude + latitudinalRadiusDeg;
+
+        // A circle that reaches a pole has no bounded longitude span - every meridian
+        // runs through it - and its latitudes run past the pole, which is not a position
+        // any coordinate can hold. Clamp to the pole and span the whole range instead of
+        // handing back an envelope no coordinate could ever sit inside.
+        if (minLat <= -90 || maxLat >= 90)
+            return new Envelope(Math.Max(minLat, -90), -180, Math.Min(maxLat, 90), 180);
+
+        // A degree of longitude spans metresPerDegree * cos(latitude) metres, so the
+        // parallels converge towards the poles and the east-west extent of the box grows
+        // with latitude. The widest meridians the circle touches are the ones tangent to
+        // it, at asin(sin r / cos lat) from the centre - not r / cos(lat), which is only
+        // its small-angle approximation and understates the box near the poles.
+        var longitudinalRadiusDeg = Math.Asin(
+                Math.Sin(latitudinalRadiusDeg.ToRadians()) / Math.Cos(center.Latitude.ToRadians())
+            )
+            .ToDegrees();
+
+        var minLon = center.Longitude - longitudinalRadiusDeg;
+        var maxLon = center.Longitude + longitudinalRadiusDeg;
+
+        // An envelope's longitudes run west to east, so it cannot describe a box that
+        // wraps across the anti-meridian. A circle that does gets the whole range, which
+        // still contains it, rather than a box that silently excludes half of it.
+        if (minLon < -180 || maxLon > 180)
+            return new Envelope(minLat, -180, maxLat, 180);
+
+        return new Envelope(minLat, minLon, maxLat, maxLon);
     }
 
     public Area GetArea()

--- a/Geo/Gps/Serialization/Gpx11Serializer.cs
+++ b/Geo/Gps/Serialization/Gpx11Serializer.cs
@@ -158,12 +158,24 @@ public class Gpx11Serializer : GpsXmlSerializer<GpxFile>
             x => x.Author.Email,
             (gpx, s) =>
             {
+                // GPX 1.1 splits an address into an id and a domain, so one that has no
+                // '@' to split on - or nothing on either side of it - cannot be written
+                // at all. Leave the element out rather than indexing past the end of the
+                // split and taking the whole serialization down with it.
+                var at = s.IndexOf('@');
+                if (at <= 0 || at == s.Length - 1)
+                    return;
+
                 if (gpx.metadata == null)
                     gpx.metadata = new GpxMetadata();
                 if (gpx.metadata.author == null)
                     gpx.metadata.author = new GpxPerson();
-                var parts = s.Split('@');
-                gpx.metadata.author.email = new GpxEmail { id = parts[0], domain = parts[1] };
+
+                gpx.metadata.author.email = new GpxEmail
+                {
+                    id = s.Substring(0, at),
+                    domain = s.Substring(at + 1),
+                };
             }
         );
 

--- a/Geo/IO/GeoJson/GeoJsonReader.cs
+++ b/Geo/IO/GeoJson/GeoJsonReader.cs
@@ -120,19 +120,19 @@ public class GeoJsonReader
             Dictionary<string, object?>? pr = null;
 
             // "geometry" may legitimately be null (an unlocated feature). Anything
-            // else that is not a JSON object is malformed: fail the parse rather
-            // than letting the cast throw out of a TryParse, or silently discarding
-            // the value.
+            // else that does not parse as a geometry is malformed - whether it is not
+            // a JSON object at all or an object of an unknown type - so fail the parse
+            // rather than letting the cast throw out of a TryParse, or handing back a
+            // feature that has quietly lost the geometry it was given.
             if (obj.TryGetValue("geometry", out var geometry) && geometry != null)
-            {
-                if (!(geometry is JsonObject geometryObject))
+                if (
+                    !(geometry is JsonObject geometryObject)
+                    || !TryParseGeometry(geometryObject, out geo)
+                )
                 {
                     result = null;
                     return false;
                 }
-
-                TryParseGeometry(geometryObject, out geo);
-            }
 
             if (obj.TryGetValue("properties", out var prop) && prop is JsonObject)
             {

--- a/Geo/Measure/AreaUnit.cs
+++ b/Geo/Measure/AreaUnit.cs
@@ -11,7 +11,7 @@ public enum AreaUnit
     [Unit("km²", 1000 * 1000)]
     Km = 2,
 
-    [Unit("mi²", 1609.34 * 1609.34)]
+    [Unit("mi²", 1609.344 * 1609.344)]
     Mile = 3,
 
     [Unit("ft²", 0.3048 * 0.3048)]

--- a/Geo/Measure/DistanceUnit.cs
+++ b/Geo/Measure/DistanceUnit.cs
@@ -11,7 +11,9 @@ public enum DistanceUnit
     [Unit("km", 1000)]
     Km = 2,
 
-    [Unit("mi", 1609.34)]
+    // The international mile is exactly 1609.344 m; the rounded 1609.34 used before
+    // left every mile 4 mm short.
+    [Unit("mi", 1609.344)]
     Mile = 3,
 
     [Unit("ft", 0.3048)]

--- a/Geo/Measure/SpeedUnit.cs
+++ b/Geo/Measure/SpeedUnit.cs
@@ -5,10 +5,13 @@ public enum SpeedUnit
     [Unit("m/s", 1)]
     Ms = 0,
 
-    [Unit("knots", 0.514444444)]
+    // The factors are written as the exact ratios that define the units rather than as
+    // rounded decimals: 0.277778 m/s is not a kilometre per hour, and converting 10 m/s
+    // through it gave 35.99997 kph instead of 36.
+    [Unit("knots", 1852d / 3600d)]
     Knots = 1,
 
-    [Unit("kph", 0.277778)]
+    [Unit("kph", 1000d / 3600d)]
     Kph = 2,
 
     [Unit("mph", 0.44704)]


### PR DESCRIPTION
Circle.GetBounds returned an envelope no coordinate could sit inside once the
circle came near a pole: a 100 km circle at 89.5N reported a maximum latitude of
90.4, and at 89.9N a longitude span of +/-515 degrees (at the pole itself,
+/-1.5e16). Clamp to the pole and span every longitude when the circle reaches
one, do the same when it wraps the anti-meridian - an envelope runs west to east
and cannot describe a wrapped box - and take the east-west extent from the
meridians actually tangent to the circle, asin(sin r / cos lat), rather than its
small-angle approximation r / cos(lat).

Coordinate equality contradicted its own hash code whenever the elevation or the
measure was excluded from the comparison. Every coordinate type hashes to the
same value in 2D, but each Equals also demanded the other side be its own
concrete type, so Equals2D was false for a Coordinate against a CoordinateZ at
the same position - and Distinct2D and Spatial2DComparer, whose whole purpose is
to collapse exactly that pair, kept both. Compare the ordinates the options ask
for and ignore the ones they do not, which is what the hash codes have always
done. The comparison is now written once on Coordinate instead of four times.

A GeoJSON feature carrying a geometry that could not be read - an unknown type,
absent coordinates, coordinates of the wrong shape - parsed into a feature with
a null geometry, indistinguishable from a genuinely unlocated one. Fail the
parse, as the reader already does for a geometry that is not an object at all.

Serializing GPX 1.1 metadata whose author email had no '@' threw
IndexOutOfRangeException out of the middle of the document. Leave the element
out when the address cannot be split into an id and a domain.

Unit conversion factors were rounded decimals rather than the exact ratios that
define the units, so 10 m/s converted to 35.99997 kph instead of 36 and every
mile came out 4 mm short of the international 1609.344 m.

GeomagnetismResult discarded the entire field - including the vertical
component - whenever x or y was zero. Math.Atan2 is defined for a zero argument,
so no such guard is needed; a field pointing straight down reported no field.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NvDD3umHZ5T3J3TF3mmDo