### PR TITLE
Fix three geodesy bugs: circle bounds, direct back azimuth, and datum-blind areas

### DIFF
--- a/Geo.Tests/Geodesy/SphereCalculatorTests.cs
+++ b/Geo.Tests/Geodesy/SphereCalculatorTests.cs
@@ -144,4 +144,294 @@ public class SphereCalculatorTests
 
         Assert.Equal(expected, result.SiValue, expected * 1e-9);
     }
+
+    #region Orthodromic (great circle) lines
+
+    private static readonly SphereCalculator Calculator = new(Radius);
+
+    /// <summary>The signed difference between two bearings, in degrees.</summary>
+    private static double BearingDelta(double a, double b) => (a - b + 540) % 360 - 180;
+
+    [Theory]
+    // A quarter of the equator, and the equator to the pole: both a quarter great circle.
+    [InlineData(0, 0, 0, 90)]
+    [InlineData(0, 0, 90, 0)]
+    public void Orthodromic_quarter_turns_are_a_quarter_of_a_great_circle(
+        double lat1,
+        double lon1,
+        double lat2,
+        double lon2
+    )
+    {
+        var line = Calculator.CalculateOrthodromicLine(
+            new Coordinate(lat1, lon1),
+            new Coordinate(lat2, lon2)
+        );
+
+        var expected = Math.PI * Radius / 2;
+        Assert.Equal(expected, line.Distance.SiValue, expected * 1e-12);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0, 10, 90, 270)] // due east along the equator
+    [InlineData(0, 10, 0, 0, 270, 90)] // due west along the equator
+    [InlineData(0, 0, 10, 0, 0, 180)] // due north along a meridian
+    [InlineData(10, 0, 0, 0, 180, 0)] // due south along a meridian
+    public void Orthodromic_bearings_are_degrees_from_north(
+        double lat1,
+        double lon1,
+        double lat2,
+        double lon2,
+        double expectedForward,
+        double expectedBack
+    )
+    {
+        var line = Calculator.CalculateOrthodromicLine(
+            new Coordinate(lat1, lon1),
+            new Coordinate(lat2, lon2)
+        );
+
+        Assert.Equal(0, BearingDelta(line.Bearing12, expectedForward), 1e-9);
+        Assert.Equal(0, BearingDelta(line.Bearing21, expectedBack), 1e-9);
+    }
+
+    [Theory]
+    [InlineData(-60)]
+    [InlineData(0)]
+    [InlineData(51.5)]
+    [InlineData(80)]
+    public void Orthodromic_direct_and_inverse_are_inverses_of_each_other(double latitude)
+    {
+        foreach (var heading in new[] { 0d, 37, 90, 143, 180, 231, 270, 322 })
+        foreach (var distance in new[] { 1000d, 100000, 3000000 })
+        {
+            var start = new Coordinate(latitude, 10);
+            var direct = Calculator.CalculateOrthodromicLine(start, heading, distance);
+            var inverse = Calculator.CalculateOrthodromicLine(start, direct.Coordinate2);
+
+            Assert.NotNull(inverse);
+            Assert.Equal(distance, inverse.Distance.SiValue, distance * 1e-9);
+            Assert.Equal(0, BearingDelta(inverse.Bearing12, direct.Bearing12), 1e-6);
+            Assert.Equal(0, BearingDelta(inverse.Bearing21, direct.Bearing21), 1e-6);
+        }
+    }
+
+    [Fact]
+    public void Orthodromic_direct_solution_carries_on_over_the_pole()
+    {
+        // 2000 km north of 80N is about 18 degrees away, so it runs over the pole and
+        // back down the far side: the latitude folds back to 180 - (80 + 18) on the
+        // opposite meridian, and the way home is due north again.
+        const double distance = 2000000;
+        var line = Calculator.CalculateOrthodromicLine(new Coordinate(80, 0), 0, distance);
+
+        var expected = 180 - (80 + distance / Radius * 180 / Math.PI);
+
+        Assert.Equal(expected, line.Coordinate2.Latitude, 1e-9);
+        Assert.Equal(180, Math.Abs(line.Coordinate2.Longitude), 1e-9);
+        Assert.Equal(0, BearingDelta(line.Bearing21, 0), 1e-9);
+    }
+
+    [Fact]
+    public void Orthodromic_direct_solution_wraps_across_the_anti_meridian()
+    {
+        const double distance = 500000;
+        var line = Calculator.CalculateOrthodromicLine(new Coordinate(0, 179), 90, distance);
+
+        // 500 km east of 179E is past the anti-meridian, so it comes back as a western
+        // longitude rather than one Coordinate would refuse to hold.
+        var expected = 179 + distance / Radius * 180 / Math.PI - 360;
+
+        Assert.InRange(line.Coordinate2.Longitude, -180, 180);
+        Assert.Equal(expected, line.Coordinate2.Longitude, 1e-9);
+    }
+
+    [Fact]
+    public void Orthodromic_direct_solution_lands_exactly_on_the_pole()
+    {
+        var line = Calculator.CalculateOrthodromicLine(
+            new Coordinate(0, 0),
+            0,
+            Math.PI * Radius / 2
+        );
+
+        Assert.Equal(90, line.Coordinate2.Latitude);
+    }
+
+    [Fact]
+    public void Orthodromic_line_between_coincident_points_is_null()
+    {
+        Assert.Null(
+            Calculator.CalculateOrthodromicLine(new Coordinate(1, 2), new Coordinate(1, 2))
+        );
+    }
+
+    #endregion
+
+    #region Loxodromic (rhumb) lines
+
+    [Fact]
+    public void Loxodromic_line_along_a_parallel_follows_the_parallel()
+    {
+        var line = Calculator.CalculateLoxodromicLine(
+            new Coordinate(60, 0),
+            new Coordinate(60, 10)
+        );
+
+        // Due east, the rhumb line is the parallel itself: R * cos(lat) * dLon.
+        var expected = Radius * Math.Cos(60 * Math.PI / 180) * (10 * Math.PI / 180);
+
+        Assert.Equal(expected, line.Distance.SiValue, expected * 1e-9);
+        Assert.Equal(90, line.Bearing12, 1e-9);
+        Assert.Equal(270, line.Bearing21, 1e-9);
+    }
+
+    [Fact]
+    public void Loxodromic_line_along_a_meridian_follows_the_meridian()
+    {
+        var line = Calculator.CalculateLoxodromicLine(new Coordinate(0, 5), new Coordinate(10, 5));
+
+        var expected = Radius * (10 * Math.PI / 180);
+
+        Assert.Equal(expected, line.Distance.SiValue, expected * 1e-9);
+        Assert.Equal(0, line.Bearing12, 1e-9);
+        Assert.Equal(180, line.Bearing21, 1e-9);
+    }
+
+    [Fact]
+    public void Loxodromic_course_is_the_slope_on_a_mercator_chart()
+    {
+        var line = Calculator.CalculateLoxodromicLine(new Coordinate(0, 0), new Coordinate(10, 10));
+
+        // A rhumb line is straight on a Mercator chart, so its course is the ratio of the
+        // longitude difference to the stretched latitude difference.
+        var expected =
+            Math.Atan2(10 * Math.PI / 180, Math.Log(Math.Tan(Math.PI / 4 + 5 * Math.PI / 180)))
+            * 180
+            / Math.PI;
+
+        Assert.Equal(expected, line.Bearing12, 1e-9);
+        // The bearing never changes along a rhumb line, so the return leg is its reciprocal.
+        Assert.Equal(0, BearingDelta(line.Bearing21, line.Bearing12 + 180), 1e-9);
+        // ... and it is longer than the great circle between the same two points.
+        Assert.True(
+            line.Distance
+                > Calculator
+                    .CalculateOrthodromicLine(new Coordinate(0, 0), new Coordinate(10, 10))
+                    .Distance
+        );
+    }
+
+    [Fact]
+    public void Loxodromic_line_between_coincident_points_is_null()
+    {
+        Assert.Null(Calculator.CalculateLoxodromicLine(new Coordinate(1, 2), new Coordinate(1, 2)));
+    }
+
+    #endregion
+
+    #region Meridional measures and sequence length
+
+    [Theory]
+    [InlineData(25)]
+    [InlineData(-25)]
+    [InlineData(0)]
+    public void Meridional_distance_is_the_arc_from_the_equator(double latitude)
+    {
+        // A sphere's meridians are circles of a single radius, so the arc is R * latitude.
+        var expected = Radius * latitude * Math.PI / 180;
+
+        Assert.Equal(expected, Calculator.CalculateMeridionalDistance(latitude), 1e-6);
+    }
+
+    [Fact]
+    public void Meridional_parts_are_the_mercator_ordinate_in_nautical_miles()
+    {
+        var expected = Radius * Math.Log(Math.Tan(Math.PI / 4 + 25 * Math.PI / 360)) / 1852;
+
+        Assert.Equal(expected, Calculator.CalculateMeridionalParts(25), 1e-6);
+        // Mercator is symmetric about the equator.
+        Assert.Equal(-expected, Calculator.CalculateMeridionalParts(-25), 1e-6);
+        Assert.Equal(0, Calculator.CalculateMeridionalParts(0), 1e-12);
+    }
+
+    [Fact]
+    public void Length_of_a_sequence_is_the_sum_of_its_legs()
+    {
+        var first = new Coordinate(0, 0);
+        var second = new Coordinate(0, 10);
+        var third = new Coordinate(10, 10);
+
+        var expected =
+            Calculator.CalculateOrthodromicLine(first, second).Distance.SiValue
+            + Calculator.CalculateOrthodromicLine(second, third).Distance.SiValue;
+
+        var length = Calculator.CalculateLength(new CoordinateSequence(first, second, third));
+
+        Assert.Equal(expected, length.SiValue, expected * 1e-9);
+    }
+
+    [Fact]
+    public void Length_of_a_sequence_with_nothing_to_measure_is_zero()
+    {
+        Assert.Equal(0, Calculator.CalculateLength(new CoordinateSequence()).SiValue);
+        Assert.Equal(
+            0,
+            Calculator.CalculateLength(new CoordinateSequence(new Coordinate(1, 2))).SiValue
+        );
+        // Repeated coordinates contribute nothing rather than faulting.
+        Assert.Equal(
+            0,
+            Calculator
+                .CalculateLength(new CoordinateSequence(new Coordinate(1, 2), new Coordinate(1, 2)))
+                .SiValue
+        );
+    }
+
+    #endregion
+
+    [Theory]
+    [InlineData(0, 0, 10, 10)]
+    [InlineData(51.5, -0.1, 48.85, 2.35)]
+    [InlineData(-33.9, 151.2, 35.7, 139.7)]
+    public void Sphere_and_spheroid_agree_to_within_a_percent(
+        double lat1,
+        double lon1,
+        double lat2,
+        double lon2
+    )
+    {
+        // The sphere is an approximation of the spheroid, not a different notion of
+        // distance: the two must land in the same place.
+        var a = new Coordinate(lat1, lon1);
+        var b = new Coordinate(lat2, lon2);
+        var spheroid = new SpheroidCalculator(Spheroid.Wgs84);
+
+        var sphereGreatCircle = Calculator.CalculateOrthodromicLine(a, b);
+        var spheroidGreatCircle = spheroid.CalculateOrthodromicLine(a, b);
+        var sphereRhumb = Calculator.CalculateLoxodromicLine(a, b);
+        var spheroidRhumb = spheroid.CalculateLoxodromicLine(a, b);
+
+        Assert.Equal(
+            spheroidGreatCircle.Distance.SiValue,
+            sphereGreatCircle.Distance.SiValue,
+            spheroidGreatCircle.Distance.SiValue * 0.01
+        );
+        Assert.Equal(
+            spheroidRhumb.Distance.SiValue,
+            sphereRhumb.Distance.SiValue,
+            spheroidRhumb.Distance.SiValue * 0.01
+        );
+        Assert.Equal(
+            0,
+            BearingDelta(sphereGreatCircle.Bearing12, spheroidGreatCircle.Bearing12),
+            0.5
+        );
+        Assert.Equal(
+            0,
+            BearingDelta(sphereGreatCircle.Bearing21, spheroidGreatCircle.Bearing21),
+            0.5
+        );
+        Assert.Equal(0, BearingDelta(sphereRhumb.Bearing12, spheroidRhumb.Bearing12), 0.5);
+    }
 }

--- a/Geo.Tests/Geodesy/SpheroidCalculatorTests.cs
+++ b/Geo.Tests/Geodesy/SpheroidCalculatorTests.cs
@@ -131,4 +131,35 @@ public class SpheroidCalculatorTests
         Assert.Equal(bearing12, result.Bearing12, Millionth);
         Assert.Equal(bearing21, result.Bearing21, Millionth);
     }
+
+    [Fact]
+    public void Direct_solution_reports_the_back_azimuth_in_degrees()
+    {
+        // Setting off due east from the equator, the way back is due west. The back
+        // azimuth used to be left in radians, so this returned 4.712389 - a number small
+        // enough to pass for a bearing, which is exactly why it went unnoticed.
+        var calculator = new SpheroidCalculator(Spheroid.Wgs84);
+
+        var result = calculator.CalculateOrthodromicLine(new Point(0, 0), 90, 100000);
+
+        Assert.Equal(270, result.Bearing21, Millionth);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(45)]
+    [InlineData(90)]
+    [InlineData(135)]
+    [InlineData(270)]
+    public void Direct_and_inverse_solutions_agree_on_both_bearings(double heading)
+    {
+        var calculator = new SpheroidCalculator(Spheroid.Wgs84);
+        var start = new Point(51.5, -0.1);
+
+        var direct = calculator.CalculateOrthodromicLine(start, heading, 100000);
+        var inverse = calculator.CalculateOrthodromicLine(start, direct.Coordinate2);
+
+        Assert.Equal(direct.Bearing12, inverse.Bearing12, Millionth);
+        Assert.Equal(direct.Bearing21, inverse.Bearing21, Millionth);
+    }
 }

--- a/Geo.Tests/Geodesy/SpheroidCalculatorTests.cs
+++ b/Geo.Tests/Geodesy/SpheroidCalculatorTests.cs
@@ -1,4 +1,5 @@
-﻿using Geo.Geodesy;
+﻿using System;
+using Geo.Geodesy;
 using Geo.Geometries;
 using Geo.Measure;
 using Xunit;
@@ -131,6 +132,151 @@ public class SpheroidCalculatorTests
         Assert.Equal(bearing12, result.Bearing12, Millionth);
         Assert.Equal(bearing21, result.Bearing21, Millionth);
     }
+
+    #region Areas and lengths answer for the spheroid they were given
+
+    // These used to be handed to a hardcoded sphere of the WGS-84 mean radius, so the
+    // Spheroid passed to the constructor made no difference to any of them: a planet half
+    // the size returned bit-identical areas.
+
+    [Fact]
+    public void Envelope_area_of_the_whole_world_is_the_spheroids_surface_area()
+    {
+        // 2*pi*a^2 + pi*(b^2/e)*ln((1+e)/(1-e)), the closed form for an oblate spheroid.
+        var spheroid = Spheroid.Wgs84;
+        var e = spheroid.Eccentricity;
+        var b = spheroid.PolarAxis;
+        var expected =
+            2 * Math.PI * spheroid.EquatorialAxis * spheroid.EquatorialAxis
+            + Math.PI * (b * b / e) * Math.Log((1 + e) / (1 - e));
+
+        var area = new SpheroidCalculator(spheroid)
+            .CalculateArea(new Envelope(-90, -180, 90, 180))
+            .SiValue;
+
+        Assert.Equal(expected, area, expected * 1e-12);
+    }
+
+    [Fact]
+    public void Envelope_perimeter_of_the_whole_world_is_the_meridian_circumference()
+    {
+        // North pole to south pole and back: the sides are the whole meridian, and the
+        // parallels at the poles have no length at all.
+        var calculator = new SpheroidCalculator(Spheroid.Wgs84);
+
+        var expected = 4 * calculator.CalculateMeridionalDistance(90);
+        var perimeter = calculator.CalculateLength(new Envelope(-90, -180, 90, 180)).SiValue;
+
+        Assert.Equal(expected, perimeter, expected * 1e-12);
+    }
+
+    [Theory]
+    [InlineData(0, 10)]
+    [InlineData(40, 50)]
+    [InlineData(-60, -50)]
+    [InlineData(80, 89)]
+    public void Ring_area_around_a_box_matches_the_envelopes_own_area(double minLat, double maxLat)
+    {
+        // Two independent routes to the same number - the zone formula and the ring
+        // formula with authalic latitudes - which must agree.
+        var calculator = new SpheroidCalculator(Spheroid.Wgs84);
+
+        var envelope = calculator.CalculateArea(new Envelope(minLat, 0, maxLat, 10)).SiValue;
+        var ring = calculator
+            .CalculateArea(
+                new CoordinateSequence(
+                    new Coordinate(minLat, 0),
+                    new Coordinate(minLat, 10),
+                    new Coordinate(maxLat, 10),
+                    new Coordinate(maxLat, 0),
+                    new Coordinate(minLat, 0)
+                )
+            )
+            .SiValue;
+
+        Assert.Equal(envelope, ring, envelope * 1e-12);
+    }
+
+    [Fact]
+    public void A_smaller_planet_has_proportionally_smaller_areas_and_lengths()
+    {
+        var full = new SpheroidCalculator(new Spheroid("full", 6378137, 298.257223563));
+        var half = new SpheroidCalculator(new Spheroid("half", 6378137d / 2, 298.257223563));
+        var envelope = new Envelope(0, 0, 10, 10);
+        var ring = new CoordinateSequence(
+            new Coordinate(0, 0),
+            new Coordinate(0, 10),
+            new Coordinate(10, 10),
+            new Coordinate(10, 0),
+            new Coordinate(0, 0)
+        );
+
+        // Area goes with the square of the radius, length with the radius itself.
+        Assert.Equal(
+            full.CalculateArea(envelope).SiValue / 4,
+            half.CalculateArea(envelope).SiValue,
+            full.CalculateArea(envelope).SiValue * 1e-12
+        );
+        Assert.Equal(
+            full.CalculateArea(ring).SiValue / 4,
+            half.CalculateArea(ring).SiValue,
+            full.CalculateArea(ring).SiValue * 1e-12
+        );
+        Assert.Equal(
+            full.CalculateLength(envelope).SiValue / 2,
+            half.CalculateLength(envelope).SiValue,
+            full.CalculateLength(envelope).SiValue * 1e-12
+        );
+    }
+
+    [Fact]
+    public void Different_datums_give_different_answers()
+    {
+        var envelope = new Envelope(0, 0, 10, 10);
+        var wgs84 = new SpheroidCalculator(Spheroid.Wgs84);
+        var clarke = new SpheroidCalculator(Spheroid.Clarke1866);
+        var international = new SpheroidCalculator(Spheroid.International1924);
+
+        Assert.NotEqual(
+            wgs84.CalculateArea(envelope).SiValue,
+            clarke.CalculateArea(envelope).SiValue
+        );
+        Assert.NotEqual(
+            wgs84.CalculateArea(envelope).SiValue,
+            international.CalculateArea(envelope).SiValue
+        );
+        Assert.NotEqual(
+            wgs84.CalculateLength(envelope).SiValue,
+            clarke.CalculateLength(envelope).SiValue
+        );
+
+        // ... but they are all the same planet, so only just.
+        Assert.Equal(
+            wgs84.CalculateArea(envelope).SiValue,
+            clarke.CalculateArea(envelope).SiValue,
+            wgs84.CalculateArea(envelope).SiValue * 0.001
+        );
+    }
+
+    [Fact]
+    public void An_envelope_with_no_extent_encloses_nothing()
+    {
+        var calculator = new SpheroidCalculator(Spheroid.Wgs84);
+
+        foreach (var latitude in new[] { -90d, -45, 0, 45, 90 })
+        {
+            Assert.Equal(
+                0,
+                calculator.CalculateArea(new Envelope(latitude, 5, latitude, 5)).SiValue
+            );
+            Assert.Equal(
+                0,
+                calculator.CalculateArea(new Envelope(latitude, 0, latitude, 10)).SiValue
+            );
+        }
+    }
+
+    #endregion
 
     [Fact]
     public void Direct_solution_reports_the_back_azimuth_in_degrees()

--- a/Geo.Tests/Geodesy/SpheroidTests.cs
+++ b/Geo.Tests/Geodesy/SpheroidTests.cs
@@ -65,4 +65,41 @@ public class SpheroidTests
         Assert.Equal(Spheroid.Wgs84.Name, Spheroid.Default.Name);
         Assert.Equal(Spheroid.Wgs84.EquatorialAxis, Spheroid.Default.EquatorialAxis);
     }
+
+    [Fact]
+    public void Authalic_radius_is_the_published_value()
+    {
+        // The equal-area radius of WGS-84 is a published constant (R2 in NIMA TR8350.2).
+        Assert.Equal(6371007.181, Spheroid.Wgs84.AuthalicRadius, 1e-3);
+    }
+
+    [Fact]
+    public void Authalic_radius_of_a_sphere_is_its_own_radius()
+    {
+        var sphere = new Spheroid("Sphere", 6371000d, double.PositiveInfinity);
+
+        Assert.Equal(6371000d, sphere.AuthalicRadius, 1e-6);
+    }
+
+    [Theory]
+    [InlineData(298.257223563)]
+    [InlineData(297)]
+    [InlineData(294.9786982)]
+    [InlineData(50)]
+    public void Authalic_radius_lies_between_the_two_axes(double inverseFlattening)
+    {
+        // An equal-area sphere has to sit between the flattened and unflattened extremes.
+        var spheroid = new Spheroid("test", 6378137d, inverseFlattening);
+
+        Assert.InRange(spheroid.AuthalicRadius, spheroid.PolarAxis, spheroid.EquatorialAxis);
+    }
+
+    [Fact]
+    public void Authalic_radius_scales_with_the_spheroid()
+    {
+        var full = new Spheroid("full", 6378137d, 298.257223563d);
+        var half = new Spheroid("half", 6378137d / 2, 298.257223563d);
+
+        Assert.Equal(full.AuthalicRadius / 2, half.AuthalicRadius, 1e-6);
+    }
 }

--- a/Geo.Tests/Geometries/CircleTests.cs
+++ b/Geo.Tests/Geometries/CircleTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using Geo.Geodesy;
 using Geo.Geometries;
 using Xunit;
 
@@ -6,16 +8,21 @@ namespace Geo.Tests.Geometries;
 
 public class CircleTests
 {
+    // A 111 km arc subtends a little over a degree on WGS-84 - 1.00385 degrees, since
+    // the meridian it runs along curves with a radius of 6335439 m near the equator, not
+    // the 6366707 m of the sphere on which a nautical mile is an arcminute. The boxes
+    // below are therefore a shade over two (and four) degrees rather than a shade under.
+
     [Fact]
     public void AnEquatorialCircleWith_111000M_RadiusShouldBeAboutTwoDegreesTall()
     {
         var circle = new Circle(0, 20, 111000);
         var bounds = circle.GetBounds();
 
-        var minLatError = Distance(-1, bounds.MinLat);
+        var minLatError = Distance(-1.0039, bounds.MinLat);
         Assert.True(minLatError <= 0.002);
 
-        var maxLatError = Distance(+1, bounds.MaxLat);
+        var maxLatError = Distance(+1.0039, bounds.MaxLat);
         Assert.True(maxLatError <= 0.002);
     }
 
@@ -25,10 +32,10 @@ public class CircleTests
         var circle = new Circle(0, 20, 111000);
         var bounds = circle.GetBounds();
 
-        var minLonError = Distance(19, bounds.MinLon);
+        var minLonError = Distance(18.9961, bounds.MinLon);
         Assert.True(minLonError <= 0.002);
 
-        var maxLonError = Distance(21, bounds.MaxLon);
+        var maxLonError = Distance(21.0039, bounds.MaxLon);
         Assert.True(maxLonError <= 0.002);
     }
 
@@ -38,10 +45,10 @@ public class CircleTests
         var circle = new Circle(60, 20, 111000);
         var bounds = circle.GetBounds();
 
-        var minLatError = Distance(59, bounds.MinLat);
+        var minLatError = Distance(58.9961, bounds.MinLat);
         Assert.True(minLatError <= 0.002);
 
-        var maxLatError = Distance(61, bounds.MaxLat);
+        var maxLatError = Distance(61.0039, bounds.MaxLat);
         Assert.True(maxLatError <= 0.002);
     }
 
@@ -54,11 +61,59 @@ public class CircleTests
         // At 60N a degree of longitude spans only cos(60) = half the metres of a degree
         // of latitude, so a circle that is ~2 degrees tall is ~4 degrees wide (about two
         // degrees either side of the centre).
-        var minLonError = Distance(18.002, bounds.MinLon);
+        var minLonError = Distance(17.992, bounds.MinLon);
         Assert.True(minLonError <= 0.002);
 
-        var maxLonError = Distance(21.998, bounds.MaxLon);
+        var maxLonError = Distance(22.008, bounds.MaxLon);
         Assert.True(maxLonError <= 0.002);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(10)]
+    [InlineData(30)]
+    [InlineData(45)]
+    [InlineData(60)]
+    [InlineData(75)]
+    [InlineData(85)]
+    [InlineData(89)]
+    public void Bounds_contain_the_circles_own_geodesic_vertices(double latitude)
+    {
+        // The bounds and ToPolygon have to describe the same circle. Measuring the box on
+        // a sphere of 6366707 m while projecting the vertices onto WGS-84 left the box
+        // about half a percent too short, so it excluded the very geometry it bounds.
+        foreach (var radius in new[] { 100d, 1000, 10000, 100000, 500000 })
+        {
+            var circle = new Circle(latitude, 20, radius);
+            var bounds = circle.GetBounds();
+
+            foreach (var coordinate in circle.ToPolygon(720).Shell.Coordinates)
+                Assert.True(
+                    bounds.Contains(coordinate),
+                    $"({coordinate}) fell outside the bounds of a {radius} m circle at {latitude}"
+                );
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(30)]
+    [InlineData(60)]
+    [InlineData(85)]
+    public void Bounds_are_not_wastefully_larger_than_the_circle(double latitude)
+    {
+        // Containing the circle is not enough on its own - the whole plane contains it.
+        // The box is a deliberate over-estimate (it uses the tightest curvature the
+        // spheroid has anywhere) but stays within a few percent of the real extent.
+        var circle = new Circle(latitude, 20, 100000);
+        var bounds = circle.GetBounds();
+        var ring = circle.ToPolygon(720).Shell.Coordinates;
+
+        var latitudeSpan = ring.Max(x => x.Latitude) - ring.Min(x => x.Latitude);
+        var longitudeSpan = ring.Max(x => x.Longitude) - ring.Min(x => x.Longitude);
+
+        Assert.InRange(bounds.MaxLat - bounds.MinLat, latitudeSpan, latitudeSpan * 1.03);
+        Assert.InRange(bounds.MaxLon - bounds.MinLon, longitudeSpan, longitudeSpan * 1.03);
     }
 
     [Theory]
@@ -123,17 +178,18 @@ public class CircleTests
         // The widest meridians a circle touches are at asin(sin r / cos lat) from its
         // centre, not the r / cos(lat) small-angle approximation, which understates them.
         const double latitude = 80;
-        var radiusDeg = 100000 / (1852d * 60);
+        var spheroid = Spheroid.Wgs84;
+        var angularRadius =
+            100000
+            / (spheroid.EquatorialAxis * (1 - spheroid.Eccentricity * spheroid.Eccentricity));
         var bounds = new Circle(latitude, 20, 100000).GetBounds();
 
         var expected =
-            Math.Asin(Math.Sin(radiusDeg * Math.PI / 180) / Math.Cos(latitude * Math.PI / 180))
-            * 180
-            / Math.PI;
+            Math.Asin(Math.Sin(angularRadius) / Math.Cos(latitude * Math.PI / 180)) * 180 / Math.PI;
 
         Assert.Equal(20 - expected, bounds.MinLon, 9);
         Assert.Equal(20 + expected, bounds.MaxLon, 9);
-        Assert.True(expected > radiusDeg / Math.Cos(latitude * Math.PI / 180));
+        Assert.True(expected > angularRadius * 180 / Math.PI / Math.Cos(latitude * Math.PI / 180));
     }
 
     [Fact]

--- a/Geo/Geodesy/SphereCalculator.cs
+++ b/Geo/Geodesy/SphereCalculator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using Geo.Abstractions.Interfaces;
 using Geo.Geometries;
@@ -17,19 +18,100 @@ public class SphereCalculator : IGeodeticCalculator
 
     public double Radius { get; protected set; }
 
+    /// <summary>
+    /// The great-circle direct problem: where you arrive setting off from
+    /// <paramref name="point" /> on the given <paramref name="heading" /> and holding a
+    /// great circle for <paramref name="distance" /> metres.
+    /// </summary>
     public GeodeticLine CalculateOrthodromicLine(IPosition point, double heading, double distance)
     {
-        throw new NotImplementedException();
+        var coordinate = point.GetCoordinate();
+        var lat1 = coordinate.Latitude.ToRadians();
+        var lon1 = coordinate.Longitude.ToRadians();
+        var azimuth = heading.ToRadians();
+        var angularDistance = distance / Radius;
+
+        var sinLat1 = Math.Sin(lat1);
+        var cosLat1 = Math.Cos(lat1);
+        var sinAngular = Math.Sin(angularDistance);
+        var cosAngular = Math.Cos(angularDistance);
+
+        var lat2 = Math.Asin(sinLat1 * cosAngular + cosLat1 * sinAngular * Math.Cos(azimuth));
+        var lon2 =
+            lon1
+            + Math.Atan2(
+                Math.Sin(azimuth) * sinAngular * cosLat1,
+                cosAngular - sinLat1 * Math.Sin(lat2)
+            );
+
+        return new GeodeticLine(
+            new Coordinate(coordinate.Latitude, coordinate.Longitude),
+            new Coordinate(ClampLatitude(lat2.ToDegrees()), NormalizeLongitude(lon2).ToDegrees()),
+            distance,
+            heading,
+            // The back azimuth is the heading you would set off on to make the return
+            // journey, so it is the initial bearing of the reversed line - in degrees,
+            // like every other bearing here.
+            InitialBearing(lat2, lon2, lat1, lon1).ToDegrees()
+        );
     }
 
-    public GeodeticLine CalculateOrthodromicLine(IPosition point1, IPosition point2)
+    /// <summary>
+    /// The great-circle inverse problem: the shortest path between two points, and the
+    /// headings it starts and ends on. Returns <c>null</c> when the two coincide.
+    /// </summary>
+    public GeodeticLine? CalculateOrthodromicLine(IPosition point1, IPosition point2)
     {
-        throw new NotImplementedException();
+        var result = CalculateOrthodromicLineInternal(point1, point2);
+        if (result == null)
+            return null;
+
+        return new GeodeticLine(
+            point1.GetCoordinate(),
+            point2.GetCoordinate(),
+            result[0],
+            result[1],
+            result[2]
+        );
     }
 
-    public GeodeticLine CalculateLoxodromicLine(IPosition point1, IPosition point2)
+    /// <summary>
+    /// The rhumb line (line of constant bearing) between two points. Longer than the
+    /// great circle, but it can be steered on a single heading. Returns <c>null</c> when
+    /// the two points coincide.
+    /// </summary>
+    public GeodeticLine? CalculateLoxodromicLine(IPosition point1, IPosition point2)
     {
-        throw new NotImplementedException();
+        var coordinate1 = point1.GetCoordinate();
+        var coordinate2 = point2.GetCoordinate();
+
+        if (Coincident(coordinate1, coordinate2))
+            return null;
+
+        var lat1 = coordinate1.Latitude.ToRadians();
+        var lat2 = coordinate2.Latitude.ToRadians();
+        var deltaLat = lat2 - lat1;
+        var deltaLon = NormalizeLongitude(
+            coordinate2.Longitude.ToRadians() - coordinate1.Longitude.ToRadians()
+        );
+
+        // A rhumb line is a straight line on a Mercator chart, so it is measured against
+        // the stretched (Mercator) latitude rather than the true one.
+        var deltaStretched = Math.Log(
+            Math.Tan(Math.PI / 4 + lat2 / 2) / Math.Tan(Math.PI / 4 + lat1 / 2)
+        );
+
+        // deltaLat / deltaStretched is the north-south scale factor. Due east or west
+        // both are zero, and the ratio tends to cos(latitude) - the parallel's own scale.
+        var scale = Math.Abs(deltaStretched) > 1e-12 ? deltaLat / deltaStretched : Math.Cos(lat1);
+
+        var distance =
+            Radius * Math.Sqrt(deltaLat * deltaLat + scale * scale * deltaLon * deltaLon);
+        var course = Math.Atan2(deltaLon, deltaStretched).ToDegrees();
+
+        // The bearing is constant along a rhumb line, so the return heading is simply the
+        // reciprocal (GeodeticLine wraps it back into 0-360).
+        return new GeodeticLine(coordinate1, coordinate2, distance, course, course + 180);
     }
 
     public Distance CalculateLength(Circle circle)
@@ -41,7 +123,15 @@ public class SphereCalculator : IGeodeticCalculator
 
     public Distance CalculateLength(CoordinateSequence coordinates)
     {
-        throw new NotImplementedException();
+        var distance = 0d;
+        for (var i = 1; i < coordinates.Count; i++)
+        {
+            var result = CalculateOrthodromicLineInternal(coordinates[i - 1], coordinates[i]);
+            if (result != null)
+                distance += result[0];
+        }
+
+        return new Distance(distance);
     }
 
     public Distance CalculateLength(Envelope envelope)
@@ -111,13 +201,87 @@ public class SphereCalculator : IGeodeticCalculator
         return new Area(zoneArea * lonPercentage);
     }
 
+    /// <summary>
+    /// The Mercator ordinate of a latitude, in nautical miles - the same unit
+    /// <see cref="SpheroidCalculator.CalculateMeridionalParts" /> reports, so the two are
+    /// directly comparable. On a sphere the eccentricity correction a spheroid needs
+    /// vanishes and only the isometric latitude remains.
+    /// </summary>
     public double CalculateMeridionalParts(double latitude)
     {
-        throw new NotImplementedException();
+        return Radius
+            * Math.Log(Math.Tan(Math.PI / 4 + latitude.ToRadians() / 2))
+            / Constants.NauticalMile;
     }
 
+    /// <summary>
+    /// The distance along the meridian from the equator to a latitude, in metres. A
+    /// sphere's meridians are circles of a single radius, so the arc is simply
+    /// <see cref="Radius" /> times the latitude in radians.
+    /// </summary>
     public double CalculateMeridionalDistance(double latitude)
     {
-        throw new NotImplementedException();
+        return Radius * latitude.ToRadians();
+    }
+
+    private double[]? CalculateOrthodromicLineInternal(IPosition position1, IPosition position2)
+    {
+        var coordinate1 = position1.GetCoordinate();
+        var coordinate2 = position2.GetCoordinate();
+
+        if (Coincident(coordinate1, coordinate2))
+            return null;
+
+        var lat1 = coordinate1.Latitude.ToRadians();
+        var lon1 = coordinate1.Longitude.ToRadians();
+        var lat2 = coordinate2.Latitude.ToRadians();
+        var lon2 = coordinate2.Longitude.ToRadians();
+
+        // Haversine rather than the spherical law of cosines: the latter loses its
+        // precision for points close together, which is where a length is most often
+        // summed over many short legs.
+        var sinHalfLat = Math.Sin((lat2 - lat1) / 2);
+        var sinHalfLon = Math.Sin((lon2 - lon1) / 2);
+        var h = sinHalfLat * sinHalfLat + Math.Cos(lat1) * Math.Cos(lat2) * sinHalfLon * sinHalfLon;
+
+        return new[]
+        {
+            2 * Math.Asin(Math.Min(1, Math.Sqrt(h))) * Radius,
+            InitialBearing(lat1, lon1, lat2, lon2).ToDegrees(),
+            InitialBearing(lat2, lon2, lat1, lon1).ToDegrees(),
+        };
+    }
+
+    /// <summary>
+    /// The heading, in radians, to set off on at (<paramref name="lat1" />,
+    /// <paramref name="lon1" />) to reach (<paramref name="lat2" />,
+    /// <paramref name="lon2" />) along a great circle.
+    /// </summary>
+    private static double InitialBearing(double lat1, double lon1, double lat2, double lon2)
+    {
+        var deltaLon = lon2 - lon1;
+        return Math.Atan2(
+            Math.Sin(deltaLon) * Math.Cos(lat2),
+            Math.Cos(lat1) * Math.Sin(lat2) - Math.Sin(lat1) * Math.Cos(lat2) * Math.Cos(deltaLon)
+        );
+    }
+
+    private static bool Coincident(Coordinate coordinate1, Coordinate coordinate2)
+    {
+        return Math.Abs(coordinate1.Latitude - coordinate2.Latitude) < double.Epsilon
+            && Math.Abs(coordinate1.Longitude - coordinate2.Longitude) < double.Epsilon;
+    }
+
+    private static double NormalizeLongitude(double radians)
+    {
+        var turn = 2 * Math.PI;
+        return radians - turn * Math.Floor((radians + Math.PI) / turn);
+    }
+
+    // Asin is bounded by pi/2, but converting that to degrees can land a hair past 90,
+    // which Coordinate rejects outright.
+    private static double ClampLatitude(double degrees)
+    {
+        return Math.Max(-90, Math.Min(90, degrees));
     }
 }

--- a/Geo/Geodesy/Spheroid.cs
+++ b/Geo/Geodesy/Spheroid.cs
@@ -7,6 +7,8 @@ public class Spheroid
 {
     public static readonly Spheroid Default = Wgs84;
 
+    private readonly double _authalicQAtPole;
+
     public Spheroid(string name, double equatorialAxis, double inverseFlattening)
     {
         Name = name;
@@ -17,6 +19,9 @@ public class Spheroid
         Eccentricity = Math.Sqrt(2 * Flattening - Flattening * Flattening);
         MeanRadius = (2 * EquatorialAxis + PolarAxis) / 3;
         IsSphere = Math.Abs(EquatorialAxis - PolarAxis) < double.Epsilon;
+
+        _authalicQAtPole = AuthalicQ(1);
+        AuthalicRadius = EquatorialAxis * Math.Sqrt(_authalicQAtPole / 2);
     }
 
     public static Spheroid Wgs84 => new("WGS84", 6378137d, 298.257223563d);
@@ -35,4 +40,46 @@ public class Spheroid
     public double Eccentricity { get; }
     public double MeanRadius { get; }
     public bool IsSphere { get; }
+
+    /// <summary>
+    /// The radius of the sphere with the same surface area as this spheroid (6371007.181 m
+    /// for WGS-84). An area worked out on that sphere is the spheroid's own area, which is
+    /// what makes it the sphere to reduce an area calculation to - <see cref="MeanRadius" />
+    /// is an average of the axes and carries no such guarantee.
+    /// </summary>
+    public double AuthalicRadius { get; }
+
+    /// <summary>
+    /// The sine of the authalic latitude: the latitude on the sphere of
+    /// <see cref="AuthalicRadius" /> that has the same area between it and the equator as
+    /// <paramref name="latitude" /> does here. Substituting it for the sine of the true
+    /// latitude turns a spherical area formula into a spheroidal one.
+    /// </summary>
+    internal double AuthalicSine(double latitude)
+    {
+        return AuthalicQ(Math.Sin(latitude.ToRadians())) / _authalicQAtPole;
+    }
+
+    /// <summary>
+    /// The area, in units of the equatorial radius squared, between the equator and the
+    /// latitude whose sine is <paramref name="sinLatitude" />, per radian of longitude
+    /// (Snyder's <em>q</em>).
+    /// </summary>
+    private double AuthalicQ(double sinLatitude)
+    {
+        var eccentricity = Eccentricity;
+
+        // A sphere's own latitude is already authalic, and the expression below is 0/0
+        // there, so take the limit it tends to.
+        if (eccentricity < 1e-12)
+            return 2 * sinLatitude;
+
+        var eccentricitySquared = eccentricity * eccentricity;
+        return (1 - eccentricitySquared)
+            * (
+                sinLatitude / (1 - eccentricitySquared * sinLatitude * sinLatitude)
+                - Math.Log((1 - eccentricity * sinLatitude) / (1 + eccentricity * sinLatitude))
+                    / (2 * eccentricity)
+            );
+    }
 }

--- a/Geo/Geodesy/SpheroidCalculator.cs
+++ b/Geo/Geodesy/SpheroidCalculator.cs
@@ -91,7 +91,7 @@ public class SpheroidCalculator : IGeodeticCalculator
         c = ((-3 * c2a + 4) * Spheroid.Flattening + 4) * c2a * Spheroid.Flattening / 16;
         d = ((e * cy * c + cz) * sy * c + y) * sa;
         var glon2 = modlon(lon1 + x - (1 - c) * d * Spheroid.Flattening); // fix date line problems
-        var baz = modcrs(Math.Atan2(sa, b) + Math.PI);
+        var baz = modcrs(Math.Atan2(sa, b) + Math.PI).ToDegrees();
 
         return new GeodeticLine(
             new Coordinate(point.GetCoordinate().Latitude, point.GetCoordinate().Longitude),

--- a/Geo/Geodesy/SpheroidCalculator.cs
+++ b/Geo/Geodesy/SpheroidCalculator.cs
@@ -11,7 +11,10 @@ namespace Geo.Geodesy;
 
 public class SpheroidCalculator : IGeodeticCalculator
 {
-    private readonly SphereCalculator _sphereCalculator = new();
+    // A geodesic circle on a spheroid has no elementary area or circumference, so those
+    // two are worked out on the sphere that has the same surface area as this spheroid -
+    // built from it, so that they answer for the datum in use rather than for a fixed one.
+    private readonly SphereCalculator _authalicSphere;
 
     public SpheroidCalculator()
         : this(Spheroid.Default) { }
@@ -19,6 +22,7 @@ public class SpheroidCalculator : IGeodeticCalculator
     public SpheroidCalculator(Spheroid spheroid)
     {
         Spheroid = spheroid;
+        _authalicSphere = new SphereCalculator(spheroid.AuthalicRadius);
     }
 
     public Spheroid Spheroid { get; }
@@ -183,7 +187,7 @@ public class SpheroidCalculator : IGeodeticCalculator
 
     public Distance CalculateLength(Circle circle)
     {
-        return _sphereCalculator.CalculateLength(circle);
+        return _authalicSphere.CalculateLength(circle);
     }
 
     public Distance CalculateLength(CoordinateSequence coordinates)
@@ -199,9 +203,40 @@ public class SpheroidCalculator : IGeodeticCalculator
         return new Distance(distance);
     }
 
+    /// <summary>
+    /// The perimeter of an envelope on the spheroid: two meridian arcs down the sides, and
+    /// the two parallels closing the top and the bottom.
+    /// </summary>
     public Distance CalculateLength(Envelope envelope)
     {
-        return _sphereCalculator.CalculateLength(envelope);
+        // The sides run along meridians, whose arc the spheroid already knows how to
+        // measure; the top and bottom run along parallels, whose radius is the
+        // prime-vertical radius of curvature foreshortened by the latitude.
+        var sides =
+            2
+            * (
+                CalculateMeridionalDistance(envelope.MaxLat)
+                - CalculateMeridionalDistance(envelope.MinLat)
+            );
+
+        var longitudeSpan = (envelope.MaxLon - envelope.MinLon).ToRadians();
+        var top = longitudeSpan * ParallelRadius(envelope.MaxLat);
+        var bottom = longitudeSpan * ParallelRadius(envelope.MinLat);
+
+        return new Distance(sides + top + bottom);
+    }
+
+    /// <summary>
+    /// The radius of the circle of latitude (the parallel) at <paramref name="latitude" />.
+    /// </summary>
+    private double ParallelRadius(double latitude)
+    {
+        var lat = latitude.ToRadians();
+        var sinLat = Math.Sin(lat);
+        var eccentricitySquared = Spheroid.Eccentricity * Spheroid.Eccentricity;
+        var primeVertical =
+            Spheroid.EquatorialAxis / Math.Sqrt(1 - eccentricitySquared * sinLat * sinLat);
+        return primeVertical * Math.Cos(lat);
     }
 
     public double CalculateMeridionalParts(double latitude)
@@ -244,19 +279,49 @@ public class SpheroidCalculator : IGeodeticCalculator
         return dist * Spheroid.EquatorialAxis;
     }
 
+    /// <summary>
+    /// The area enclosed by a closed ring on the spheroid.
+    /// </summary>
     public Area CalculateArea(CoordinateSequence coordinates)
     {
-        return _sphereCalculator.CalculateArea(coordinates);
+        // The spherical formula, with each latitude replaced by its authalic counterpart
+        // and the equal-area radius standing in for the sphere's. That substitution is
+        // area-preserving by construction, so what comes out is the spheroid's own area
+        // rather than a sphere's approximation of it.
+        var area = 0.0;
+        if (coordinates.Count > 3 && coordinates.IsClosed)
+        {
+            for (var i = 0; i < coordinates.Count - 1; i++)
+            {
+                var p1 = coordinates[i];
+                var p2 = coordinates[i + 1];
+                area +=
+                    (p2.Longitude - p1.Longitude).ToRadians()
+                    * (2 + Spheroid.AuthalicSine(p1.Latitude) + Spheroid.AuthalicSine(p2.Latitude));
+            }
+
+            area = area * Spheroid.AuthalicRadius * Spheroid.AuthalicRadius / 2.0;
+        }
+
+        // Signed by the ring's winding order; callers want the magnitude.
+        return new Area(Math.Abs(area));
     }
 
     public Area CalculateArea(Circle circle)
     {
-        return _sphereCalculator.CalculateArea(circle);
+        return _authalicSphere.CalculateArea(circle);
     }
 
+    /// <summary>
+    /// The area of an envelope on the spheroid: the zone between its two parallels, over
+    /// the span of longitude it covers.
+    /// </summary>
     public Area CalculateArea(Envelope envelope)
     {
-        return _sphereCalculator.CalculateArea(envelope);
+        var longitudeSpan = (envelope.MaxLon - envelope.MinLon).ToRadians();
+        var zone = Spheroid.AuthalicSine(envelope.MaxLat) - Spheroid.AuthalicSine(envelope.MinLat);
+
+        return new Area(longitudeSpan * Spheroid.AuthalicRadius * Spheroid.AuthalicRadius * zone);
     }
 
     private double mod(double x, double y)

--- a/Geo/Geometries/Circle.cs
+++ b/Geo/Geometries/Circle.cs
@@ -56,7 +56,24 @@ public class Circle : Geometry, ISurface
             return null;
 
         var center = Center;
-        var latitudinalRadiusDeg = Math.Abs(Radius) / (Constants.NauticalMile * 60);
+
+        // The circle is the set of points a geodesic Radius away from the centre on the
+        // ambient spheroid - the surface ToPolygon projects its own vertices onto - so
+        // the box has to be measured on that spheroid too. Treating one nautical mile as
+        // one arcminute assumed a sphere of 6366707 m, which is larger than the meridian
+        // the circle actually runs along, and left the box about half a percent too
+        // short: a 100 km circle on the equator reached 0.90437 degrees north while its
+        // bounds stopped at 0.89993, excluding its own vertices.
+        //
+        // The angular radius is taken over the spheroid's smallest radius of curvature,
+        // a(1-e^2) - the meridional one at the equator. No arc of a given length subtends
+        // a larger angle anywhere on the surface, so this cannot understate the box in
+        // any direction, at any latitude.
+        var spheroid = GeoContext.Current.Spheroid;
+        var angularRadius =
+            Math.Abs(Radius)
+            / (spheroid.EquatorialAxis * (1 - spheroid.Eccentricity * spheroid.Eccentricity));
+        var latitudinalRadiusDeg = angularRadius.ToDegrees();
 
         var minLat = center.Latitude - latitudinalRadiusDeg;
         var maxLat = center.Latitude + latitudinalRadiusDeg;
@@ -74,7 +91,7 @@ public class Circle : Geometry, ISurface
         // it, at asin(sin r / cos lat) from the centre - not r / cos(lat), which is only
         // its small-angle approximation and understates the box near the poles.
         var longitudinalRadiusDeg = Math.Asin(
-                Math.Sin(latitudinalRadiusDeg.ToRadians()) / Math.Cos(center.Latitude.ToRadians())
+                Math.Sin(angularRadius) / Math.Cos(center.Latitude.ToRadians())
             )
             .ToDegrees();
 

--- a/docs/geodesy.md
+++ b/docs/geodesy.md
@@ -91,6 +91,11 @@ Built-in spheroids include `Spheroid.Wgs84` (the default), `Spheroid.Grs80`,
 `Spheroid.International1924`, and `Spheroid.Clarke1866`. You can also construct a
 custom one with `new Spheroid(name, equatorialAxis, inverseFlattening)`.
 
+Alongside its defining parameters, `Spheroid` exposes derived quantities:
+`PolarAxis`, `Eccentricity`, `MeanRadius`, and `AuthalicRadius` — the radius of
+the sphere with the same surface area, which is the sphere area calculations
+reduce to, so that they answer for the spheroid you configured.
+
 The `Distance` and `Area` result types (from the `Geo.Measure` namespace) carry
 their value in S.I. units and convert to others via `ConvertTo`, e.g.
 `distance.ConvertTo(DistanceUnit.Nm).Value`.


### PR DESCRIPTION
Three independent fixes in `Geo.Geodesy` and `Circle`, each with its own commit. They came out of following the `Circle.GetBounds()` under-estimate noted in #119 through to the calculators underneath it.

## 1. Circle bounds did not contain the circle (`c1bd74a`)

`Circle.GetBounds()` measured its box by treating one nautical mile as one arcminute — implicitly a sphere of 6 366 707 m — while `Circle.ToPolygon()` projects vertices onto the ambient spheroid, whose meridian curves with a radius of 6 335 439 m near the equator. The box came out ~0.5% short and so excluded the geometry it bounds:

| | 100 km circle on the equator |
|---|---|
| reached by `ToPolygon` | 0.90437° N |
| covered by `GetBounds` | 0.89993° N |

The angular radius is now taken over the spheroid's smallest radius of curvature, `a(1−e²)` (the meridional one at the equator). No arc of a given length subtends a larger angle anywhere on the surface, so the box cannot come out short in any direction at any latitude — provable for latitude, since the meridian arc `∫M dφ ≥ M(0)·Δφ`.

Checked against a 7200-point sampling of the true geodesic circle over 54 combinations (latitude 0–89°, radius 100 m – 1000 km): every vertex now falls inside, and the box stays within 1.9% of the real extent in the worst non-polar case.

I did **not** route this through `IGeodeticCalculator`. The interface can't express a bounding box: the easternmost point of a geodesic circle is not at heading 90° (measured shortfall 37 m at 60°N, 9.6 km at 88°N, 365 km at 88°N with a 500 km radius), so an exact box needs a root-find on the launch heading — ~23 iterative solves, 212× slower than the closed form — and `GetBounds` is the cheap pre-filter `GeometryCollection.GetBounds()` calls on every member.

## 2. The direct solution returned its back azimuth in radians (`908bd0c`)

`SpheroidCalculator.CalculateOrthodromicLine(point, heading, distance)` built `baz` with `modcrs`, which reduces mod 2π, and handed it to `GeodeticLine`, which takes degrees. The inverse overload converts both of its azimuths; this path didn't.

| from | heading | direct `Bearing21` | inverse `Bearing21` |
|---|---|---|---|
| (0, 0) | 90 | 4.712389 | 270.000000 |
| (51.5, −0.1) | 45 | 3.941158 | 225.811692 |
| (−33.9, 151.2) | 270 | 1.581320 | 90.602967 |

Because the values land in [0, 6.28) they read as plausible bearings, so nothing threw — callers just got a wrong answer. `Bearing12` was unaffected (it's the heading it was handed).

**Also in this commit:** `SphereCalculator` threw `NotImplementedException` from six members, including the inverse orthodromic line — so it could not measure the distance between two points, and setting it as the ambient calculator broke `LineString.GetLength()`, `Circle.ToPolygon()` and anything else reaching for a geodetic line. All six are now closed forms: the direct and inverse great-circle problems (haversine for the inverse), the rhumb line, sequence length, meridional parts and meridional distance.

Direct and inverse invert each other to 5e-9 m and 1e-10°; cardinal bearings come out exact; a rhumb along a parallel is exactly `R·cos φ·Δλ`; against the spheroid, distances agree to 0.43% and bearings to 0.2°.

## 3. Areas and envelope lengths ignored the configured spheroid (`38452fe`)

`SpheroidCalculator` handed five members — every area, plus circle and envelope lengths — to a hardcoded sphere of the WGS-84 mean radius. The `Spheroid` it was constructed with made no difference to any of them:

| spheroid | equatorial axis | envelope area |
|---|---|---|
| WGS84 | 6 378 137.0 | 1 230 166 804 525.028 |
| Clarke 1866 | 6 378 206.4 | 1 230 166 804 525.028 |
| "half-size" | 3 189 068.5 | **1 230 166 804 525.028** |

`Spheroid` gains `AuthalicRadius` — the radius of the sphere with the same surface area (6 371 007.181 m for WGS-84, the published NIMA TR8350.2 value) — and the authalic latitude that goes with it. Substituting an authalic latitude for a true one turns a spherical area formula into a spheroidal one *exactly*, because the substitution is area-preserving by construction, so the existing formulas keep their shape and stop being approximations:

- envelope area → the spheroidal zone between its parallels
- ring area → the same formula over authalic latitudes and that radius
- envelope perimeter → two meridian arcs (via the class's own `CalculateMeridionalDistance`) plus two parallels at the prime-vertical radius
- circle area and circumference → no elementary spheroidal form exists, so still spherical, but on the spheroid's own equal-area sphere rather than a fixed one

The whole world now comes out at the spheroid's closed-form surface area to twelve digits, and its envelope perimeter at the meridian circumference. The zone and ring formulas — two independent routes — agree to twelve digits across four latitude bands.

## Behaviour changes worth a release note

- `Envelope.GetArea()`, `Polygon.GetArea()`, `Envelope.GetLength()` and the corresponding `IGeodeticCalculator` members move by **+0.44% at the equator to −0.87% at high latitude** (about half that for lengths). Corrections in every case, but they are different numbers.
- `Circle.GetBounds()` returns a slightly larger box — a 111 km arc subtends 1.00385° on WGS-84, not 0.99892°. The four `CircleTests` that pinned the nautical-mile figures move with it.
- `SpheroidCalculator.CalculateOrthodromicLine(point, heading, distance).Bearing21` now returns degrees. Anyone who compensated for the radians will need to stop.
- New public API: `Spheroid.AuthalicRadius`. No breaking signature changes.

## Testing

845 tests pass (up from 796), `dotnet csharpier check .` clean, no build warnings. New coverage: `SphereCalculatorTests` gains the whole line/rhumb/meridional surface including over-the-pole and anti-meridian cases; `SpheroidCalculatorTests` gains the datum-honouring regressions and the back-azimuth fix; `SpheroidTests` gains `AuthalicRadius`; `CircleTests` gains containment against the circle's own geodesic vertices.

Note that `./build.sh CheckForUncommittedChanges` fails in my sandbox with "Could not find Husky path" — it does so on unmodified `master` too, so it's environmental. The gate it runs, `csharpier check`, passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NvDD3umHZ5T3J3TF3mmDo

---
_Generated by [Claude Code](https://claude.ai/code/session_013NvDD3umHZ5T3J3TF3mmDo)_