### PR TITLE
Fix five bugs: WKT triangles, reader error contracts, IGC dates

### DIFF
--- a/Geo.Tests/Gps/Serialization/IgcDeSerializerTests.cs
+++ b/Geo.Tests/Gps/Serialization/IgcDeSerializerTests.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Geo.Gps.Serialization;
@@ -85,5 +87,34 @@ public class IgcDeSerializerTests : SerializerTestFixtureBase
         Assert.NotNull(result);
         Assert.Empty(result.Tracks);
         Assert.Empty(result.Waypoints);
+    }
+
+    [Theory]
+    [InlineData("en-GB")]
+    // Calendars whose current year is not the Gregorian one.
+    [InlineData("th-TH")]
+    [InlineData("ar-SA")]
+    public void Two_digit_year_is_resolved_independently_of_the_current_culture(string culture)
+    {
+        // HFDTE160701 -> 16 July 2001. The pivot for the file's two-digit year is the
+        // current Gregorian year's last two digits; read through the current culture's
+        // calendar instead it came from a different era, and every fix in the file
+        // landed decades out.
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(culture);
+
+            var file = GetReferenceFileDirectory("igc").GetFiles().First(x => x.Name == "igc2.igc");
+            using var stream = new FileStream(file.FullName, FileMode.Open);
+            var result = new IgcDeSerializer().DeSerialize(new StreamWrapper(stream));
+
+            var first = result.Tracks[0].Segments[0].Waypoints[0];
+            Assert.Equal(new DateTime(2001, 7, 16, 16, 2, 40), first.TimeUtc);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
     }
 }

--- a/Geo.Tests/Gps/Serialization/StreamWrapperTests.cs
+++ b/Geo.Tests/Gps/Serialization/StreamWrapperTests.cs
@@ -37,6 +37,19 @@ public class StreamWrapperTests
     }
 
     [Fact]
+    public void Buffered_stream_starts_at_the_beginning_of_what_it_buffered()
+    {
+        var wrapper = new StreamWrapper(new NonSeekableStream(Bytes("buffered content")));
+
+        // Left where the copy finished, the wrapper read as empty until something
+        // happened to seek it first - unlike a wrapper over a seekable stream, and
+        // unlike CreateAsync, which has always rewound.
+        Assert.Equal(0, wrapper.Position);
+        using var reader = new StreamReader(wrapper, Encoding.UTF8, false, 1024, true);
+        Assert.Equal("buffered content", reader.ReadToEnd());
+    }
+
+    [Fact]
     public async Task CreateAsync_buffers_the_source_and_rewinds_to_the_start()
     {
         var inner = new NonSeekableStream(Bytes("async content"));

--- a/Geo.Tests/IO/GeoJson/GeoJsonReaderWriterTests.cs
+++ b/Geo.Tests/IO/GeoJson/GeoJsonReaderWriterTests.cs
@@ -321,4 +321,28 @@ public class GeoJsonReaderWriterTests
         Assert.False(new GeoJsonReader().TryRead(json, out _));
         Assert.Throws<SerializationException>(() => new GeoJsonReader().Read(json));
     }
+
+    [Theory]
+    // a latitude past the pole
+    [InlineData("{\"type\":\"Point\",\"coordinates\":[0,95]}")]
+    // a longitude past the anti-meridian
+    [InlineData("{\"type\":\"Point\",\"coordinates\":[181,0]}")]
+    // an out-of-range ordinate inside a nested geometry
+    [InlineData(
+        "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[0,95]}]}"
+    )]
+    // a ring that does not close
+    [InlineData("{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,1],[2,2],[3,3]]]}")]
+    // a ring with too few coordinates
+    [InlineData("{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,1],[0,0]]]}")]
+    public void Geometry_with_impossible_coordinates_does_not_parse(string json)
+    {
+        // Values the JSON is free to hold but a geometry is not reach the coordinate
+        // and geometry constructors, which reject them as bad arguments. TryRead
+        // reports a document it cannot read by returning false, and Read raises the
+        // same SerializationException as every other malformed GeoJSON, rather than
+        // either of them throwing an argument exception at the caller.
+        Assert.False(new GeoJsonReader().TryRead(json, out _));
+        Assert.Throws<SerializationException>(() => new GeoJsonReader().Read(json));
+    }
 }

--- a/Geo.Tests/IO/Wkt/WktReaderTests.cs
+++ b/Geo.Tests/IO/Wkt/WktReaderTests.cs
@@ -264,6 +264,60 @@ public class WktReaderTests
     }
 
     [Fact]
+    public void Triangle_is_read_back_as_a_triangle()
+    {
+        var reader = new WktReader();
+
+        // A triangle is its own geometry type, not a polygon that happens to have three
+        // sides: reading it as a plain Polygon lost the type, so it could not be written
+        // back out as TRIANGLE.
+        Assert.IsType<Geo.Geometries.Triangle>(
+            reader.Read("TRIANGLE ((0.0 65.9, -34.5 9, -20 40, 0 65.9))")
+        );
+        Assert.IsType<Geo.Geometries.Triangle>(reader.Read("TRIANGLE EMPTY"));
+
+        // And with the type kept, a triangle survives a WKT round-trip.
+        var settings = new WktWriterSettings { Triangle = true };
+        var wkt = "TRIANGLE ((0 65.9, -34.5 9, -20 40, 0 65.9))";
+        Assert.Equal(wkt, new WktWriter(settings).Write(reader.Read(wkt)));
+    }
+
+    [Fact]
+    public void Triangle_whose_ring_is_not_a_triangle_is_rejected()
+    {
+        var reader = new WktReader();
+
+        // Read as a plain Polygon the ring went unchecked, and a four-sided "triangle"
+        // was accepted without complaint.
+        Assert.Throws<SerializationException>(() =>
+            reader.Read("TRIANGLE ((0 0, 1 1, 2 2, 3 3, 0 0))")
+        );
+    }
+
+    [Theory]
+    // a latitude past the pole
+    [InlineData("POINT (0 95)")]
+    // a longitude past the anti-meridian
+    [InlineData("POINT (181 0)")]
+    // an out-of-range ordinate inside a nested geometry
+    [InlineData("GEOMETRYCOLLECTION (POINT (0 95))")]
+    // a ring that does not close
+    [InlineData("POLYGON ((0 0, 1 1, 2 2, 3 3))")]
+    // a ring with too few coordinates
+    [InlineData("POLYGON ((0 0, 1 1, 0 0))")]
+    // numbers the tokenizer accepts but double.Parse does not
+    [InlineData("POINT (1-2 3)")]
+    [InlineData("POINT (1.2.3 4)")]
+    public void Malformed_wkt_is_reported_as_a_serialization_exception(string wkt)
+    {
+        // The argument at fault is the WKT, not anything the caller passed, so a
+        // malformed document is reported like every other WKT parse failure rather than
+        // escaping as an argument or format exception naming a parameter the caller
+        // never supplied.
+        Assert.Throws<SerializationException>(() => new WktReader().Read(wkt));
+    }
+
+    [Fact]
     public void GeometryCollection()
     {
         var reader = new WktReader();

--- a/Geo/Gps/Serialization/IgcDeSerializer.cs
+++ b/Geo/Gps/Serialization/IgcDeSerializer.cs
@@ -72,10 +72,14 @@ public class IgcDeSerializer : IGpsFileDeSerializer
                         var d = int.Parse(match.Groups["d"].Value, CultureInfo.InvariantCulture);
                         var m = int.Parse(match.Groups["m"].Value, CultureInfo.InvariantCulture);
                         var y = int.Parse(match.Groups["y"].Value, CultureInfo.InvariantCulture);
-                        var yn = int.Parse(
-                            DateTime.UtcNow.ToString("yy"),
-                            CultureInfo.InvariantCulture
-                        );
+                        // The pivot for the file's two-digit year is the current year's
+                        // own last two digits, taken from the Gregorian year directly.
+                        // Formatting "yy" reads it through the current culture's
+                        // calendar, so under a non-Gregorian default (th-TH's Buddhist
+                        // calendar, ar-SA's Umm al-Qura) the pivot came from a different
+                        // era entirely and every fix in the file landed decades out: a
+                        // 2026 flight was dated 1983 under th-TH.
+                        var yn = DateTime.UtcNow.Year % 100;
                         if (y > yn)
                             yn += 100;
                         var yd = yn - y;

--- a/Geo/Gps/Serialization/StreamWrapper.cs
+++ b/Geo/Gps/Serialization/StreamWrapper.cs
@@ -56,6 +56,13 @@ public class StreamWrapper : Stream
         int read;
         while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
             ms.Write(buffer, 0, read);
+
+        // Rewind, so the wrapper starts at the beginning of what it buffered rather
+        // than at the end of it. Left where the copy finished, a wrapper built from a
+        // non-seekable stream read as empty until something happened to seek it first,
+        // while one built from a seekable stream (and one built by CreateAsync, which
+        // has always rewound) started at the beginning.
+        ms.Position = 0;
         return ms;
     }
 

--- a/Geo/IO/GeoJson/GeoJsonReader.cs
+++ b/Geo/IO/GeoJson/GeoJsonReader.cs
@@ -54,15 +54,27 @@ public class GeoJsonReader
         if (!Json.TryParse(json, out var obj))
             return false;
 
-        if (obj is JsonObject)
-        {
-            if (TryParseGeometry((JsonObject)obj, out result))
-                return true;
-            if (TryParseFeature((JsonObject)obj, out result))
-                return true;
-            if (TryParseFeatureCollection((JsonObject)obj, out result))
-                return true;
-        }
+        if (obj is JsonObject jsonObject)
+            try
+            {
+                if (TryParseGeometry(jsonObject, out result))
+                    return true;
+                if (TryParseFeature(jsonObject, out result))
+                    return true;
+                if (TryParseFeatureCollection(jsonObject, out result))
+                    return true;
+            }
+            // Values the JSON is free to hold but a geometry is not - a latitude past
+            // the pole, a ring that does not close - reach the coordinate and geometry
+            // constructors, which reject them as bad arguments. A TryParse reports a
+            // document it cannot read by returning false, so those are a failed parse
+            // rather than an exception thrown at the caller (and Read turns them into a
+            // SerializationException like every other malformed GeoJSON).
+            catch (ArgumentException)
+            {
+                result = null;
+                return false;
+            }
 
         return false;
     }

--- a/Geo/IO/Wkt/WktReader.cs
+++ b/Geo/IO/Wkt/WktReader.cs
@@ -66,6 +66,17 @@ public class WktReader
             // as a SerializationException like every other WKT parse failure.
             throw new SerializationException("Invalid WKT string.");
         }
+        // A number the tokenizer accepted but double.Parse will not ("1-2", "1.2.3"),
+        // or an ordinate the coordinate and geometry constructors reject outright - a
+        // latitude past the pole, a ring that does not close, a triangle that is not a
+        // triangle. The argument at fault is the WKT, not anything the caller passed,
+        // so these are reported like every other decoding failure rather than escaping
+        // as an argument or format exception naming a parameter the caller never
+        // supplied. WkbReader and GooglePolylineEncoder do the same.
+        catch (Exception ex) when (ex is ArgumentException or FormatException or OverflowException)
+        {
+            throw new SerializationException("Invalid WKT string.", ex);
+        }
     }
 
     private IGeometry? ParseGeometry(WktTokenQueue tokens)
@@ -146,28 +157,47 @@ public class WktReader
         return ParsePolygonInner(tokens, dimensions);
     }
 
+    // A TRIANGLE is its own geometry type, not a polygon that happens to have three
+    // sides: it validates its ring and it is written back out as TRIANGLE. Reading one
+    // as a plain Polygon lost the type on the way in, so a triangle could not survive a
+    // WKT round-trip and the ring went unchecked. WkbReader already reads it this way.
     private Polygon ParseTriangle(WktTokenQueue tokens)
     {
         tokens.Dequeue("TRIANGLE");
         var dimensions = ParseDimensions(tokens);
-        return ParsePolygonInner(tokens, dimensions);
+
+        var rings = ParseRings(tokens, dimensions);
+        if (rings == null)
+            return Triangle.Empty;
+
+        return new Triangle(rings[0], rings.Skip(1));
     }
 
     private Polygon ParsePolygonInner(WktTokenQueue tokens, WktDimensions dimensions)
     {
+        var rings = ParseRings(tokens, dimensions);
+        if (rings == null)
+            return Polygon.Empty;
+
+        return new Polygon(rings[0], rings.Skip(1));
+    }
+
+    /// <summary>
+    /// The parenthesised ring list shared by POLYGON and TRIANGLE, or <c>null</c> when
+    /// the geometry is EMPTY.
+    /// </summary>
+    private List<LinearRing>? ParseRings(WktTokenQueue tokens, WktDimensions dimensions)
+    {
         if (tokens.NextTokenIs("EMPTY"))
         {
             tokens.Dequeue();
-            return Polygon.Empty;
+            return null;
         }
 
         tokens.Dequeue(WktTokenType.LeftParenthesis);
         var linestrings = ParseLineStrings(tokens, dimensions);
         tokens.Dequeue(WktTokenType.RightParenthesis);
-        return new Polygon(
-            new LinearRing(linestrings.First().Coordinates),
-            linestrings.Skip(1).Select(x => new LinearRing(x.Coordinates))
-        );
+        return linestrings.Select(x => new LinearRing(x.Coordinates)).ToList();
     }
 
     private List<LineString> ParseLineStrings(WktTokenQueue tokens, WktDimensions dimensions)


### PR DESCRIPTION
WktReader read TRIANGLE as a plain Polygon. The type was lost on the way
in, so a triangle could not survive a WKT round-trip (WktWriter with
Triangle = true wrote it back out as POLYGON) and its ring went
unchecked - a five-coordinate "triangle" was accepted without complaint.
WkbReader already reads it as a Triangle; WktReader now does the same.

WktReader let exceptions from the coordinate and geometry constructors
escape: a latitude past the pole, a ring that does not close, or a number
the tokenizer accepts but double.Parse does not ("1-2", "1.2.3") surfaced
as ArgumentOutOfRangeException or FormatException naming a parameter the
caller never supplied. These are now reported as SerializationException,
like every other WKT parse failure, and as WkbReader and
GooglePolylineEncoder already do.

GeoJsonReader had the same problem, from a method that reports failure by
returning false: TryRead threw ArgumentException for out-of-range
ordinates or a malformed ring instead of returning false, and Read raised
that in place of a SerializationException.

StreamWrapper's constructor buffered a non-seekable source into memory but
left the buffer positioned at the end of the copy, so the wrapper read as
empty until something happened to seek it first - unlike a wrapper over a
seekable stream, and unlike CreateAsync, which has always rewound.

IgcDeSerializer resolved a file's two-digit year against a pivot taken
from DateTime.UtcNow.ToString("yy"), which reads the year through the
current culture's calendar. Under a non-Gregorian default the pivot came
from a different era and every fix in the file landed decades out: a 2026
flight was dated 1983 under th-TH and 2004 under ar-SA.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012UgbPvjs91476zJPLHPyLo