### PR TITLE
Fix five bugs: negative-zero coordinates, midnight rollover, NaN ordering

### DIFF
--- a/Geo.Tests/CoordinateTests.cs
+++ b/Geo.Tests/CoordinateTests.cs
@@ -283,6 +283,29 @@ public class CoordinateTests
     }
 
     [Theory]
+    // "-0" parses to negative zero, which is not less than zero, so the sign has to come
+    // from the text: every coordinate in the (-1, 0) degree band would otherwise come back
+    // on the wrong side of the equator or the meridian.
+    [InlineData("51 30 0, -0 7 12", 51.5, -0.12)]
+    [InlineData("51 30 0, 0 7 12", 51.5, 0.12)]
+    [InlineData("-0 30 0, 10 0 0", -0.5, 10)]
+    [InlineData("-0 7.2, -0 7.2", -0.12, -0.12)]
+    [InlineData("-0.5, -0.25", -0.5, -0.25)]
+    // A hemisphere letter still wins over the sign of the degrees, as it always has.
+    [InlineData("0 30 0 S, 0 7 12 W", -0.5, -0.12)]
+    public void Parse_keeps_the_sign_of_a_negative_zero_degrees_field(
+        string coordinate,
+        double latitude,
+        double longitude
+    )
+    {
+        var result = Coordinate.Parse(coordinate);
+
+        Assert.Equal(latitude, result.Latitude, 10);
+        Assert.Equal(longitude, result.Longitude, 10);
+    }
+
+    [Theory]
     [InlineData("91, 0")]
     [InlineData("-91, 0")]
     [InlineData("0, 181")]

--- a/Geo.Tests/Gps/Serialization/IgcDeSerializerTests.cs
+++ b/Geo.Tests/Gps/Serialization/IgcDeSerializerTests.cs
@@ -89,6 +89,53 @@ public class IgcDeSerializerTests : SerializerTestFixtureBase
         Assert.Empty(result.Waypoints);
     }
 
+    [Fact]
+    public void Fixes_past_midnight_are_dated_to_the_following_day()
+    {
+        // A B-record carries a time of day and nothing else, so a flight that runs past
+        // midnight UTC restarts at 00:00:00. Stamped onto the header's date regardless,
+        // the track jumped back a day mid-flight and its duration came out negative.
+        var igc = string.Join(
+            "\n",
+            "HFDTE010120",
+            "B2358005411868N00248134WA0050000600",
+            "B2359595411880N00248137WA0050000600",
+            "B0000015411890N00248139WA0050000600",
+            "B0001005411900N00248140WA0050000600"
+        );
+
+        var result = new IgcDeSerializer().DeSerialize(Wrap(igc));
+        var segment = result.Tracks[0].Segments[0];
+
+        Assert.Equal(new DateTime(2020, 1, 1, 23, 58, 0), segment.Waypoints[0].TimeUtc);
+        Assert.Equal(new DateTime(2020, 1, 1, 23, 59, 59), segment.Waypoints[1].TimeUtc);
+        Assert.Equal(new DateTime(2020, 1, 2, 0, 0, 1), segment.Waypoints[2].TimeUtc);
+        Assert.Equal(new DateTime(2020, 1, 2, 0, 1, 0), segment.Waypoints[3].TimeUtc);
+        Assert.Equal(TimeSpan.FromMinutes(3), segment.GetDuration());
+    }
+
+    [Fact]
+    public void A_reused_deserializer_does_not_carry_the_day_over_between_files()
+    {
+        // GpsData holds the deserializers as shared singletons, so the rollover state has
+        // to be per-call: the second file must start on its own header date.
+        var igc = string.Join(
+            "\n",
+            "HFDTE010120",
+            "B2358005411868N00248134WA0050000600",
+            "B0001005411900N00248140WA0050000600"
+        );
+
+        var parser = new IgcDeSerializer();
+        parser.DeSerialize(Wrap(igc));
+        var second = parser.DeSerialize(Wrap(igc));
+
+        Assert.Equal(
+            new DateTime(2020, 1, 1, 23, 58, 0),
+            second.Tracks[0].Segments[0].Waypoints[0].TimeUtc
+        );
+    }
+
     [Theory]
     [InlineData("en-GB")]
     // Calendars whose current year is not the Gregorian one.

--- a/Geo.Tests/Gps/Serialization/NmeaDeSerializerTests.cs
+++ b/Geo.Tests/Gps/Serialization/NmeaDeSerializerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Geo.Gps.Serialization;
@@ -106,5 +107,44 @@ public class NmeaDeSerializerTests : SerializerTestFixtureBase
 
         Assert.Single(result.Tracks);
         Assert.Single(result.Tracks[0].Segments[0].Waypoints);
+    }
+
+    [Fact]
+    public void Fixes_past_midnight_are_dated_to_the_following_day()
+    {
+        // GPGGA carries a time of day and no date, so a track that runs past midnight UTC
+        // restarts at 00:00:00. Stamped onto the same day regardless, the track jumped
+        // back twenty-four hours mid-recording and its duration came out negative.
+        var nmea = string.Join(
+            "\n",
+            "$GPGGA,235800.00,5920.7009,N,01803.2938,E,1,05,3.3,78.2,M,23.2,M,0.0,0000*4A",
+            "$GPGGA,000100.00,5920.7010,N,01803.2939,E,1,05,3.3,78.2,M,23.2,M,0.0,0000*4A"
+        );
+
+        var segment = new NmeaDeSerializer().DeSerialize(Wrap(nmea)).Tracks[0].Segments[0];
+
+        Assert.Equal(
+            segment.Waypoints[0].TimeUtc!.Value.AddMinutes(3),
+            segment.Waypoints[1].TimeUtc
+        );
+        Assert.Equal(TimeSpan.FromMinutes(3), segment.GetDuration());
+    }
+
+    [Fact]
+    public void A_reused_deserializer_does_not_carry_the_day_over_between_files()
+    {
+        // GpsData holds the deserializers as shared singletons, so the rollover state has
+        // to be per-call: the second file must start on the same day as the first did.
+        var nmea = string.Join(
+            "\n",
+            "$GPGGA,235800.00,5920.7009,N,01803.2938,E,1,05,3.3,78.2,M,23.2,M,0.0,0000*4A",
+            "$GPGGA,000100.00,5920.7010,N,01803.2939,E,1,05,3.3,78.2,M,23.2,M,0.0,0000*4A"
+        );
+
+        var parser = new NmeaDeSerializer();
+        var first = parser.DeSerialize(Wrap(nmea)).Tracks[0].Segments[0];
+        var second = parser.DeSerialize(Wrap(nmea)).Tracks[0].Segments[0];
+
+        Assert.Equal(first.Waypoints[0].TimeUtc, second.Waypoints[0].TimeUtc);
     }
 }

--- a/Geo.Tests/IO/GeoJson/GeoJsonReaderWriterTests.cs
+++ b/Geo.Tests/IO/GeoJson/GeoJsonReaderWriterTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
@@ -197,6 +198,15 @@ public class GeoJsonReaderWriterTests
         Assert.Throws<SerializationException>(() =>
             new GeoJsonWriter().Write((object)"not a geometry")
         );
+    }
+
+    [Fact]
+    public void Write_null_object_throws_argument_null()
+    {
+        // Reported as the bad argument it is, like every other null the readers and
+        // writers are handed, rather than as the NullReferenceException thrown while
+        // building the "not supported" message out of the missing object's type.
+        Assert.Throws<ArgumentNullException>(() => new GeoJsonWriter().Write((object)null!));
     }
 
     [Fact]

--- a/Geo.Tests/Measure/AreaTests.cs
+++ b/Geo.Tests/Measure/AreaTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Geo.Measure;
 using Xunit;
 
@@ -106,6 +107,16 @@ public class AreaTests
         Assert.True(new Area(100) <= new Area(400));
         Assert.False(new Area(400) <= new Area(100));
         Assert.Equal(-1, new Area(100).CompareTo(new Area(400)));
+    }
+
+    [Fact]
+    public void CompareTo_is_a_total_order_when_a_value_is_not_a_number()
+    {
+        var nan = new Area(double.NaN);
+
+        Assert.Equal(-1, Math.Sign(nan.CompareTo(new Area(100))));
+        Assert.Equal(1, Math.Sign(new Area(100).CompareTo(nan)));
+        Assert.Equal(0, nan.CompareTo(new Area(double.NaN)));
     }
 
     [Theory]

--- a/Geo.Tests/Measure/DistanceTests.cs
+++ b/Geo.Tests/Measure/DistanceTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Geo.Measure;
 using Xunit;
 
@@ -105,6 +107,33 @@ public class DistanceTests
         Assert.Equal(1, large.CompareTo(small));
         Assert.Equal(-1, small.CompareTo(large));
         Assert.Equal(0, large.CompareTo(new Distance(100)));
+    }
+
+    [Fact]
+    public void CompareTo_is_a_total_order_when_a_value_is_not_a_number()
+    {
+        var nan = new Distance(double.NaN);
+        var value = new Distance(100);
+
+        // Not equal, not less than - but not greater than either. Answering "greater" to
+        // both sides made the comparison self-contradictory, which is enough for a sort to
+        // shuffle unrelated elements out of order or to give up outright.
+        Assert.Equal(-1, Math.Sign(nan.CompareTo(value)));
+        Assert.Equal(1, Math.Sign(value.CompareTo(nan)));
+        Assert.Equal(0, nan.CompareTo(new Distance(double.NaN)));
+    }
+
+    [Fact]
+    public void Sorting_orders_every_value_even_alongside_a_nan()
+    {
+        var distances = new[] { 3d, double.NaN, 1d, 2d, 0d }.Select(x => new Distance(x)).ToArray();
+
+        Array.Sort(distances);
+
+        Assert.Equal(
+            new[] { double.NaN, 0d, 1d, 2d, 3d },
+            distances.Select(x => x.SiValue).ToArray()
+        );
     }
 
     [Fact]

--- a/Geo.Tests/Measure/SpeedTests.cs
+++ b/Geo.Tests/Measure/SpeedTests.cs
@@ -120,6 +120,16 @@ public class SpeedTests
     }
 
     [Fact]
+    public void CompareTo_is_a_total_order_when_a_value_is_not_a_number()
+    {
+        var nan = new Speed(double.NaN);
+
+        Assert.Equal(-1, Math.Sign(nan.CompareTo(new Speed(10))));
+        Assert.Equal(1, Math.Sign(new Speed(10).CompareTo(nan)));
+        Assert.Equal(0, nan.CompareTo(new Speed(double.NaN)));
+    }
+
+    [Fact]
     public void Equal_speeds_share_a_hash_code()
     {
         Assert.Equal(new Speed(12.5).GetHashCode(), new Speed(12.5).GetHashCode());

--- a/Geo/Coordinate.cs
+++ b/Geo/Coordinate.cs
@@ -112,33 +112,8 @@ public class Coordinate : SpatialObject, IPosition
 
         if (match.Success)
         {
-            var deg1 = double.Parse(match.Groups["Deg1"].Value, CultureInfo.InvariantCulture);
-            var deg2 = double.Parse(match.Groups["Deg2"].Value, CultureInfo.InvariantCulture);
-
-            double temp;
-            double dir;
-
-            if (deg1 < 0.0)
-                dir = -1.0;
-            else
-                dir = 1.0;
-
-            if (TryParseOrdinatePart(match, "Min1", out temp))
-                deg1 += dir * temp / 60;
-
-            if (TryParseOrdinatePart(match, "Sec1", out temp))
-                deg1 += dir * temp / 3600;
-
-            if (deg2 < 0.0)
-                dir = -1.0;
-            else
-                dir = 1.0;
-
-            if (TryParseOrdinatePart(match, "Min2", out temp))
-                deg2 += dir * temp / 60;
-
-            if (TryParseOrdinatePart(match, "Sec2", out temp))
-                deg2 += dir * temp / 3600;
+            var deg1 = ParseOrdinate(match, "Deg1", "Min1", "Sec1");
+            var deg2 = ParseOrdinate(match, "Deg2", "Min2", "Sec2");
 
             var dir1 = Regex.IsMatch(match.Groups["Dir1"].Value, "[Ss]") ? -1d : 1d;
             var dir2 = Regex.IsMatch(match.Groups["Dir2"].Value, "[Ww]") ? -1d : 1d;
@@ -152,6 +127,40 @@ public class Coordinate : SpatialObject, IPosition
 
         result = default;
         return false;
+    }
+
+    /// <summary>
+    /// Assembles one ordinate from its degrees, minutes and seconds groups.
+    /// </summary>
+    /// <remarks>
+    /// The minutes and seconds are added to the <em>magnitude</em> of the degrees and the
+    /// sign is applied once at the end, because a degrees field of "-0" parses to negative
+    /// zero, which is not less than zero. Deciding the direction by testing the parsed
+    /// value therefore read "-0 7 12" as travelling north/east of zero, and every
+    /// coordinate in the (-1, 0) degree band - which is where most of western Europe's
+    /// longitudes sit - came back on the wrong side of the meridian, up to 111 km out.
+    /// The sign is taken from the text instead, which is the only place it survives.
+    /// </remarks>
+    private static double ParseOrdinate(
+        Match match,
+        string degreesGroup,
+        string minutesGroup,
+        string secondsGroup
+    )
+    {
+        var text = match.Groups[degreesGroup].Value;
+        var degrees = double.Parse(text, CultureInfo.InvariantCulture);
+        var negative = degrees < 0 || text.TrimStart().StartsWith("-", StringComparison.Ordinal);
+
+        var magnitude = Math.Abs(degrees);
+
+        if (TryParseOrdinatePart(match, minutesGroup, out var minutes))
+            magnitude += minutes / 60;
+
+        if (TryParseOrdinatePart(match, secondsGroup, out var seconds))
+            magnitude += seconds / 3600;
+
+        return negative ? -magnitude : magnitude;
     }
 
     // The minutes and seconds groups must be read with the same invariant culture as the

--- a/Geo/Gps/Serialization/FixClock.cs
+++ b/Geo/Gps/Serialization/FixClock.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using System;
+
+namespace Geo.Gps.Serialization;
+
+/// <summary>
+/// Turns the bare time of day carried by a track fix into a full timestamp, rolling the
+/// date forward every time the clock wraps past midnight.
+/// </summary>
+/// <remarks>
+/// IGC B-records and NMEA sentences date their fixes with a time of day and nothing else:
+/// a flight or a drive that runs past midnight UTC simply restarts at 00:00:00. Stamping
+/// every fix onto the same day therefore sent the track twenty-four hours backwards
+/// mid-recording, which left <see cref="TrackSegment.GetDuration" /> negative and
+/// <see cref="TrackSegment.GetAverageSpeed" /> with it. Fixes arrive in order, so a time
+/// of day earlier than the one before it can only mean the date has moved on.
+/// </remarks>
+internal sealed class FixClock
+{
+    private TimeSpan _previous = TimeSpan.MinValue;
+    private int _days;
+
+    /// <summary>
+    /// The timestamp for a fix recorded at <paramref name="timeOfDay" /> on the day that
+    /// began at <paramref name="date" />, or on a later one if the clock has wrapped since
+    /// the first fix.
+    /// </summary>
+    public DateTime Resolve(DateTime date, TimeSpan timeOfDay)
+    {
+        if (timeOfDay < _previous)
+            _days++;
+
+        _previous = timeOfDay;
+        return date.AddDays(_days) + timeOfDay;
+    }
+}

--- a/Geo/Gps/Serialization/IgcDeSerializer.cs
+++ b/Geo/Gps/Serialization/IgcDeSerializer.cs
@@ -57,6 +57,9 @@ public class IgcDeSerializer : IGpsFileDeSerializer
         var data = new GpsData();
         var date = default(DateTime);
         var trackSegment = new TrackSegment();
+        // Local to this call: the deserializers are held as shared singletons by GpsData,
+        // so per-file state cannot live on the instance.
+        var clock = new FixClock();
 
         streamWrapper.Position = 0;
         using (var reader = new StreamReader(streamWrapper))
@@ -100,7 +103,7 @@ public class IgcDeSerializer : IGpsFileDeSerializer
                 if (ParseMetadata(data, x => x.Vehicle.Crew2, H_CREW2_REGEX, line))
                     continue;
 
-                if (ParseFix(line, trackSegment, date))
+                if (ParseFix(line, trackSegment, date, clock))
                     continue;
             }
         }
@@ -131,7 +134,7 @@ public class IgcDeSerializer : IGpsFileDeSerializer
         return false;
     }
 
-    private bool ParseFix(string line, TrackSegment trackSegment, DateTime date)
+    private bool ParseFix(string line, TrackSegment trackSegment, DateTime date, FixClock clock)
     {
         if (string.IsNullOrWhiteSpace(line))
             return false;
@@ -147,14 +150,18 @@ public class IgcDeSerializer : IGpsFileDeSerializer
             var presAlt = match.Groups["presAlt"].Value;
             var gpsAlt = match.Groups["gpsAlt"].Value;
 
+            var timeOfDay = new TimeSpan(
+                int.Parse(h, CultureInfo.InvariantCulture),
+                int.Parse(m, CultureInfo.InvariantCulture),
+                int.Parse(s, CultureInfo.InvariantCulture)
+            );
+
             var cood = ParseCoordinate(coord);
             var waypoint = new Waypoint(
                 cood.Latitude,
                 cood.Longitude,
                 double.Parse(gpsAlt, CultureInfo.InvariantCulture),
-                date.AddHours(int.Parse(h, CultureInfo.InvariantCulture))
-                    .AddMinutes(int.Parse(m, CultureInfo.InvariantCulture))
-                    .AddSeconds(int.Parse(s, CultureInfo.InvariantCulture))
+                clock.Resolve(date, timeOfDay)
             );
 
             trackSegment.Waypoints.Add(waypoint);

--- a/Geo/Gps/Serialization/NmeaDeSerializer.cs
+++ b/Geo/Gps/Serialization/NmeaDeSerializer.cs
@@ -39,13 +39,16 @@ public class NmeaDeSerializer : IGpsFileDeSerializer
     {
         var data = new GpsData();
         var trackSegment = new TrackSegment();
+        // Local to this call: the deserializers are held as shared singletons by GpsData,
+        // so per-file state cannot live on the instance.
+        var clock = new FixClock();
         streamWrapper.Position = 0;
         using (var reader = new StreamReader(streamWrapper))
         {
             string? line;
             while ((line = reader.ReadLine()) != null)
             {
-                if (ParseFix(line, trackSegment))
+                if (ParseFix(line, trackSegment, clock))
                     continue;
                 if (ParseWaypoint(line, data))
                     continue;
@@ -61,7 +64,7 @@ public class NmeaDeSerializer : IGpsFileDeSerializer
         return data;
     }
 
-    private bool ParseFix(string line, TrackSegment trackSegment)
+    private bool ParseFix(string line, TrackSegment trackSegment, FixClock clock)
     {
         if (string.IsNullOrWhiteSpace(line))
             return false;
@@ -76,12 +79,12 @@ public class NmeaDeSerializer : IGpsFileDeSerializer
             var lat = ConvertOrd(match.Groups["lat"].Value, match.Groups["latd"].Value);
             var lon = ConvertOrd(match.Groups["lon"].Value, match.Groups["lond"].Value);
 
-            var waypoint = new Waypoint(
-                lat,
-                lon,
-                alt,
-                DateTime.MinValue.AddHours(h).AddMinutes(m).AddSeconds(s)
-            );
+            // GPGGA carries no date, so the fixes are stamped onto the first representable
+            // day; only the intervals between them are meaningful.
+            var timeOfDay =
+                TimeSpan.FromHours(h) + TimeSpan.FromMinutes(m) + TimeSpan.FromSeconds(s);
+
+            var waypoint = new Waypoint(lat, lon, alt, clock.Resolve(DateTime.MinValue, timeOfDay));
             trackSegment.Waypoints.Add(waypoint);
 
             return true;

--- a/Geo/IO/GeoJson/GeoJsonWriter.cs
+++ b/Geo/IO/GeoJson/GeoJsonWriter.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -23,6 +24,11 @@ public class GeoJsonWriter
 
     public string Write(object obj)
     {
+        // Reported as the bad argument it is, rather than as the NullReferenceException
+        // the "not supported by GeoJSON" message threw while naming the type.
+        if (obj == null)
+            throw new ArgumentNullException("obj");
+
         var geometry = obj as IGeometry;
         if (geometry != null)
             return Write(geometry);

--- a/Geo/Measure/Area.cs
+++ b/Geo/Measure/Area.cs
@@ -37,11 +37,11 @@ public struct Area : IMeasure, IEquatable<Area>, IComparable<Area>
         return ConvertTo(unit).ToString();
     }
 
+    // Delegating to double keeps the ordering total; see Distance.CompareTo for why
+    // deriving "greater than" from "neither equal nor less than" does not hold.
     public int CompareTo(Area other)
     {
-        if (Equals(other))
-            return 0;
-        return SiValue < other.SiValue ? -1 : 1;
+        return SiValue.CompareTo(other.SiValue);
     }
 
     public bool Equals(Area other)

--- a/Geo/Measure/Distance.cs
+++ b/Geo/Measure/Distance.cs
@@ -38,11 +38,15 @@ public struct Distance : IMeasure, IEquatable<Distance>, IComparable<Distance>
         return ConvertTo(unit).ToString();
     }
 
+    // Delegating to double keeps the ordering total. Deciding "not equal, and not less
+    // than, therefore greater than" broke down for a NaN measure, which is neither: two
+    // distances could each report themselves the greater, and a sort handed that pair
+    // shuffled the values around it out of order (or gave up with "IComparer.Compare()
+    // method returns inconsistent results"). Double.CompareTo agrees with Equals on the
+    // cases that matter here - NaN compares equal to NaN, and zero to negative zero.
     public int CompareTo(Distance other)
     {
-        if (Equals(other))
-            return 0;
-        return SiValue < other.SiValue ? -1 : 1;
+        return SiValue.CompareTo(other.SiValue);
     }
 
     public bool Equals(Distance other)

--- a/Geo/Measure/Speed.cs
+++ b/Geo/Measure/Speed.cs
@@ -55,11 +55,11 @@ public struct Speed : IMeasure, IEquatable<Speed>, IComparable<Speed>
         return ConvertTo(unit).ToString();
     }
 
+    // Delegating to double keeps the ordering total; see Distance.CompareTo for why
+    // deriving "greater than" from "neither equal nor less than" does not hold.
     public int CompareTo(Speed other)
     {
-        if (Equals(other))
-            return 0;
-        return SiValue < other.SiValue ? -1 : 1;
+        return SiValue.CompareTo(other.SiValue);
     }
 
     public bool Equals(Speed other)


### PR DESCRIPTION
Coordinate.TryParse lost the sign of a degrees field written as "-0". The
direction was decided by testing the parsed value, and negative zero is not
less than zero, so the minutes and seconds were added rather than subtracted
and the result came back positive. Every DMS/DM coordinate in the (-1, 0)
degree band - which is where most of western Europe's longitudes sit - landed
on the wrong side of the meridian, up to 111 km out: "51 30 0, -0 7 12" parsed
as 51.5, +0.12. The sign is now read from the text, which is the only place it
survives, and applied once to the assembled magnitude.

IGC and NMEA fixes carry a time of day and nothing else, so a track that runs
past midnight UTC restarts at 00:00:00. Both deserializers stamped every fix
onto the same day, sending the track twenty-four hours backwards mid-recording
and leaving GetDuration and GetAverageSpeed negative. A new FixClock rolls the
date forward whenever the clock goes backwards; it is created per call, since
GpsData holds the deserializers as shared singletons.

Distance, Area and Speed derived CompareTo from "neither equal nor less than,
therefore greater than", which does not hold for a NaN measure: each side
reported itself the greater, and sorting such a set shuffled the surrounding
values out of order. They now delegate to Double.CompareTo, which is total and
agrees with their Equals.

GeoJsonWriter.Write(object) threw NullReferenceException for a null argument
while building the "not supported by GeoJSON" message out of its type; it now
reports the bad argument like the other readers and writers do.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MnzgV69TWFePB2s2sva3Wp