### PR TITLE
Parse leading hemisphere letters and hyphen-separated DMS coordinates

### DIFF
--- a/Geo.Tests/CoordinateTests.cs
+++ b/Geo.Tests/CoordinateTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using Xunit;
 
 namespace Geo.Tests;
@@ -326,17 +327,80 @@ public class CoordinateTests
         Assert.Null(result);
     }
 
+    [Theory]
+    // The hyphen-separated form used by the FAA and the NGS. The hyphen is a separator,
+    // not a sign: read as one, "40-26-46N" subtracted its own minutes and seconds and came
+    // out 190 km from where it says, and "000-07-12W" drove the ordinate negative and then
+    // let the W negate it again, landing on the wrong side of the meridian entirely.
+    [InlineData("40-26-46N, 079-56-55W", 40.446111111111111, -79.948611111111111)]
+    [InlineData("40-26-46N 079-56-55W", 40.446111111111111, -79.948611111111111)]
+    [InlineData("51-30-00N, 000-07-12W", 51.5, -0.12)]
+    [InlineData("N51-30-00, W000-07-12", 51.5, -0.12)]
+    [InlineData("S33-52-00, E151-12-00", -33.866666666666667, 151.2)]
+    [InlineData("51-30, 0-7", 51.5, 0.11666666666666667)]
+    public void Parse_accepts_hyphen_separated_degrees_minutes_and_seconds(
+        string coordinate,
+        double latitude,
+        double longitude
+    )
+    {
+        var result = Coordinate.Parse(coordinate);
+
+        Assert.Equal(latitude, result.Latitude, 10);
+        Assert.Equal(longitude, result.Longitude, 10);
+    }
+
+    [Theory]
+    // Only the degrees carry a sign. A minutes or seconds field is a magnitude - no
+    // notation writes "51° -30'" - so the hyphen in front of one is the separator that
+    // introduces it, and the field is added rather than subtracted.
+    [InlineData("1 -2, 3", 1.0333333333333333, 3)]
+    [InlineData("51 -30, 0", 51.5, 0)]
+    // A sign on the degrees is still honoured, including where the ordinate that follows
+    // is separated by whitespace alone.
+    [InlineData("51.5 -0.12", 51.5, -0.12)]
+    [InlineData("51.5, -0.12", 51.5, -0.12)]
+    public void Minutes_and_seconds_are_magnitudes(
+        string coordinate,
+        double latitude,
+        double longitude
+    )
+    {
+        var result = Coordinate.Parse(coordinate);
+
+        Assert.Equal(latitude, result.Latitude, 10);
+        Assert.Equal(longitude, result.Longitude, 10);
+    }
+
+    [Theory]
+    // A sign or a stray point glued to a number used to open a fresh minutes or seconds
+    // field, so these returned a position instead of failing. Nothing writes a coordinate
+    // this way, and requiring a separator is what makes the parse linear.
+    [InlineData("1+2, 3")]
+    [InlineData("4, 1+5")]
+    [InlineData("1.2.3, 4")]
+    [InlineData("1..2, 3")]
+    public void TryParse_rejects_a_field_that_is_not_introduced_by_a_separator(string coordinate)
+    {
+        Assert.False(Coordinate.TryParse(coordinate, out var result));
+        Assert.Null(result);
+    }
+
     [Fact]
     public void TryParse_does_not_hang_on_a_long_run_of_digits()
     {
-        // Six number fields whose separators are all optional used to let the engine carve
+        // Six number fields whose separators were all optional used to let the engine carve
         // a digit run up an exponential number of ways before giving up: forty digits took
-        // over five seconds, and each further digit multiplied that.
+        // over five seconds, and each further digit multiplied that. Requiring a separator
+        // in front of the minutes and the seconds leaves one way to read a run, so the
+        // whole thing is linear and needs no match timeout to bound it.
         var stopwatch = Stopwatch.StartNew();
 
-        Assert.False(Coordinate.TryParse(new string('1', 4000), out _));
-        Assert.False(Coordinate.TryParse(new string('1', 4000) + "!", out _));
-        Assert.False(Coordinate.TryParse("N" + new string('1', 4000), out _));
+        Assert.False(Coordinate.TryParse(new string('1', 50000), out _));
+        Assert.False(Coordinate.TryParse(new string('1', 50000) + "!", out _));
+        Assert.False(Coordinate.TryParse("N" + new string('1', 50000), out _));
+        Assert.False(Coordinate.TryParse(string.Concat(Enumerable.Repeat("1-", 50000)), out _));
+        Assert.False(Coordinate.TryParse(string.Concat(Enumerable.Repeat("1-2, ", 50000)), out _));
 
         Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5));
     }

--- a/Geo.Tests/CoordinateTests.cs
+++ b/Geo.Tests/CoordinateTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 using Xunit;
 
@@ -280,6 +281,64 @@ public class CoordinateTests
         Assert.False(success);
         Assert.Null(result);
         Assert.Null(Coordinate.TryParse(null));
+    }
+
+    [Theory]
+    // The hemisphere letter written in front of the ordinate, as aviation and marine
+    // sources overwhelmingly write it. None of these parsed at all before.
+    [InlineData("N51 30.0, W000 07.2", 51.5, -0.12)]
+    [InlineData("N51 30.0 W000 07.2", 51.5, -0.12)]
+    [InlineData("N 51 30.0, W 000 07.2", 51.5, -0.12)]
+    [InlineData("N51°30.0', W000°07.2'", 51.5, -0.12)]
+    [InlineData("N51 30 00, W000 07 12", 51.5, -0.12)]
+    [InlineData("S33 52 00, E151 12 00", -33.866666666666667, 151.2)]
+    [InlineData("N51.5, W0.12", 51.5, -0.12)]
+    [InlineData("n51.5, w0.12", 51.5, -0.12)]
+    [InlineData("(N51 30.0, W000 07.2)", 51.5, -0.12)]
+    // Stated on both sides, saying the same thing twice.
+    [InlineData("N51 30.0N, W000 07.2W", 51.5, -0.12)]
+    public void Parse_accepts_a_leading_hemisphere_letter(
+        string coordinate,
+        double latitude,
+        double longitude
+    )
+    {
+        var result = Coordinate.Parse(coordinate);
+
+        Assert.Equal(latitude, result.Latitude, 10);
+        Assert.Equal(longitude, result.Longitude, 10);
+    }
+
+    [Theory]
+    // The two letters contradict each other.
+    [InlineData("N51 30.0S, W000 07.2W")]
+    [InlineData("N51 30.0, W000 07.2E")]
+    // A letter naming the wrong axis. Ignoring it dropped the hemisphere silently and put
+    // the position on the wrong side of the meridian, so it fails the parse instead; the
+    // ordinates are read latitude first, and the caller has to present them that way.
+    [InlineData("E51 30.0, W000 07.2")]
+    [InlineData("N51 30.0, N000 07.2")]
+    [InlineData("W000 07.2, N51 30.0")]
+    [InlineData("0.12W, 51.5N")]
+    public void TryParse_rejects_hemisphere_letters_it_cannot_honour(string coordinate)
+    {
+        Assert.False(Coordinate.TryParse(coordinate, out var result));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryParse_does_not_hang_on_a_long_run_of_digits()
+    {
+        // Six number fields whose separators are all optional used to let the engine carve
+        // a digit run up an exponential number of ways before giving up: forty digits took
+        // over five seconds, and each further digit multiplied that.
+        var stopwatch = Stopwatch.StartNew();
+
+        Assert.False(Coordinate.TryParse(new string('1', 4000), out _));
+        Assert.False(Coordinate.TryParse(new string('1', 4000) + "!", out _));
+        Assert.False(Coordinate.TryParse("N" + new string('1', 4000), out _));
+
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5));
     }
 
     [Theory]

--- a/Geo/Coordinate.cs
+++ b/Geo/Coordinate.cs
@@ -10,12 +10,34 @@ namespace Geo;
 
 public class Coordinate : SpatialObject, IPosition
 {
-    private const string CoordinateRegex =
+    // One ordinate's number: an optional sign, then digits with optional decimals, or a
+    // bare fraction. Spelling it this way rather than as (?:\d+\.?\d*|\d*\.?\d+) matches
+    // exactly the same strings but only one way each. The two branches of the old form
+    // both accepted a plain run of digits, and could split one between \d+ and \d* at any
+    // point, so six of these in sequence gave the engine an exponential number of ways to
+    // carve up a long run before admitting the string was not a coordinate at all: forty
+    // digits took over five seconds, and each further digit multiplied that.
+    private const string OrdinateNumber = @"[+-]?(?:\d+(?:\.\d*)?|\.\d+)";
+
+    // The hemisphere letter may lead the ordinate ("N51 30.0") as well as follow it
+    // ("51 30.0N"): aviation and marine sources overwhelmingly write it in front, and a
+    // string of theirs did not parse at all before. Both spellings are optional, and an
+    // ordinate that carries the letter on both sides has to say the same thing twice.
+    private static readonly string CoordinateRegex =
         @"^[\(\[\{\s]*"
-        + @"(?<Deg1>[+-]?(?:\d+\.?\d*|\d*\.?\d+)[\r\n]*)[°Dd\s]*(?<Min1>[+-]?(?:\d+\.?\d*|\d*\.?\d+)[\r\n]*)?[°'′Mm\s]*(?<Sec1>[+-]?(?:\d+\.?\d*|\d*\.?\d+)[\r\n]*)?[\""″\s]*(?<Dir1>[NnSsEeWw])?"
+        + $@"(?<Pre1>[NnSsEeWw])?\s*(?<Deg1>{OrdinateNumber}[\r\n]*)[°Dd\s]*(?<Min1>{OrdinateNumber}[\r\n]*)?[°'′Mm\s]*(?<Sec1>{OrdinateNumber}[\r\n]*)?[\""″\s]*(?<Dir1>[NnSsEeWw])?"
         + @"[,\s]+"
-        + @"(?<Deg2>[+-]?(?:\d+\.?\d*|\d*\.?\d+)[\r\n]*)[°Dd\s]*(?<Min2>[+-]?(?:\d+\.?\d*|\d*\.?\d+)[\r\n]*)?[°'′Mm\s]*(?<Sec2>[+-]?(?:\d+\.?\d*|\d*\.?\d+)[\r\n]*)?[\""″\s]*(?<Dir2>[NnSsEeWw])?"
+        + $@"(?<Pre2>[NnSsEeWw])?\s*(?<Deg2>{OrdinateNumber}[\r\n]*)[°Dd\s]*(?<Min2>{OrdinateNumber}[\r\n]*)?[°'′Mm\s]*(?<Sec2>{OrdinateNumber}[\r\n]*)?[\""″\s]*(?<Dir2>[NnSsEeWw])?"
         + @"[\)\]\}\s]*$";
+
+    // A backstop for what the rewrite above cannot reach. Degrees, minutes and seconds are
+    // separated by characters that are all optional, so a long run of digits can still be
+    // divided between the three fields polynomially many ways; that is no longer
+    // exponential, but several hundred digits would still take seconds. Nothing any
+    // coordinate notation produces comes within orders of magnitude of this budget, and a
+    // string that exhausts it is reported as one that does not parse rather than being
+    // allowed to occupy the caller indefinitely.
+    private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(250);
 
     public Coordinate()
         : this(0, 0) { }
@@ -108,15 +130,25 @@ public class Coordinate : SpatialObject, IPosition
             return false;
         }
 
-        var match = Regex.Match(coordinate, CoordinateRegex);
+        Match match;
+        try
+        {
+            match = Regex.Match(coordinate, CoordinateRegex, RegexOptions.None, MatchTimeout);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            result = default;
+            return false;
+        }
 
-        if (match.Success)
+        if (
+            match.Success
+            && TryParseHemisphere(match, "Pre1", "Dir1", 'N', 'S', out var dir1)
+            && TryParseHemisphere(match, "Pre2", "Dir2", 'E', 'W', out var dir2)
+        )
         {
             var deg1 = ParseOrdinate(match, "Deg1", "Min1", "Sec1");
             var deg2 = ParseOrdinate(match, "Deg2", "Min2", "Sec2");
-
-            var dir1 = Regex.IsMatch(match.Groups["Dir1"].Value, "[Ss]") ? -1d : 1d;
-            var dir2 = Regex.IsMatch(match.Groups["Dir2"].Value, "[Ww]") ? -1d : 1d;
 
             if (deg1 is <= 90 and >= -90 && deg2 is <= 180 and >= -180)
             {
@@ -126,6 +158,58 @@ public class Coordinate : SpatialObject, IPosition
         }
 
         result = default;
+        return false;
+    }
+
+    /// <summary>
+    /// The sign the ordinate's hemisphere letter asks for — <c>1</c> for
+    /// <paramref name="positive" /> (and for no letter at all), <c>-1</c> for
+    /// <paramref name="negative" />. Returns <c>false</c> when the letters cannot be
+    /// honoured, which fails the parse.
+    /// </summary>
+    /// <remarks>
+    /// A letter naming the other axis — an E or a W where a latitude belongs — is rejected
+    /// rather than ignored. Ignoring it dropped the hemisphere silently, so "0.12W, 51.5N"
+    /// parsed as if both ordinates were positive and put the position on the wrong side of
+    /// the meridian; refusing it leaves the caller to swap the ordinates into the
+    /// latitude-then-longitude order this method reads them in.
+    /// </remarks>
+    private static bool TryParseHemisphere(
+        Match match,
+        string prefixGroup,
+        string suffixGroup,
+        char positive,
+        char negative,
+        out double sign
+    )
+    {
+        sign = 1;
+
+        var prefix = match.Groups[prefixGroup].Value;
+        var suffix = match.Groups[suffixGroup].Value;
+
+        if (prefix.Length == 0 && suffix.Length == 0)
+            return true;
+
+        // Written on both sides, the two can only be a restatement of one hemisphere.
+        if (
+            prefix.Length > 0
+            && suffix.Length > 0
+            && char.ToUpperInvariant(prefix[0]) != char.ToUpperInvariant(suffix[0])
+        )
+            return false;
+
+        var letter = char.ToUpperInvariant(prefix.Length > 0 ? prefix[0] : suffix[0]);
+
+        if (letter == positive)
+            return true;
+
+        if (letter == negative)
+        {
+            sign = -1;
+            return true;
+        }
+
         return false;
     }
 

--- a/Geo/Coordinate.cs
+++ b/Geo/Coordinate.cs
@@ -10,34 +10,44 @@ namespace Geo;
 
 public class Coordinate : SpatialObject, IPosition
 {
-    // One ordinate's number: an optional sign, then digits with optional decimals, or a
-    // bare fraction. Spelling it this way rather than as (?:\d+\.?\d*|\d*\.?\d+) matches
-    // exactly the same strings but only one way each. The two branches of the old form
-    // both accepted a plain run of digits, and could split one between \d+ and \d* at any
-    // point, so six of these in sequence gave the engine an exponential number of ways to
-    // carve up a long run before admitting the string was not a coordinate at all: forty
-    // digits took over five seconds, and each further digit multiplied that.
-    private const string OrdinateNumber = @"[+-]?(?:\d+(?:\.\d*)?|\.\d+)";
+    // A number, written only one way: digits with optional decimals, or a bare fraction.
+    // Spelling it so rather than as (?:\d+\.?\d*|\d*\.?\d+) matches exactly the same
+    // strings, but that older form had two branches which both accepted a plain run of
+    // digits and could split one between \d+ and \d* at any point. Six of those in
+    // sequence gave the engine an exponential number of ways to carve up a long run before
+    // admitting the string was not a coordinate at all: forty digits took over five
+    // seconds, and every further digit multiplied that.
+    private const string Number = @"(?:\d+(?:\.\d*)?|\.\d+)";
+
+    // Only the degrees carry a sign. A minutes or seconds field is a magnitude - no
+    // notation writes "51° -30'" - and reading one as signed is what made "51-30-00N",
+    // the hyphen-separated form below, subtract its own minutes.
+    private const string DegreesNumber = "[+-]?" + Number;
+
+    // What may stand between the degrees, the minutes and the seconds of one ordinate.
+    // The hyphen is a separator here, as in the FAA/NGS form "40-26-46N 079-56-55W", and
+    // never a sign: a sign belongs to the degrees or to the hemisphere letter.
+    private const string DegreesSeparator = @"[°Dd\s\-]";
+    private const string MinutesSeparator = @"[°'′Mm\s\-]";
+    private const string SecondsSeparator = @"[""″\s]";
+
+    // A minutes or seconds field has to be introduced by at least one separator, so a run
+    // of digits can no longer be divided between the three fields at arbitrary points.
+    // That kept the parse both honest and cheap: "40-26-46N" is 40°26'46" rather than 40
+    // degrees less 26 minutes less 46 seconds, and twenty thousand digits are rejected in
+    // milliseconds instead of hanging the caller.
+    private static string Ordinate(string n) =>
+        $@"(?<Pre{n}>[NnSsEeWw])?\s*(?<Deg{n}>{DegreesNumber}[\r\n]*)"
+        + $@"{DegreesSeparator}*(?:{DegreesSeparator}(?<Min{n}>{Number}[\r\n]*))?"
+        + $@"{MinutesSeparator}*(?:{MinutesSeparator}(?<Sec{n}>{Number}[\r\n]*))?"
+        + $@"{SecondsSeparator}*(?<Dir{n}>[NnSsEeWw])?";
 
     // The hemisphere letter may lead the ordinate ("N51 30.0") as well as follow it
     // ("51 30.0N"): aviation and marine sources overwhelmingly write it in front, and a
     // string of theirs did not parse at all before. Both spellings are optional, and an
     // ordinate that carries the letter on both sides has to say the same thing twice.
     private static readonly string CoordinateRegex =
-        @"^[\(\[\{\s]*"
-        + $@"(?<Pre1>[NnSsEeWw])?\s*(?<Deg1>{OrdinateNumber}[\r\n]*)[°Dd\s]*(?<Min1>{OrdinateNumber}[\r\n]*)?[°'′Mm\s]*(?<Sec1>{OrdinateNumber}[\r\n]*)?[\""″\s]*(?<Dir1>[NnSsEeWw])?"
-        + @"[,\s]+"
-        + $@"(?<Pre2>[NnSsEeWw])?\s*(?<Deg2>{OrdinateNumber}[\r\n]*)[°Dd\s]*(?<Min2>{OrdinateNumber}[\r\n]*)?[°'′Mm\s]*(?<Sec2>{OrdinateNumber}[\r\n]*)?[\""″\s]*(?<Dir2>[NnSsEeWw])?"
-        + @"[\)\]\}\s]*$";
-
-    // A backstop for what the rewrite above cannot reach. Degrees, minutes and seconds are
-    // separated by characters that are all optional, so a long run of digits can still be
-    // divided between the three fields polynomially many ways; that is no longer
-    // exponential, but several hundred digits would still take seconds. Nothing any
-    // coordinate notation produces comes within orders of magnitude of this budget, and a
-    // string that exhausts it is reported as one that does not parse rather than being
-    // allowed to occupy the caller indefinitely.
-    private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(250);
+        @"^[\(\[\{\s]*" + Ordinate("1") + @"[,\s]+" + Ordinate("2") + @"[\)\]\}\s]*$";
 
     public Coordinate()
         : this(0, 0) { }
@@ -130,16 +140,7 @@ public class Coordinate : SpatialObject, IPosition
             return false;
         }
 
-        Match match;
-        try
-        {
-            match = Regex.Match(coordinate, CoordinateRegex, RegexOptions.None, MatchTimeout);
-        }
-        catch (RegexMatchTimeoutException)
-        {
-            result = default;
-            return false;
-        }
+        var match = Regex.Match(coordinate, CoordinateRegex);
 
         if (
             match.Success
@@ -217,13 +218,14 @@ public class Coordinate : SpatialObject, IPosition
     /// Assembles one ordinate from its degrees, minutes and seconds groups.
     /// </summary>
     /// <remarks>
-    /// The minutes and seconds are added to the <em>magnitude</em> of the degrees and the
-    /// sign is applied once at the end, because a degrees field of "-0" parses to negative
-    /// zero, which is not less than zero. Deciding the direction by testing the parsed
-    /// value therefore read "-0 7 12" as travelling north/east of zero, and every
-    /// coordinate in the (-1, 0) degree band - which is where most of western Europe's
-    /// longitudes sit - came back on the wrong side of the meridian, up to 111 km out.
-    /// The sign is taken from the text instead, which is the only place it survives.
+    /// Minutes and seconds are magnitudes, always moving the position further from the
+    /// equator or the meridian, and only the degrees carry a sign. That sign is applied
+    /// once, at the end, rather than to each field as it is added: a degrees field of "-0"
+    /// parses to negative zero, which is not less than zero, so deciding the direction by
+    /// testing the parsed value read "-0 7 12" as travelling north/east of zero and put
+    /// every coordinate in the (-1, 0) degree band - which is where most of western
+    /// Europe's longitudes sit - on the wrong side of the meridian, up to 111 km out. The
+    /// sign is taken from the text instead, which is the only place it survives.
     /// </remarks>
     private static double ParseOrdinate(
         Match match,

--- a/docs/coordinate.md
+++ b/docs/coordinate.md
@@ -89,5 +89,23 @@ ordinate is allowed as long as it says the same thing twice.
 Coordinate.TryParse("W000 07.2, N51 30.0", out var swapped);  // false — longitude first
 ```
 
+Degrees, minutes and seconds may be separated by a degree/minute/second mark,
+whitespace, or a hyphen — the last being the form the FAA and the NGS use:
+
+```csharp
+Coordinate.Parse("40-26-46N, 079-56-55W");      // 40.4461…, -79.9486…
+Coordinate.Parse("N51-30-00, W000-07-12");      // 51.5, -0.12
+```
+
+Only the degrees carry a sign; minutes and seconds are magnitudes, so a hyphen in
+front of one is always the separator introducing it and never a negative value.
+Whichever separator is used, it has to be there: `1+2, 3` and `1.2.3, 4` do not
+parse, because the second field is not introduced by anything.
+
+```csharp
+Coordinate.Parse("51 -30, 0");                  // 51.5 — 51° 30′, not 51° less 30′
+Coordinate.Parse("-0 07 12, 10");               // -0.12 — the sign is on the degrees
+```
+
 If you don't know whether a string is a coordinate pair, WKT, or GeoJSON, use
 [`GeoFormat`](parsing.md) to detect the format and parse it in one step.

--- a/docs/coordinate.md
+++ b/docs/coordinate.md
@@ -71,5 +71,23 @@ var maybe = Coordinate.TryParse("12 34.56'N 123 45.55'E");     // returns null o
 if (Coordinate.TryParse("...", out var parsed)) { /* ... */ }
 ```
 
+The hemisphere letter may lead the ordinate as well as follow it, which is how
+aviation and marine sources usually write it:
+
+```csharp
+Coordinate.Parse("N51 30.0, W000 07.2");        // 51.5, -0.12
+Coordinate.Parse("N51°30.0', W000°07.2'");      // 51.5, -0.12
+Coordinate.Parse("S33 52 00, E151 12 00");      // -33.8666…, 151.2
+```
+
+The ordinates are always read **latitude first**, so the letters have to agree
+with that order: an `E` or a `W` on the first ordinate (or an `N`/`S` on the
+second) fails the parse rather than being ignored. A letter on both sides of one
+ordinate is allowed as long as it says the same thing twice.
+
+```csharp
+Coordinate.TryParse("W000 07.2, N51 30.0", out var swapped);  // false — longitude first
+```
+
 If you don't know whether a string is a coordinate pair, WKT, or GeoJSON, use
 [`GeoFormat`](parsing.md) to detect the format and parse it in one step.


### PR DESCRIPTION
Adds two coordinate notations `Coordinate.Parse` could not read, and fixes what
it did with them instead. Along the way the parser stops being exponential.

## The leading hemisphere letter

Only the trailing form (`51 30.0N`) was recognised. Aviation and marine sources
overwhelmingly write the letter in front, and none of these parsed at all:

```csharp
Coordinate.Parse("N51 30.0, W000 07.2");     // 51.5, -0.12
Coordinate.Parse("N51°30.0', W000°07.2'");   // 51.5, -0.12
Coordinate.Parse("S33 52 00, E151 12 00");   // -33.8666…, 151.2
```

Either position now works, and an ordinate carrying the letter on both sides has
to say the same thing twice.

Reading the letter meant deciding what it says. Only `[Ss]` and `[Ww]` were ever
tested, one per ordinate, so a letter naming the other axis was silently dropped:
`"0.12W, 51.5N"` parsed as if both ordinates were positive, putting the position
on the wrong side of the meridian. A letter now has to agree with the axis it
sits on — ordinates are read latitude first — and fails the parse when it does
not. Swapped ordinates (`"W000 07.2, N51 30.0"`) fail cleanly rather than
parsing wrongly.

## Hyphen-separated degrees, minutes and seconds

The form the FAA and the NGS use parsed, but every hyphen was read as the sign of
the field behind it, so the ordinate subtracted its own minutes and seconds:

| input | before | after |
|---|---|---|
| `40-26-46N, 079-56-55W` | `39.5539, -78.0514` — 190 km off | `40.4461, -79.9486` |
| `51-30-00N, 000-07-12W` | `50.5, +0.12` — wrong side of the meridian | `51.5, -0.12` |
| `N51-30-00, W000-07-12` | `50.5, +0.12` | `51.5, -0.12` |

`000-07-12W` was the worse case: the ordinate went negative, then the `W` negated
it a second time. The hyphen now joins the degree and minute marks and whitespace
as a separator.

**Minutes and seconds are now unsigned.** A sign belongs to the degrees or to the
hemisphere letter, and no notation writes `51° -30′` to mean anything but 51°30′.
This is the one place a previously-parsing input changes value — `"51 -30, 0"` is
`51.5` where it used to be `50.5` — and it is exactly the misreading that made
hyphen-DMS wrong. Degrees keep their sign, including where the ordinates are
separated by whitespace alone: `"51.5 -0.12"` is still `51.5, -0.12`.

## A separator is now required, and parsing is linear

A minutes or seconds field must be introduced by at least one separator. Without
that a run of digits could be divided between the three fields at any point,
which is what let a sign or a stray point glued to a number open a fresh field:
`"1+2, 3"` and `"1.2.3, 4"` returned positions rather than failing. An exhaustive
sweep over a coordinate-shaped alphabet found 1,922 such strings up to length 7,
all of the shape *digit-or-`.` immediately followed by `+`, `-` or `.`*, and none
that both parses today and means what it parses to.

The same ambiguity was a denial-of-service. Each of the six number fields was
spelt `(?:\d+\.?\d*|\d*\.?\d+)`, whose two branches both accept a plain run of
digits and can split one between `\d+` and `\d*` anywhere; six in sequence gave
the engine an exponential number of ways to carve up a long run before admitting
the string was not a coordinate. Rewritten as `(?:\d+(?:\.\d*)?|\.\d+)` — the
same language, one parse each — and with the separator required, there is one way
to read a run:

| input | before | after |
|---|---|---|
| 40 digits | > 5 s | < 1 ms |
| 50,000 digits | — | 23 ms |
| 250,000 chars of `1-2, ` | — | < 1 ms |

Verified against several adversarial shapes, not just digit runs — repeated `1-`,
`1 `, `1.`, `1°` and `1-2, ` — since adding `-` to the separator classes could
have opened a new blowup. None did.

## Notes

- Also drops a stray backslash from the seconds-marker character class:
  `@"[\""″\s]"` was written as if `\"` escaped a quote, but in a verbatim string
  it is a literal backslash, so `\` matched as a seconds marker.
- `docs/coordinate.md` documents both notations, the unsigned-minutes rule and
  the mandatory separator. The examples are compiled by
  `DocumentationExamplesTests`.

## Testing

`./build.sh Test` — 909 passing, 0 failing (was 895 on `master`). `dotnet
csharpier check .` clean.

Every previously supported notation was re-checked and is unchanged: decimal,
signed, `° ′ ″` DMS, prefixed and suffixed hemispheres, brackets,
whitespace-separated, `.5`/`1.` forms, negative-zero DMS, poles and the
antimeridian.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnzgV69TWFePB2s2sva3Wp)_