### PR TITLE
Make Point immutable

### DIFF
--- a/Geo.Tests/Geometries/PointTests.cs
+++ b/Geo.Tests/Geometries/PointTests.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Geo.Geometries;
 using Xunit;
 
@@ -14,15 +17,40 @@ public class PointTests
     }
 
     [Fact]
-    public void Empty_returns_a_fresh_instance_that_cannot_corrupt_the_shared_state()
+    public void Coordinate_is_read_only()
     {
-        // Point.Coordinate is mutable, so Empty must hand out a new instance each time;
-        // mutating one must not turn a later Point.Empty into a non-empty point.
-        var first = Point.Empty;
-        first.Coordinate = new Coordinate(1, 2);
+        // A point's equality and its hash code are both derived from its coordinate, so a
+        // settable one was a key able to rewrite itself. Asserted by reflection so that
+        // putting the setter back is a failing test rather than a silent regression.
+        var property = typeof(Point).GetProperty(nameof(Point.Coordinate));
 
-        Assert.NotSame(first, Point.Empty);
-        Assert.True(Point.Empty.IsEmpty);
+        Assert.NotNull(property);
+        Assert.False(property!.CanWrite);
+    }
+
+    [Fact]
+    public void Every_geometry_type_is_immutable()
+    {
+        // Point was the last geometry with public mutable state; the rest have always been
+        // built through their constructors and left alone.
+        var mutable =
+            from type in typeof(Point).Assembly.GetTypes()
+            where type.IsPublic && type.Namespace == typeof(Point).Namespace
+            from property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            where property.SetMethod != null && property.SetMethod.IsPublic
+            select $"{type.Name}.{property.Name}";
+
+        Assert.Empty(mutable.ToArray());
+    }
+
+    [Fact]
+    public void A_point_stays_findable_as_a_dictionary_key()
+    {
+        var point = new Point(1, 2);
+        var dictionary = new Dictionary<Point, string> { [point] = "here" };
+
+        Assert.True(dictionary.ContainsKey(point));
+        Assert.True(dictionary.ContainsKey(new Point(1, 2)));
     }
 
     [Fact]

--- a/Geo/Geometries/Point.cs
+++ b/Geo/Geometries/Point.cs
@@ -31,7 +31,17 @@ public class Point : Geometry, IPosition
         Coordinate = coordinate;
     }
 
-    public Coordinate? Coordinate { get; set; }
+    /// <summary>
+    /// The position this point holds, or <c>null</c> when it is empty.
+    /// </summary>
+    /// <remarks>
+    /// Read-only, like every other geometry's contents. A point's equality and its hash
+    /// code are both derived from this, so a settable one was a key that could rewrite
+    /// itself: a point put into a dictionary and then given a new coordinate hashed to a
+    /// different bucket and could no longer be found, in the very dictionary holding it.
+    /// Build a new point rather than moving an existing one.
+    /// </remarks>
+    public Coordinate? Coordinate { get; }
 
     public override bool IsEmpty => Coordinate == null;
 

--- a/Geo/IO/Wkb/WkbReader.cs
+++ b/Geo/IO/Wkb/WkbReader.cs
@@ -182,10 +182,9 @@ public class WkbReader
         var coordinate = ReadCoordinate(reader, dimensions);
 
         // A point whose position ordinates are all NaN encodes POINT EMPTY, matching
-        // NTS/GEOS/PostGIS. Return a fresh empty point rather than the shared singleton,
-        // since Point.Coordinate is mutable.
+        // NTS/GEOS/PostGIS.
         if (double.IsNaN(coordinate.Latitude) && double.IsNaN(coordinate.Longitude))
-            return new Point();
+            return Point.Empty;
 
         return new Point(coordinate);
     }

--- a/docs/geometries.md
+++ b/docs/geometries.md
@@ -4,6 +4,11 @@ Geo's geometry types mirror the OGC simple-feature geometries, plus a `Circle`.
 All coordinates are latitude/longitude in degrees (WGS-84), and constructors take
 them in **latitude, longitude** order.
 
+Geometries are **immutable**: they are built through their constructors and never
+change afterwards. Equality and hash codes are derived from their contents, so
+this is what lets a geometry serve as a dictionary key or a set member — build a
+new geometry rather than moving an existing one.
+
 ```csharp
 using Geo;
 using Geo.Geometries;


### PR DESCRIPTION
`Point.Coordinate` was the only public mutable state left in the geometry layer.
A point's equality and its hash code are both derived from it, so a settable one
was a key able to rewrite itself:

```csharp
var point = new Point(1, 2);
var dictionary = new Dictionary<Point, string> { [point] = "here" };

dictionary.ContainsKey(point);   // True
point.Coordinate = new Coordinate(9, 9);
dictionary.ContainsKey(point);   // False — lost inside the dictionary holding it
```

The property is now get-only.

## Nothing depended on it

No code in the library ever set it. The single assignment anywhere in the
repository was a test asserting that `Point.Empty` hands out a fresh instance
each time — which existed *only* because mutating one could otherwise turn a
later `Point.Empty` into a non-empty point. That hazard no longer exists, so the
test is replaced by three that pin down the new invariant:

- `Coordinate` is read-only, asserted by reflection, so restoring the setter is a
  failing test rather than a silent regression.
- No type in `Geo.Geometries` exposes public mutable state at all. `Point` was
  the last one; every other geometry has always been built through its
  constructors and left alone.
- A point stays findable as a dictionary key.

`WkbReader` had been avoiding `Point.Empty` for an empty point specifically
because the coordinate was mutable; it now reads like the WKT and GeoJSON readers
again.

## Release note

Removing a public setter is a **source- and binary-breaking change**, so this
wants a major version rather than a point release. `<Version>` in `Geo.csproj` is
deliberately untouched — bumping it is a separate, deliberate commit.

## Testing

`./build.sh Test` — 911 passing, 0 failing (909 on `master`; one test replaced by
three). `dotnet csharpier check .` clean.

## Not included

This closes one of the two ways a geometry's hash can shift under a live hash
container. The other is that `SpatialObject.GetHashCode()` reads the ambient,
mutable `GeoContext.Current.EqualityOptions`, so changing those options makes a
`HashSet` lose an item it already holds. That is a separate fix — hashing the
position only, never the options-dependent ordinates — and is not part of this
change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnzgV69TWFePB2s2sva3Wp)_