### PR TITLE
Make hash codes independent of the ambient equality options

### DIFF
--- a/Geo.Tests/CoordinateTests.cs
+++ b/Geo.Tests/CoordinateTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -140,6 +141,131 @@ public class CoordinateTests
         Assert.False(m.Equals(z, options));
         Assert.False(zm.Equals(z, options));
         Assert.False(zm.Equals(flat, options));
+    }
+
+    [Fact]
+    public void GetHashCode_does_not_depend_on_the_ambient_options()
+    {
+        // A hash has to hold still for as long as the object is a key. Reading
+        // GeoContext.Current here meant a dictionary could stop finding an entry it
+        // already held the moment anything changed the ambient options.
+        var coordinates = new Coordinate[]
+        {
+            new Coordinate(1, 2),
+            new CoordinateZ(1, 2, 30),
+            new CoordinateM(1, 2, 30),
+            new CoordinateZM(1, 2, 30, 40),
+            new Coordinate(90, 150),
+            new Coordinate(4, -180),
+        };
+
+        var previous = GeoContext.Current.EqualityOptions;
+        try
+        {
+            foreach (var coordinate in coordinates)
+            {
+                var hashes = new HashSet<int>();
+                foreach (var useElevation in new[] { true, false })
+                foreach (var useM in new[] { true, false })
+                foreach (var poles in new[] { true, false })
+                foreach (var antiMeridian in new[] { true, false })
+                {
+                    GeoContext.Current.EqualityOptions = new SpatialEqualityOptions
+                    {
+                        UseElevation = useElevation,
+                        UseM = useM,
+                        PoleCoordiantesAreEqual = poles,
+                        AntiMeridianCoordinatesAreEqual = antiMeridian,
+                    };
+
+                    hashes.Add(coordinate.GetHashCode());
+                }
+
+                Assert.Single(hashes);
+            }
+        }
+        finally
+        {
+            GeoContext.Current.EqualityOptions = previous;
+        }
+    }
+
+    [Fact]
+    public void A_set_keeps_finding_its_entries_when_the_ambient_options_change()
+    {
+        var stored = new CoordinateZ(1, 2, 30);
+        var set = new HashSet<Coordinate> { stored };
+
+        var previous = GeoContext.Current.EqualityOptions;
+        try
+        {
+            GeoContext.Current.EqualityOptions = new SpatialEqualityOptions
+            {
+                UseElevation = false,
+            };
+
+            Assert.Contains(stored, set);
+            // Equality still answers to the ambient options, and the set agrees with it:
+            // the coarser hash puts both in the same bucket.
+            Assert.True(stored.Equals(new CoordinateZ(1, 2, 99)));
+            Assert.Contains(new CoordinateZ(1, 2, 99), set);
+        }
+        finally
+        {
+            GeoContext.Current.EqualityOptions = previous;
+        }
+    }
+
+    [Fact]
+    public void Equal_coordinates_share_a_hash_under_every_combination_of_options()
+    {
+        // The one direction the hash contract runs in: unequal values may share a bucket,
+        // equal ones may never be split across two.
+        var coordinates = new Coordinate[]
+        {
+            new Coordinate(1, 2),
+            new CoordinateZ(1, 2, 30),
+            new CoordinateZ(1, 2, 99),
+            new CoordinateM(1, 2, 30),
+            new CoordinateZM(1, 2, 30, 40),
+            new Coordinate(90, 0),
+            new Coordinate(90, 150),
+            new Coordinate(4, 180),
+            new Coordinate(4, -180),
+        };
+
+        var previous = GeoContext.Current.EqualityOptions;
+        try
+        {
+            foreach (var useElevation in new[] { true, false })
+            foreach (var useM in new[] { true, false })
+            foreach (var poles in new[] { true, false })
+            foreach (var antiMeridian in new[] { true, false })
+            {
+                var options = new SpatialEqualityOptions
+                {
+                    UseElevation = useElevation,
+                    UseM = useM,
+                    PoleCoordiantesAreEqual = poles,
+                    AntiMeridianCoordinatesAreEqual = antiMeridian,
+                };
+                GeoContext.Current.EqualityOptions = options;
+
+                foreach (var left in coordinates)
+                foreach (var right in coordinates)
+                {
+                    if (left.Equals(right))
+                        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+
+                    if (left.Equals(right, options))
+                        Assert.Equal(left.GetHashCode(options), right.GetHashCode(options));
+                }
+            }
+        }
+        finally
+        {
+            GeoContext.Current.EqualityOptions = previous;
+        }
     }
 
     [Fact]

--- a/Geo.Tests/Linq/Spatial2DComparerTests.cs
+++ b/Geo.Tests/Linq/Spatial2DComparerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Geo.Geometries;
 using Geo.Linq;
 using Xunit;
@@ -25,5 +26,33 @@ public class Spatial2DComparerTests
         var b = new Point(3, 4, 100);
 
         Assert.False(Comparer.Equals(a, b));
+    }
+
+    [Fact]
+    public void GetHashCode_does_not_depend_on_the_ambient_options()
+    {
+        var point = new Point(1, 2, 100);
+        var previous = GeoContext.Current.EqualityOptions;
+        try
+        {
+            var hashes = new HashSet<int>();
+            foreach (var poles in new[] { true, false })
+            foreach (var antiMeridian in new[] { true, false })
+            {
+                GeoContext.Current.EqualityOptions = new SpatialEqualityOptions
+                {
+                    PoleCoordiantesAreEqual = poles,
+                    AntiMeridianCoordinatesAreEqual = antiMeridian,
+                };
+
+                hashes.Add(Comparer.GetHashCode(point));
+            }
+
+            Assert.Single(hashes);
+        }
+        finally
+        {
+            GeoContext.Current.EqualityOptions = previous;
+        }
     }
 }

--- a/Geo.Tests/Linq/Spatial3DComparerTests.cs
+++ b/Geo.Tests/Linq/Spatial3DComparerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Geo.Geometries;
 using Geo.Linq;
 using Xunit;
@@ -34,5 +35,45 @@ public class Spatial3DComparerTests
         var b = new Point(3, 4, 100);
 
         Assert.False(Comparer.Equals(a, b));
+    }
+
+    [Fact]
+    public void Elevation_keeps_stacked_positions_in_separate_buckets()
+    {
+        // What the options overload is for: without the elevation in the hash, every
+        // coordinate sharing one position lands in the same bucket and Distinct3D
+        // degrades to comparing each against all the rest.
+        var a = new Point(1, 2, 100);
+        var b = new Point(1, 2, 200);
+
+        Assert.NotEqual(Comparer.GetHashCode(a), Comparer.GetHashCode(b));
+    }
+
+    [Fact]
+    public void GetHashCode_does_not_depend_on_the_ambient_options()
+    {
+        var point = new Point(1, 2, 100);
+        var previous = GeoContext.Current.EqualityOptions;
+        try
+        {
+            var hashes = new HashSet<int>();
+            foreach (var poles in new[] { true, false })
+            foreach (var antiMeridian in new[] { true, false })
+            {
+                GeoContext.Current.EqualityOptions = new SpatialEqualityOptions
+                {
+                    PoleCoordiantesAreEqual = poles,
+                    AntiMeridianCoordinatesAreEqual = antiMeridian,
+                };
+
+                hashes.Add(Comparer.GetHashCode(point));
+            }
+
+            Assert.Single(hashes);
+        }
+        finally
+        {
+            GeoContext.Current.EqualityOptions = previous;
+        }
     }
 }

--- a/Geo/Abstractions/Interfaces/ISpatialEquatable.cs
+++ b/Geo/Abstractions/Interfaces/ISpatialEquatable.cs
@@ -6,5 +6,27 @@ public interface ISpatialEquatable
     bool Equals(object? obj, SpatialEqualityOptions options);
     bool Equals2D(object? obj);
     bool Equals3D(object? obj);
+
+    /// <summary>
+    /// A hash consistent with <see cref="Equals(object, SpatialEqualityOptions)" /> under
+    /// the same <paramref name="options" />: values that compare equal under them must
+    /// hash alike, though unequal ones may still collide.
+    /// </summary>
+    /// <remarks>
+    /// Only <see cref="SpatialEqualityOptions.UseElevation" /> and
+    /// <see cref="SpatialEqualityOptions.UseM" /> bear on the result.
+    /// <see cref="SpatialEqualityOptions.PoleCoordiantesAreEqual" /> and
+    /// <see cref="SpatialEqualityOptions.AntiMeridianCoordinatesAreEqual" /> do not,
+    /// because the longitudes they govern are collapsed together whichever way those
+    /// options are set - a hash may put unequal values in one bucket, so collapsing them
+    /// always is correct under either setting and keeps the result the same under both.
+    /// <para>
+    /// This is what a composite geometry passes down to the geometries it holds, and what
+    /// <see cref="Linq.Spatial2DComparer{TSource}" /> and
+    /// <see cref="Linq.Spatial3DComparer{TSource}" /> hash through, so an implementation
+    /// has to honour the two ordinate options rather than deferring to
+    /// <see cref="object.GetHashCode()" />.
+    /// </para>
+    /// </remarks>
     int GetHashCode(SpatialEqualityOptions options);
 }

--- a/Geo/Abstractions/SpatialObject.cs
+++ b/Geo/Abstractions/SpatialObject.cs
@@ -19,9 +19,19 @@ public abstract class SpatialObject : ISpatialEquatable
         return Equals(obj, GeoContext.Current.EqualityOptions.To3D());
     }
 
+    /// <remarks>
+    /// Hashed under fixed options rather than whichever are in force, because a hash has to
+    /// hold still for as long as the object is a key. Reading
+    /// <see cref="GeoContext.Current" /> here meant a dictionary or a set could stop finding
+    /// an entry it already held the moment anything changed the ambient options - and,
+    /// while both settings were live, could report an item absent that its own
+    /// <see cref="Equals(object)" /> called equal. Only <see cref="Equals(object)" /> now
+    /// answers to the ambient options; the hash it has to agree with is the coarser one
+    /// that is correct under all of them.
+    /// </remarks>
     public override int GetHashCode()
     {
-        return GetHashCode(GeoContext.Current.EqualityOptions);
+        return GetHashCode(SpatialEqualityOptions.PositionOnly);
     }
 
     public override bool Equals(object? obj)

--- a/Geo/Abstractions/SpatialReadOnlyCollection.cs
+++ b/Geo/Abstractions/SpatialReadOnlyCollection.cs
@@ -43,9 +43,11 @@ public class SpatialReadOnlyCollection<TElement> : ReadOnlyCollection<TElement>,
         return Equals(obj, GeoContext.Current.EqualityOptions.To3D());
     }
 
+    // Fixed options, not the ambient ones, so the hash holds still while the collection is
+    // a key. See SpatialObject.GetHashCode.
     public override int GetHashCode()
     {
-        return GetHashCode(GeoContext.Current.EqualityOptions);
+        return GetHashCode(SpatialEqualityOptions.PositionOnly);
     }
 
     public override bool Equals(object? obj)

--- a/Geo/Coordinate.cs
+++ b/Geo/Coordinate.cs
@@ -334,19 +334,33 @@ public class Coordinate : SpatialObject, IPosition
 
     public override int GetHashCode(SpatialEqualityOptions options)
     {
+        return GetPositionHashCode();
+    }
+
+    /// <summary>
+    /// The hash of the position alone, which every coordinate type builds its hash from.
+    /// </summary>
+    /// <remarks>
+    /// The two longitudes that name one place - every longitude at a pole, and the anti-
+    /// meridian written as both +180 and -180 - are collapsed to one value unconditionally,
+    /// rather than only when the options in force say they are equal. A hash may put
+    /// unequal values in one bucket but never equal ones in two, so collapsing them always
+    /// is safe whichever way the options go, and it leaves the hash the same under all of
+    /// them - which is what lets a coordinate stay findable in a dictionary that outlives a
+    /// change to <see cref="GeoContext.Current" />.
+    /// </remarks>
+    private protected int GetPositionHashCode()
+    {
         unchecked
         {
-            var latitude = Latitude;
             var longitude = Longitude;
 
-            if (options.PoleCoordiantesAreEqual && (Latitude.Equals(90) || Latitude.Equals(-90)))
+            if (Latitude.Equals(90d) || Latitude.Equals(-90d))
                 longitude = 0;
-            else if (options.AntiMeridianCoordinatesAreEqual && Longitude.Equals(-180))
+            else if (Longitude.Equals(-180d))
                 longitude = 180;
 
-            var hashCode = latitude.GetHashCode();
-            hashCode = (hashCode * 397) ^ longitude.GetHashCode();
-            return hashCode;
+            return (Latitude.GetHashCode() * 397) ^ longitude.GetHashCode();
         }
     }
 

--- a/Geo/CoordinateM.cs
+++ b/Geo/CoordinateM.cs
@@ -37,16 +37,7 @@ public class CoordinateM : Coordinate, IsMeasured
     {
         unchecked
         {
-            var latitude = Latitude;
-            var longitude = Longitude;
-
-            if (options.PoleCoordiantesAreEqual && (Latitude.Equals(90) || Latitude.Equals(-90)))
-                longitude = 0;
-            else if (options.AntiMeridianCoordinatesAreEqual && Longitude.Equals(-180))
-                longitude = 180;
-
-            var hashCode = latitude.GetHashCode();
-            hashCode = (hashCode * 397) ^ longitude.GetHashCode();
+            var hashCode = GetPositionHashCode();
             if (options.UseM)
                 hashCode = (hashCode * 397) ^ Measure.GetHashCode();
             return hashCode;

--- a/Geo/CoordinateZ.cs
+++ b/Geo/CoordinateZ.cs
@@ -37,16 +37,7 @@ public class CoordinateZ : Coordinate, Is3D
     {
         unchecked
         {
-            var latitude = Latitude;
-            var longitude = Longitude;
-
-            if (options.PoleCoordiantesAreEqual && (Latitude.Equals(90) || Latitude.Equals(-90)))
-                longitude = 0;
-            else if (options.AntiMeridianCoordinatesAreEqual && Longitude.Equals(-180))
-                longitude = 180;
-
-            var hashCode = latitude.GetHashCode();
-            hashCode = (hashCode * 397) ^ longitude.GetHashCode();
+            var hashCode = GetPositionHashCode();
             if (options.UseElevation)
                 hashCode = (hashCode * 397) ^ Elevation.GetHashCode();
             return hashCode;

--- a/Geo/CoordinateZM.cs
+++ b/Geo/CoordinateZM.cs
@@ -46,16 +46,7 @@ public class CoordinateZM : Coordinate, Is3D, IsMeasured
     {
         unchecked
         {
-            var latitude = Latitude;
-            var longitude = Longitude;
-
-            if (options.PoleCoordiantesAreEqual && (Latitude.Equals(90) || Latitude.Equals(-90)))
-                longitude = 0;
-            else if (options.AntiMeridianCoordinatesAreEqual && Longitude.Equals(-180))
-                longitude = 180;
-
-            var hashCode = latitude.GetHashCode();
-            hashCode = (hashCode * 397) ^ longitude.GetHashCode();
+            var hashCode = GetPositionHashCode();
             if (options.UseElevation)
                 hashCode = (hashCode * 397) ^ Elevation.GetHashCode();
             if (options.UseM)

--- a/Geo/Linq/Spatial2DComparer.cs
+++ b/Geo/Linq/Spatial2DComparer.cs
@@ -13,8 +13,13 @@ public class Spatial2DComparer<T> : IEqualityComparer<T>
         return SpatialObject.Equals2D(x, y);
     }
 
+    // To2D() builds a fresh options object, and this runs once per element - a Distinct2D
+    // over a hundred thousand coordinates allocated a hundred thousand of them. The two
+    // settings it carried over from the ambient options, PoleCoordiantesAreEqual and
+    // AntiMeridianCoordinatesAreEqual, no longer reach a hash, so one shared instance
+    // gives the same answer as a new one every time.
     public int GetHashCode(T obj)
     {
-        return obj.GetHashCode(GeoContext.Current.EqualityOptions.To2D());
+        return obj.GetHashCode(SpatialEqualityOptions.PositionOnly);
     }
 }

--- a/Geo/Linq/Spatial3DComparer.cs
+++ b/Geo/Linq/Spatial3DComparer.cs
@@ -13,8 +13,11 @@ public class Spatial3DComparer<T> : IEqualityComparer<T>
         return SpatialObject.Equals3D(x, y);
     }
 
+    // One shared options instance rather than a new one per element; see
+    // Spatial2DComparer.GetHashCode. The elevation is still hashed, which is what keeps
+    // coordinates stacked on one position in separate buckets.
     public int GetHashCode(T obj)
     {
-        return obj.GetHashCode(GeoContext.Current.EqualityOptions.To3D());
+        return obj.GetHashCode(SpatialEqualityOptions.PositionAndElevation);
     }
 }

--- a/Geo/SpatialEqualityOptions.cs
+++ b/Geo/SpatialEqualityOptions.cs
@@ -27,6 +27,23 @@ public class SpatialEqualityOptions
         UseM = false,
     };
 
+    /// <summary>
+    /// What <see cref="Linq.Spatial3DComparer{TSource}" /> hashes under: the position and
+    /// the elevation, which is what <see cref="To3D" /> asks for. Held as one instance
+    /// because <see cref="To3D" /> allocates, and hashing runs once per element.
+    /// </summary>
+    /// <remarks>
+    /// Shared and never copied, so nothing may write to it. Standing in for
+    /// <see cref="To3D" /> loses nothing: the two options it does not carry over from the
+    /// ambient settings - <see cref="PoleCoordiantesAreEqual" /> and
+    /// <see cref="AntiMeridianCoordinatesAreEqual" /> - no longer reach a hash at all.
+    /// </remarks>
+    internal static readonly SpatialEqualityOptions PositionAndElevation = new()
+    {
+        UseElevation = true,
+        UseM = false,
+    };
+
     public bool UseElevation { get; set; }
     public bool UseM { get; set; }
     public bool PoleCoordiantesAreEqual { get; set; }

--- a/Geo/SpatialEqualityOptions.cs
+++ b/Geo/SpatialEqualityOptions.cs
@@ -11,6 +11,22 @@ public class SpatialEqualityOptions
         AntiMeridianCoordinatesAreEqual = true;
     }
 
+    /// <summary>
+    /// The options every parameterless <c>GetHashCode</c> hashes under, so that a hash
+    /// never depends on which options happen to be in force. Only the ordinates a position
+    /// always has are hashed; the elevation and the measure are left out, because whether
+    /// they count towards equality is exactly what varies.
+    /// </summary>
+    /// <remarks>
+    /// Shared and never copied, so nothing may write to it. It is not exposed outside the
+    /// assembly for that reason.
+    /// </remarks>
+    internal static readonly SpatialEqualityOptions PositionOnly = new()
+    {
+        UseElevation = false,
+        UseM = false,
+    };
+
     public bool UseElevation { get; set; }
     public bool UseM { get; set; }
     public bool PoleCoordiantesAreEqual { get; set; }

--- a/docs/geocontext.md
+++ b/docs/geocontext.md
@@ -59,6 +59,32 @@ GeoContext.Current = new GeoContext(Spheroid.Grs80);
 The `To2D()` and `To3D()` helpers return option sets tuned for 2D or 3D
 comparison.
 
+### Hash codes do not follow these options
+
+`Equals(object)` answers to whichever options are in force, but `GetHashCode()`
+does not: it hashes the position alone, leaving out the elevation and the
+measure, and always collapses the longitudes that name one place (every longitude
+at a pole; the anti-meridian written as both `+180` and `-180`).
+
+That is deliberate. A hash has to hold still for as long as an object is a key,
+and equality here does not — so the hash is the coarser one that stays correct
+whichever way the options go. Equal values are therefore never split across two
+buckets, while values that are unequal under the current options may share one.
+
+```csharp
+var stored = new CoordinateZ(1, 2, 30);
+var set = new HashSet<Coordinate> { stored };
+
+GeoContext.Current.EqualityOptions = new SpatialEqualityOptions { UseElevation = false };
+
+set.Contains(stored);                        // still true
+set.Contains(new CoordinateZ(1, 2, 99));     // true — equal under the new options
+```
+
+Where you want the elevation or the measure to spread entries across buckets —
+`Distinct3D` and `Spatial3DComparer` do — use the
+`GetHashCode(SpatialEqualityOptions)` overload, which honours what you pass it.
+
 ## Scope
 
 `GeoContext.Current` is process-wide and mutable — changing it affects every


### PR DESCRIPTION
`SpatialObject.GetHashCode()` and `SpatialReadOnlyCollection.GetHashCode()` both
hashed under `GeoContext.Current.EqualityOptions`. A hash has to hold still for
as long as an object is a key, and those do not — so changing the ambient options
rehashed every geometry and a container stopped finding entries it already held:

```csharp
var stored = new CoordinateZ(1, 2, 30);
var set = new HashSet<Coordinate> { stored };

set.Contains(stored);   // True
GeoContext.Current.EqualityOptions = new SpatialEqualityOptions { UseElevation = false };
set.Contains(stored);   // False — before this change
```

While both settings were live the set also contradicted itself, reporting an item
absent that its own `Equals` called equal.

## The fix

Equality still answers to the ambient options; the hash no longer does. It is
taken over the **position alone** — elevation and measure left out, since whether
they count towards equality is exactly what varies. That is the coarser hash that
stays correct under every option set, and coarser is the safe direction: a hash
may put unequal values in one bucket, but never equal ones in two.

For the same reason the two longitudes that name one place — every longitude at a
pole, and the anti-meridian written as both `+180` and `-180` — are now collapsed
unconditionally, rather than only when the options in force call them equal.

The `GetHashCode(SpatialEqualityOptions)` overload is unchanged in what it
honours, so `Distinct3D` and `Spatial3DComparer` still spread entries by
elevation. The pole/anti-meridian normalisation had been copied into all four
coordinate types; it now lives once on `Coordinate`.

## Second commit: the comparers stop allocating per hash

Since those two flags no longer reach a hash, `Spatial2DComparer` and
`Spatial3DComparer` no longer need to rebuild their options from the ambient ones
on every call. `To2D()`/`To3D()` construct a fresh `SpatialEqualityOptions` each
time, and hashing runs once per element:

| | time | allocated |
|---|---|---|
| 2D, per-call options | 22 ms | 4,687 KB |
| 2D, shared instance | 5 ms | **0 KB** |
| 3D, per-call options | 13 ms | 4,687 KB |
| 3D, shared instance | 6 ms | **0 KB** |

*(200,000 hashes.)*

The comparers keep hashing through `ISpatialEquatable.GetHashCode(options)`
rather than `object.GetHashCode()`. The interface does not specify the latter, so
a type implementing it without deriving from `SpatialObject` would be free to
return something inconsistent with `Equals2D`/`Equals3D`.

The overload is also now documented: only `UseElevation` and `UseM` bear on it,
it is what a composite geometry passes down to what it holds, and an
implementation must honour it rather than defer to `object.GetHashCode`.

## Verification

Exhaustively over all sixteen combinations of the four options:

- every coordinate type hashes to a **single** value across all sixteen;
- **no** pair that compares equal hashes apart (3,600 pair/option checks, 0
  violations), for both the parameterless and the options overload;
- the comparers' hashes are **byte-identical** to the previous per-call
  construction, for coordinates of every dimension and for a composite that
  passes the options down.

Each new regression test was confirmed to **fail** against the behaviour it
guards, so none of them passes vacuously.

`./build.sh Test` — 917 passing, 0 failing (911 on `master`). `dotnet csharpier
check .` clean.

## Behaviour worth knowing

Hash codes no longer change with `GeoContext.Current.EqualityOptions`, which is
the point. Two consequences, both documented in `docs/geocontext.md`:

- Coordinates that differ only in elevation or measure now share a bucket under
  the default `GetHashCode()`. They still compare unequal; this is a collision,
  not an equality change. Use the options overload — as `Distinct3D` and
  `Spatial3DComparer` do — where you want them spread.
- Nothing that was equal has stopped being equal. No equality semantics change in
  this PR.

## Not included

This is the second of the two ways a geometry's hash could shift under a live
container. The first — `Point.Coordinate` being settable — was #124. Together
they make a geometry safe to use as a dictionary key.