### PR TITLE
Fix SkyDemon coordinates misread, and every malformed one throwing

### DIFF
--- a/Geo.Tests/Gps/Serialization/SkyDemonFlightplanDeSerializerTests.cs
+++ b/Geo.Tests/Gps/Serialization/SkyDemonFlightplanDeSerializerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Linq;
 using System.Text;
+using Geo.Gps;
 using Geo.Gps.Serialization;
 using Xunit;
 
@@ -68,5 +69,127 @@ public class SkyDemonFlightplanDeSerializerTests : SerializerTestFixtureBase
     public void DeSerialize_returns_null_for_malformed_xml()
     {
         Assert.Null(new SkyDemonFlightplanDeSerializer().DeSerialize(Wrap("<broken")));
+    }
+
+    private static string Plan(string body) =>
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?><DivelementsFlightPlanner>"
+        + body
+        + "</DivelementsFlightPlanner>";
+
+    private static string Route(string start, string to = "N515646.05 W0000106.30") =>
+        Plan($"<PrimaryRoute Start=\"{start}\"><RhumbLineRoute To=\"{to}\" /></PrimaryRoute>");
+
+    private static GpsData? DeSerialize(string xml) =>
+        new SkyDemonFlightplanDeSerializer().DeSerialize(Wrap(xml));
+
+    [Fact]
+    public void A_comma_in_place_of_the_decimal_point_is_not_read_as_a_thousands_separator()
+    {
+        // The seconds pattern was written (?<s>\d\d.\d\d) with a bare '.', which matches any
+        // character, so "N514807,00" matched and its seconds arrived at double.Parse as
+        // "07,00" - seven hundred, once thousands separators are allowed. The waypoint came
+        // back at 51.994, -0.983 rather than 51.802, -0.158: about 21 km north and 92 km
+        // west of where the file put it, with nothing reported.
+        Assert.Null(DeSerialize(Route("N514807,00 W0000930,00")));
+        Assert.Null(DeSerialize(Route("N514807X00 W0000930X00")));
+    }
+
+    [Theory]
+    // Whole seconds, and seconds to any number of decimal places, are all valid; only two
+    // decimal places used to be accepted, and anything else threw.
+    [InlineData("N514807.00 W0000930.00")]
+    [InlineData("N514807.0 W0000930.0")]
+    [InlineData("N514807 W0000930")]
+    [InlineData("N514807.000 W0000930.000")]
+    // More than one space between the ordinates, which used to split into an empty entry.
+    [InlineData("N514807.00  W0000930.00")]
+    [InlineData("  N514807.00 W0000930.00  ")]
+    public void Seconds_and_spacing_may_vary(string start)
+    {
+        var data = DeSerialize(Route(start));
+
+        Assert.NotNull(data);
+        var coordinate = data!.Routes[0].Waypoints[0].Coordinate;
+        Assert.Equal(51.801944, coordinate.Latitude, 6);
+        Assert.Equal(-0.158333, coordinate.Longitude, 6);
+    }
+
+    [Theory]
+    // No space at all between the ordinates, which used to index past the end of the split.
+    [InlineData("N514807.00W0000930.00")]
+    // The ordinates the wrong way round, and a lone ordinate - neither matches.
+    [InlineData("W0000930.00 N514807.00")]
+    [InlineData("N514807.00")]
+    // Degrees the pattern accepts but a position cannot hold.
+    [InlineData("N994807.00 W0000930.00")]
+    [InlineData("N514807.00 W9990930.00")]
+    // Not a coordinate at all.
+    [InlineData("Panshanger")]
+    [InlineData("")]
+    public void A_coordinate_that_cannot_be_read_yields_null_rather_than_throwing(string start)
+    {
+        // Reported the way this deserializer already reports a document it cannot parse.
+        // Previously each of these left as an exception - FormatException,
+        // IndexOutOfRangeException or ArgumentOutOfRangeException - out of GpsData.Parse.
+        Assert.Null(DeSerialize(Route(start)));
+    }
+
+    [Fact]
+    public void An_unreadable_coordinate_anywhere_in_the_route_yields_null()
+    {
+        Assert.Null(DeSerialize(Route("N514807.00 W0000930.00", to: "not a coordinate")));
+    }
+
+    [Fact]
+    public void A_route_holding_only_a_starting_point_is_read()
+    {
+        // RhumbLineRoute is absent rather than empty for such a route, and was dereferenced.
+        var data = DeSerialize(Plan("<PrimaryRoute Start=\"N514807.00 W0000930.00\" />"));
+
+        Assert.NotNull(data);
+        Assert.Single(data!.Routes);
+        Assert.Single(data.Routes[0].Waypoints);
+    }
+
+    [Theory]
+    // An absent Start, and an absent To, were both dereferenced.
+    [InlineData("<PrimaryRoute><RhumbLineRoute To=\"N515646.05 W0000106.30\" /></PrimaryRoute>")]
+    [InlineData(
+        "<PrimaryRoute Start=\"N514807.00 W0000930.00\"><RhumbLineRoute Level=\"MSL\" /></PrimaryRoute>"
+    )]
+    public void A_missing_coordinate_attribute_yields_null(string body)
+    {
+        Assert.Null(DeSerialize(Plan(body)));
+    }
+
+    [Fact]
+    public void Only_the_southern_and_western_hemispheres_are_negated()
+    {
+        // S is negative and E is not, and each ordinate is judged by its own letter. Both
+        // were previously tested against "N or E", which happened to work but only because
+        // a latitude can never carry an E.
+        var southEast = DeSerialize(Route("S332600.00 E0150900.00", to: "S332700.00 E0151000.00"));
+
+        Assert.NotNull(southEast);
+        var coordinate = southEast!.Routes[0].Waypoints[0].Coordinate;
+        Assert.Equal(-33.433333, coordinate.Latitude, 6);
+        Assert.Equal(15.15, coordinate.Longitude, 6);
+
+        var northWest = DeSerialize(Route("N332600.00 W0150900.00", to: "N332700.00 W0151000.00"));
+
+        Assert.NotNull(northWest);
+        coordinate = northWest!.Routes[0].Waypoints[0].Coordinate;
+        Assert.Equal(33.433333, coordinate.Latitude, 6);
+        Assert.Equal(-15.15, coordinate.Longitude, 6);
+    }
+
+    [Fact]
+    public void A_plan_with_no_routes_yields_no_routes()
+    {
+        var data = DeSerialize(Plan("<Aircraft Registration=\"G-ABCD\" Type=\"C172\" />"));
+
+        Assert.NotNull(data);
+        Assert.Empty(data!.Routes);
+        Assert.Equal("G-ABCD", data.Metadata.Attribute(x => x.Vehicle.Identifier));
     }
 }

--- a/Geo/Gps/Serialization/SkyDemonFlightplanDeSerializer.cs
+++ b/Geo/Gps/Serialization/SkyDemonFlightplanDeSerializer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -8,8 +9,21 @@ namespace Geo.Gps.Serialization;
 
 public class SkyDemonFlightplanDeSerializer : GpsXmlDeSerializer<SkyDemonFlightplan>
 {
-    private const string COORD_REGEX1 = @"^(?<dir>[NnSs])(?<d>\d\d)(?<m>\d\d)(?<s>\d\d.\d\d)$";
-    private const string COORD_REGEX2 = @"^(?<dir>[EeWw])(?<d>\d\d\d)(?<m>\d\d)(?<s>\d\d.\d\d)$";
+    // "N514807.00 W0000930.00": a hemisphere letter, then degrees, minutes and seconds run
+    // together.
+    //
+    // The decimal point has to be a literal one. Written as a bare '.' it stood for any
+    // character, so "N514807,00" matched and its seconds came through as "07,00" - which
+    // double.Parse, allowing thousands separators by default, reads as seven hundred. That
+    // placed the position 21 km north and 92 km west of where the file put it, and reported
+    // nothing wrong. The decimals are optional, because a whole number of seconds is no less
+    // valid and was rejected outright.
+    private const string Seconds = @"(?<s>\d\d(?:\.\d+)?)";
+
+    private const string LatitudePattern = @"^(?<dir>[NnSs])(?<d>\d\d)(?<m>\d\d)" + Seconds + "$";
+
+    private const string LongitudePattern =
+        @"^(?<dir>[EeWw])(?<d>\d\d\d)(?<m>\d\d)" + Seconds + "$";
 
     public override GpsFileFormat[] FileFormats
     {
@@ -18,36 +32,101 @@ public class SkyDemonFlightplanDeSerializer : GpsXmlDeSerializer<SkyDemonFlightp
 
     public override GpsFeatures SupportedFeatures => GpsFeatures.Routes;
 
-    private Route ConvertRoute(SkyDemonRoute route)
+    /// <summary>
+    /// The route as a list of waypoints, or <c>null</c> when any of its coordinates cannot
+    /// be read.
+    /// </summary>
+    private static Route? ConvertRoute(SkyDemonRoute route)
     {
+        var start = ParseWaypoint(route.Start);
+        if (start == null)
+            return null;
+
         var result = new Route();
-        result.Waypoints.Add(ParseWaypoint(route.Start!));
-        foreach (var rhumbLine in route.RhumbLineRoute!)
-            result.Waypoints.Add(ParseWaypoint(rhumbLine.To!));
+        result.Waypoints.Add(start);
+
+        // A route may consist of nothing but its starting point, in which case the element
+        // is absent rather than an empty array.
+        foreach (var rhumbLine in route.RhumbLineRoute ?? new SkyDemonRhumbLine[0])
+        {
+            var waypoint = ParseWaypoint(rhumbLine.To);
+            if (waypoint == null)
+                return null;
+
+            result.Waypoints.Add(waypoint);
+        }
+
         return result;
     }
 
-    private Waypoint ParseWaypoint(string c)
+    /// <summary>
+    /// The waypoint <paramref name="value" /> names, or <c>null</c> when it does not hold a
+    /// latitude and a longitude that this format can express.
+    /// </summary>
+    /// <remarks>
+    /// Every way of failing used to leave the deserializer as an exception: a coordinate the
+    /// pattern did not match reached <c>double.Parse</c> as an empty string, one written
+    /// without a space between its ordinates ran off the end of the split, and an absent
+    /// attribute was dereferenced. None of those is something a caller of
+    /// <see cref="GpsData.Parse" /> has reason to expect. A document whose coordinates cannot
+    /// be read is now reported the way this deserializer already reports one it cannot parse
+    /// at all - by returning <c>null</c>.
+    /// </remarks>
+    private static Waypoint? ParseWaypoint(string? value)
     {
-        var ord = c.Trim().Split(' ');
+        if (value == null)
+            return null;
 
-        var match1 = Regex.Match(ord[0], COORD_REGEX1);
-        var match2 = Regex.Match(ord[1], COORD_REGEX2);
+        // Split on whitespace and discard the empties, so a file separating its two
+        // ordinates by more than one space is read, and one separating them by none is
+        // rejected rather than indexed past the end.
+        var ordinates = value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (ordinates.Length != 2)
+            return null;
 
-        var lat =
-            double.Parse(match1.Groups["d"].Value, CultureInfo.InvariantCulture)
-            + double.Parse(match1.Groups["m"].Value, CultureInfo.InvariantCulture) / 60
-            + double.Parse(match1.Groups["s"].Value, CultureInfo.InvariantCulture) / 3600;
+        var latitude = Regex.Match(ordinates[0], LatitudePattern);
+        var longitude = Regex.Match(ordinates[1], LongitudePattern);
+        if (!latitude.Success || !longitude.Success)
+            return null;
 
-        var lon =
-            double.Parse(match2.Groups["d"].Value, CultureInfo.InvariantCulture)
-            + double.Parse(match2.Groups["m"].Value, CultureInfo.InvariantCulture) / 60
-            + double.Parse(match2.Groups["s"].Value, CultureInfo.InvariantCulture) / 3600;
+        try
+        {
+            return new Waypoint(ToDegrees(latitude, 'S'), ToDegrees(longitude, 'W'));
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // Degrees and minutes the pattern accepts but a position cannot hold, such as a
+            // latitude of 99 degrees. What is out of range is the document, not an argument
+            // the caller passed, so it is not raised at them as though it were theirs.
+            return null;
+        }
+    }
 
-        var latd = Regex.IsMatch(match1.Groups["dir"].Value, "[NnEe]") ? 1 : -1;
-        var lond = Regex.IsMatch(match2.Groups["dir"].Value, "[NnEe]") ? 1 : -1;
+    /// <summary>
+    /// One ordinate in degrees, negated when its hemisphere letter is
+    /// <paramref name="negative" />.
+    /// </summary>
+    private static double ToDegrees(Match match, char negative)
+    {
+        var degrees =
+            ParseOrdinatePart(match.Groups["d"].Value)
+            + ParseOrdinatePart(match.Groups["m"].Value) / 60
+            + ParseOrdinatePart(match.Groups["s"].Value) / 3600;
 
-        return new Waypoint(lat * latd, lon * lond);
+        // Each ordinate's pattern admits only its own pair of hemisphere letters, so naming
+        // the negative one settles it. Asking whether both were "N or E" instead, as this
+        // did, quietly made a latitude southern whenever the match had failed and there was
+        // no letter to read.
+        return char.ToUpperInvariant(match.Groups["dir"].Value[0]) == negative ? -degrees : degrees;
+    }
+
+    // NumberStyles.Float, rather than the default that also allows thousands separators -
+    // the leniency that turned a comma standing in for the decimal point into a hundredfold
+    // error. The pattern no longer admits one, and this keeps a later change to it from
+    // bringing the misreading back.
+    private static double ParseOrdinatePart(string value)
+    {
+        return double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
     }
 
     protected override bool CanDeSerialize(XmlReader xml)
@@ -60,15 +139,26 @@ public class SkyDemonFlightplanDeSerializer : GpsXmlDeSerializer<SkyDemonFlightp
         if (xml == null)
             return null;
 
-        //N514807.00 W0000930.00
         var data = new GpsData();
 
         if (xml.PrimaryRoute != null)
-            data.Routes.Add(ConvertRoute(xml.PrimaryRoute));
+        {
+            var primary = ConvertRoute(xml.PrimaryRoute);
+            if (primary == null)
+                return null;
+
+            data.Routes.Add(primary);
+        }
 
         if (xml.Routes != null)
             foreach (var route in xml.Routes)
-                data.Routes.Add(ConvertRoute(route));
+            {
+                var converted = ConvertRoute(route);
+                if (converted == null)
+                    return null;
+
+                data.Routes.Add(converted);
+            }
 
         if (xml.Aircraft != null && xml.Aircraft.Length > 0)
         {


### PR DESCRIPTION
## A wrong position, reported as a success

The seconds pattern was `(?<s>\d\d.\d\d)`, where the bare `.` stands for *any
character* rather than a decimal point. So a file writing its decimal separator as
a comma matched, and the seconds reached `double.Parse` as `"07,00"` — which the
default number styles, allowing thousands separators, read as **seven hundred**:

```
N514807,00 W0000930,00   ->  51.994, -0.983     (should be 51.802, -0.158)
```

About 21 km north and 92 km west of where the file put it, with nothing reported.

The point is now a literal, and the seconds are parsed with `NumberStyles.Float`
so no separator can be taken for one again even if the pattern is loosened later.

## Every other malformed coordinate threw

None of these is something a caller of `GpsData.Parse` has reason to expect:

| input | before |
|---|---|
| `N514807X00 W0000930X00` | `FormatException` on the group `"07X00"` |
| `N514807.00W0000930.00` | `IndexOutOfRangeException` — the split indexed blindly |
| `N514807.00  W0000930.00` | `FormatException` on the empty entry two spaces leave |
| `N514807.0 W0000930.0` | `FormatException` on the empty group of a failed match |
| `N994807.00 W0000930.00` | `ArgumentOutOfRangeException` naming `'latitude'` |
| route with only a `Start` | `NullReferenceException` on `RhumbLineRoute!` |
| route with no `Start` | `NullReferenceException` on `Start!` |
| `RhumbLineRoute` with no `To` | `NullReferenceException` on `To!` |

A document whose coordinates cannot be read now returns `null` — how this
deserializer already reports one it cannot parse at all, and what its existing
`DeSerialize_returns_null_for_malformed_xml` test asserts.

## Four of those were not malformed at all, and now parse

- seconds written with one, three, or no decimal places;
- more than one space between the ordinates, or surrounding whitespace;
- a route consisting of nothing but its starting point — which the model has
  always permitted, since `RhumbLineRoute` is absent rather than empty.

## Also

Each ordinate is now judged by its own hemisphere letter. Both were tested for
`"N or E"`, which worked only because a latitude can never carry an `E`, and which
silently made a latitude *southern* whenever the match had failed and there was no
letter to read.

## Testing

`./build.sh Test` — 970 passing, 0 failing (950 on `master`). `dotnet csharpier
check .` clean.

16 of the 20 new tests fail against the previous implementation. The other four
cover behaviour that was already correct — the reference file's own format, and the
hemisphere handling that happened to work — so they are documenting rather than
guarding, which seemed worth having next to the rest.

The reference file `skydemon.flightplan` parses to the same four waypoints as
before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnzgV69TWFePB2s2sva3Wp)_