### PR TITLE
Skip an unreadable NMEA sentence instead of losing the log to it

### DIFF
--- a/Geo.Tests/Gps/Serialization/NmeaDeSerializerTests.cs
+++ b/Geo.Tests/Gps/Serialization/NmeaDeSerializerTests.cs
@@ -147,4 +147,121 @@ public class NmeaDeSerializerTests : SerializerTestFixtureBase
 
         Assert.Equal(first.Waypoints[0].TimeUtc, second.Waypoints[0].TimeUtc);
     }
+
+    private static string Gga(
+        string latitude,
+        string latitudeDirection,
+        string longitude,
+        string longitudeDirection,
+        string time = "104427.591"
+    ) =>
+        $"$GPGGA,{time},{latitude},{latitudeDirection},{longitude},{longitudeDirection},"
+        + "1,05,3.3,78.2,M,23.2,M,0.0,0000*4A";
+
+    private static string Wpl(string latitude, string longitude) =>
+        $"$GPWPL,{latitude},N,{longitude},E,HOME*00";
+
+    private static readonly string GoodFix = Gga("5920.7009", "N", "01803.2938", "E");
+
+    [Fact]
+    public void One_unreadable_sentence_does_not_lose_the_rest_of_the_log()
+    {
+        // The whole point of the fix. An NMEA log is a stream of sentences, not a single
+        // document, and one of any length is likely to hold a truncated or corrupted line.
+        // Reading an ordinate used to throw on such a line, which discarded every fix in the
+        // file rather than just the bad one.
+        var nmea = string.Join("\n", GoodFix, Gga("5", "N", "01803.2938", "E"), GoodFix);
+
+        var data = new NmeaDeSerializer().DeSerialize(Wrap(nmea));
+
+        Assert.Equal(2, data.Tracks[0].Segments[0].Waypoints.Count);
+    }
+
+    [Theory]
+    // Shorter than the degrees field the format fixes the width of, so the split ran off the
+    // end of the string.
+    [InlineData("5", "N", "01803.2938", "E")]
+    [InlineData("5920.7009", "N", "01", "E")]
+    // Exactly the degrees field, leaving nothing for the minutes and an empty double.Parse.
+    [InlineData("51", "N", "01803.2938", "E")]
+    [InlineData("5920.7009", "N", "018", "E")]
+    // A bare fraction, which the sentence pattern admits.
+    [InlineData(".5", "N", "01803.2938", "E")]
+    // Degrees the pattern is free to quote but a position cannot hold.
+    [InlineData("9900.00", "N", "01803.2938", "E")]
+    [InlineData("5920.7009", "N", "19900.00", "E")]
+    public void A_fix_whose_ordinates_cannot_be_read_is_skipped(
+        string latitude,
+        string latitudeDirection,
+        string longitude,
+        string longitudeDirection
+    )
+    {
+        var nmea = Gga(latitude, latitudeDirection, longitude, longitudeDirection);
+
+        var data = new NmeaDeSerializer().DeSerialize(Wrap(nmea));
+
+        Assert.Empty(data.Tracks);
+    }
+
+    [Theory]
+    [InlineData("5", "01803.2938")]
+    [InlineData("51", "01803.2938")]
+    [InlineData("5920.7009", "018")]
+    [InlineData("9900.00", "01803.2938")]
+    public void A_waypoint_whose_ordinates_cannot_be_read_is_skipped(
+        string latitude,
+        string longitude
+    )
+    {
+        var data = new NmeaDeSerializer().DeSerialize(Wrap(Wpl(latitude, longitude)));
+
+        Assert.Empty(data.Waypoints);
+    }
+
+    [Fact]
+    public void A_skipped_sentence_does_not_advance_the_rollover_clock()
+    {
+        // The clock is asked for a timestamp only once the position is known to be good.
+        // Were a skipped sentence to advance it, the 23:00 below would become the time the
+        // 11:00 after it is measured against, and 11:00 being earlier would be taken for a
+        // new day.
+        var nmea = string.Join(
+            "\n",
+            Gga("5920.7009", "N", "01803.2938", "E", time: "100000.00"),
+            Gga("5", "N", "01803.2938", "E", time: "230000.00"),
+            Gga("5920.7010", "N", "01803.2939", "E", time: "110000.00")
+        );
+
+        var waypoints = new NmeaDeSerializer()
+            .DeSerialize(Wrap(nmea))
+            .Tracks[0]
+            .Segments[0]
+            .Waypoints;
+
+        Assert.Equal(2, waypoints.Count);
+        Assert.Equal(waypoints[0].TimeUtc!.Value.Date, waypoints[1].TimeUtc!.Value.Date);
+        Assert.Equal(TimeSpan.FromHours(1), waypoints[1].TimeUtc - waypoints[0].TimeUtc);
+    }
+
+    [Fact]
+    public void Southern_and_western_ordinates_are_negated()
+    {
+        var nmea = string.Join(
+            "\n",
+            Gga("5920.7009", "S", "01803.2938", "W"),
+            Gga("5920.7009", "N", "01803.2938", "E")
+        );
+
+        var waypoints = new NmeaDeSerializer()
+            .DeSerialize(Wrap(nmea))
+            .Tracks[0]
+            .Segments[0]
+            .Waypoints;
+
+        Assert.Equal(-59.345015, waypoints[0].Coordinate.Latitude, 6);
+        Assert.Equal(-18.054897, waypoints[0].Coordinate.Longitude, 6);
+        Assert.Equal(59.345015, waypoints[1].Coordinate.Latitude, 6);
+        Assert.Equal(18.054897, waypoints[1].Coordinate.Longitude, 6);
+    }
 }

--- a/Geo/Gps/Serialization/NmeaDeSerializer.cs
+++ b/Geo/Gps/Serialization/NmeaDeSerializer.cs
@@ -1,8 +1,10 @@
 ﻿#nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
+using Geo.Geometries;
 
 namespace Geo.Gps.Serialization;
 
@@ -72,20 +74,24 @@ public class NmeaDeSerializer : IGpsFileDeSerializer
         var match = Regex.Match(line, FIX_SENTENCE);
         if (match.Success)
         {
+            var alt = double.Parse(match.Groups["alt"].Value, CultureInfo.InvariantCulture);
+            if (!TryConvertPosition(match, alt, out var position))
+                return false;
+
             var h = int.Parse(match.Groups["h"].Value, CultureInfo.InvariantCulture);
             var m = int.Parse(match.Groups["m"].Value, CultureInfo.InvariantCulture);
             var s = double.Parse(match.Groups["s"].Value, CultureInfo.InvariantCulture);
-            var alt = double.Parse(match.Groups["alt"].Value, CultureInfo.InvariantCulture);
-            var lat = ConvertOrd(match.Groups["lat"].Value, match.Groups["latd"].Value);
-            var lon = ConvertOrd(match.Groups["lon"].Value, match.Groups["lond"].Value);
 
             // GPGGA carries no date, so the fixes are stamped onto the first representable
-            // day; only the intervals between them are meaningful.
+            // day; only the intervals between them are meaningful. The clock is only asked
+            // once the position is known to be good, so a sentence that is skipped cannot
+            // advance it and put a spurious day rollover into the fixes that follow.
             var timeOfDay =
                 TimeSpan.FromHours(h) + TimeSpan.FromMinutes(m) + TimeSpan.FromSeconds(s);
 
-            var waypoint = new Waypoint(lat, lon, alt, clock.Resolve(DateTime.MinValue, timeOfDay));
-            trackSegment.Waypoints.Add(waypoint);
+            trackSegment.Waypoints.Add(
+                new Waypoint(new Point(position), clock.Resolve(DateTime.MinValue, timeOfDay))
+            );
 
             return true;
         }
@@ -101,9 +107,10 @@ public class NmeaDeSerializer : IGpsFileDeSerializer
         var match = Regex.Match(line, WPT_SENTENCE);
         if (match.Success)
         {
-            var lat = ConvertOrd(match.Groups["lat"].Value, match.Groups["latd"].Value);
-            var lon = ConvertOrd(match.Groups["lon"].Value, match.Groups["lond"].Value);
-            data.Waypoints.Add(new Waypoint(lat, lon));
+            if (!TryConvertPosition(match, null, out var position))
+                return false;
+
+            data.Waypoints.Add(new Waypoint(new Point(position), null, null, null));
 
             return true;
         }
@@ -111,14 +118,101 @@ public class NmeaDeSerializer : IGpsFileDeSerializer
         return false;
     }
 
-    private double ConvertOrd(string ord, string dir)
+    /// <summary>
+    /// The position a matched sentence carries, with <paramref name="elevation" /> when the
+    /// sentence quotes one, or <c>false</c> when its ordinates cannot be read.
+    /// </summary>
+    /// <remarks>
+    /// A sentence whose fields matched but whose ordinates do not add up is skipped, exactly
+    /// as a line that did not match at all already is. It used to throw instead - and since
+    /// an NMEA log is a stream of sentences rather than one document, that lost every fix in
+    /// the file, not just the bad one: a single truncated or corrupted line, which a log of
+    /// any length is likely to contain, took the whole recording down with it.
+    /// </remarks>
+    private static bool TryConvertPosition(
+        Match match,
+        double? elevation,
+        [NotNullWhen(true)] out Coordinate? position
+    )
     {
-        var d = Regex.IsMatch(dir, "^[NnEe]$") ? 1 : -1;
-        var sub = Regex.IsMatch(dir, "^[NnSs]") ? 2 : 3;
-        return (
-                double.Parse(ord.Substring(0, sub), CultureInfo.InvariantCulture)
-                + double.Parse(ord.Substring(sub, ord.Length - sub), CultureInfo.InvariantCulture)
-                    / 60
-            ) * d;
+        position = null;
+
+        if (
+            !TryConvertOrd(
+                match.Groups["lat"].Value,
+                match.Groups["latd"].Value,
+                'S',
+                2,
+                out var lat
+            )
+            || !TryConvertOrd(
+                match.Groups["lon"].Value,
+                match.Groups["lond"].Value,
+                'W',
+                3,
+                out var lon
+            )
+        )
+            return false;
+
+        try
+        {
+            position =
+                elevation == null
+                    ? new Coordinate(lat, lon)
+                    : new CoordinateZ(lat, lon, elevation.Value);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // Degrees the sentence is free to quote but a position cannot hold. What is out
+            // of range is the sentence, not an argument the caller passed, so this is not
+            // raised at them as though it named a parameter of theirs. Longitude wrapping,
+            // where it is switched on, still applies - the constructor decides that, which is
+            // why the range is not pre-checked here.
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// One ordinate, written as <paramref name="degreeDigits" /> digits of degrees followed
+    /// by minutes, negated when its hemisphere letter is <paramref name="negative" />.
+    /// </summary>
+    private static bool TryConvertOrd(
+        string ord,
+        string dir,
+        char negative,
+        int degreeDigits,
+        out double degrees
+    )
+    {
+        degrees = 0;
+
+        // Both fields are fixed-width in NMEA, so the split point is known - but the pattern
+        // that matched the sentence does not enforce the width. A field too short to hold
+        // both parts ran off the end of the string, or left the minutes empty for
+        // double.Parse; either way it threw rather than being passed over.
+        if (ord.Length <= degreeDigits)
+            return false;
+
+        var minutes = double.Parse(
+            ord.Substring(degreeDigits),
+            NumberStyles.Float,
+            CultureInfo.InvariantCulture
+        );
+
+        degrees =
+            double.Parse(
+                ord.Substring(0, degreeDigits),
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture
+            )
+            + minutes / 60;
+
+        if (char.ToUpperInvariant(dir[0]) == negative)
+            degrees = -degrees;
+
+        return true;
     }
 }


### PR DESCRIPTION
## One bad sentence discarded the entire log

`ConvertOrd` split each ordinate at the fixed width the format gives its degrees
field — two digits for a latitude, three for a longitude — but the pattern that
matched the sentence does not enforce that width. A field shorter than the split
point ran off the end of the string; one exactly that length left the minutes
empty for `double.Parse`:

| latitude field | before |
|---|---|
| `5` | `ArgumentOutOfRangeException` from `Substring` |
| `51` | `FormatException` on the empty minutes |
| `.5` | `FormatException` on the empty minutes |
| `9900.00` | `ArgumentOutOfRangeException` naming `'latitude'` |
| `19900.00` (longitude) | `ArgumentOutOfRangeException` naming `'longitude'` |

An NMEA log is a **stream of sentences**, not a single document, so this did not
merely fail the bad line — it threw away the whole recording:

```
good sentence, bad sentence, good sentence

before:  ArgumentOutOfRangeException
after:   2 fixes
```

A log of any length is likely to hold a truncated or corrupted sentence, and one
such line among thousands of good fixes returned nothing at all.

Such a sentence is now skipped — which is how the parser has always treated a line
it could not match, including a truncated final one. That existing behaviour is
what made the intent clear.

## The clock ordering

The rollover clock (from #122) is now asked for a timestamp only once the position
is known to be good. Advancing it on a sentence that is then skipped would let
that sentence's time of day become the one the next fix is measured against, and a
later fix reading as earlier would be taken for a new day. Covered by
`A_skipped_sentence_does_not_advance_the_rollover_clock`, which uses a skipped
23:00 between a 10:00 and an 11:00 fix.

## Also

- Both ordinate parts are parsed with `NumberStyles.Float` rather than the default
  that allows thousands separators — the same leniency behind the SkyDemon
  misparse in #127.
- Each ordinate is negated by its own hemisphere letter, rather than both being
  tested for `"N or E"`.

## Not changed

Minutes of 60 or more are still accepted (`5170.00` reads as 52.167°). There is no
more correct reading of a malformed field than the one it already gives, so
rejecting it would change what parses without making anything more accurate. Worth
knowing rather than worth fixing.

## Testing

`./build.sh Test` — 984 passing, 0 failing (970 on `master`). `dotnet csharpier
check .` clean.

13 of the 14 new tests fail against the previous implementation. The reference log
`Stockholm_Walk.nmea` still yields the same 674 fixes, over the same 11m 12s and
1097 m.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnzgV69TWFePB2s2sva3Wp)_