### PR TITLE
Clean up CS8632 warnings in test project

### DIFF
--- a/Geo.Tests/Geo.Tests.csproj
+++ b/Geo.Tests/Geo.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>default</LangVersion>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />

--- a/Geo.Tests/IO/GeoFormatTests.cs
+++ b/Geo.Tests/IO/GeoFormatTests.cs
@@ -44,7 +44,7 @@ public class GeoFormatTests
     [InlineData("not a geo string")]
     [InlineData("{ \"type\": \"Nonsense\" }")]
     [InlineData("POINT (nope)")]
-    public void Detect_returns_unknown_for_unrecognised_input(string input)
+    public void Detect_returns_unknown_for_unrecognised_input(string? input)
     {
         Assert.Equal(GeoStringFormat.Unknown, GeoFormat.Detect(input));
     }


### PR DESCRIPTION
Geo.Tests had no <Nullable> setting, so the nullable annotations already
used in tests (object?[], Dictionary<string, object?>, (object?)null,
GpsData?) sat outside an annotations context and produced 9 CS8632
warnings across four files.

Set <Nullable>annotations</Nullable> on the test project rather than
stripping the annotations, since each one accurately describes the value
under test. Annotations-only keeps the `?` syntax legal without turning
on null-state flow analysis, which the test project is not written for
(full `enable` reports 113 further nullable warnings).

Enabling the annotation context made `string` non-nullable, which in turn
surfaced xUnit1012 on the deliberate [InlineData(null)] case in
GeoFormatTests; the parameter is now string? to match what the theory
actually passes.

Solution builds with 0 warnings; all 1024 tests pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013MJXZe39hNAXUXcfYQ2VFG