### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] — Unreleased
+## [2.0.0] — 2026-08-04
 
 The first major release since 1.0.0. It is a large correctness release: much of
 the library gained real test coverage for the first time (line coverage went from
@@ -500,4 +500,4 @@ details.
 [#127]: https://github.com/sibartlett/Geo/pull/127
 [#128]: https://github.com/sibartlett/Geo/pull/128
 [#129]: https://github.com/sibartlett/Geo/pull/129
-[2.0.0]: https://github.com/sibartlett/Geo/compare/v1.2.0...master
+[2.0.0]: https://github.com/sibartlett/Geo/compare/v1.2.0...v2.0.0

--- a/Geo/Geo.csproj
+++ b/Geo/Geo.csproj
@@ -4,7 +4,7 @@
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Simon Bartlett</Authors>
     <AssemblyName>Geo</AssemblyName>
-    <Version>1.2.0</Version>
+    <Version>2.0.0</Version>
     <Description>A geospatial library for .NET</Description>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <PackageIcon>assets/geo-icon.png</PackageIcon>


### PR DESCRIPTION
Cuts the 2.0.0 release. Three changes, no library code touched.

| File | Change |
|---|---|
| `Geo/Geo.csproj` | `<Version>` 1.2.0 → 2.0.0 |
| `CHANGELOG.md` | `## [2.0.0] — Unreleased` → `## [2.0.0] — 2026-08-04` |
| `CHANGELOG.md` | compare link `v1.2.0...master` → `v1.2.0...v2.0.0` |

## Why 2.0.0

The changelog merged in #131 lists roughly twenty breaking changes. The ones most likely to be noticed:

- `Area` moved from `DistanceUnit` to `AreaUnit`, with squared conversion factors — `new Area(2, AreaUnit.Km).SiValue` is now `2_000_000`, not `2_000`.
- `Point.Coordinate` is get-only (source- and binary-breaking).
- The geometry `Empty` members are static properties returning fresh instances, not `static readonly` fields (binary-breaking).
- Nullable reference types are on project-wide, so the annotated public surface produces new warnings for consumers compiling with NRT.
- Malformed input reaches callers as `SerializationException` across the WKT, WKB, GeoJSON and Google-polyline readers, rather than as `Argument*`/`Format` exceptions.
- Spheroid-aware areas and lengths move computed values by +0.44% to −0.87%.

## Verification

`./build.sh CheckForUncommittedChanges Test` — all four targets succeeded, **1024 tests passed, 0 failed**. `dotnet csharpier check .` clean across 258 files.

The generated package was inspected rather than assumed:

```
package: Geo.2.0.0.nupkg
  id       Geo
  version  2.0.0
  icon     assets/geo-icon.png
  readme   README.md
  files    Geo.nuspec, README.md, assets/geo-icon.png, lib/netstandard2.0/Geo.dll
```

## After merging

The `v2.0.0` tag does not exist yet, so the changelog's compare link 404s until it is pushed. Tagging the merge commit resolves it — nothing else in the changelog or README depends on the tag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DstKdJWTt4RATfiRdzXybP)_